### PR TITLE
FEAT-002-T1: Criar JobLifecycleStepper componente puro de stepper horizontal

### DIFF
--- a/frontend/src/components/JobLifecycleStepper.tsx
+++ b/frontend/src/components/JobLifecycleStepper.tsx
@@ -1,0 +1,49 @@
+import { CheckCircle } from 'lucide-react'
+
+interface Step {
+  label: string
+  status: 'complete' | 'active' | 'pending'
+}
+
+interface JobLifecycleStepperProps {
+  steps: Step[]
+}
+
+export default function JobLifecycleStepper({ steps }: JobLifecycleStepperProps) {
+  if (steps.length === 0) return null
+
+  const getStepClass = (status: Step['status']): string => {
+    switch (status) {
+      case 'complete':
+        return 'bg-green-500 text-white'
+      case 'active':
+        return 'bg-blue-600 text-white animate-pulse'
+      case 'pending':
+        return 'bg-gray-200 text-gray-400'
+    }
+  }
+
+  return (
+    <div className="flex flex-col sm:flex-row items-center justify-between gap-2 w-full">
+      {steps.map((step, index) => (
+        <div key={index} className="flex items-center flex-1 w-full">
+          <div className="flex flex-col items-center flex-shrink-0">
+            <div
+              className={`w-8 h-8 rounded-full flex items-center justify-center ${getStepClass(step.status)}`}
+            >
+              {step.status === 'complete' ? (
+                <CheckCircle size={16} />
+              ) : (
+                <span className="w-2 h-2 rounded-full bg-current" />
+              )}
+            </div>
+            <span className="text-xs font-bold text-center mt-1 max-w-16">{step.label}</span>
+          </div>
+          {index < steps.length - 1 && (
+            <div className="border-t-2 border-gray-200 flex-1 hidden sm:block mx-2" />
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## O que foi implementado

Componente visual puro `JobLifecycleStepper` que renderiza um stepper horizontal/vertical responsivo. O componente suporta 3 estados de etapa (`complete`, `active`, `pending`), exibe ícone `CheckCircle` para etapas completas, aplica `animate-pulse` para etapas ativas, e usa conectores horizontais em desktop (`sm:flex`). Segue o padrão de componentes puros tipados do projeto.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `frontend/src/components/JobLifecycleStepper.tsx` | Criado | Componente visual de stepper horizontal com props `{ steps: Step[] }` |

## Referências

- **Issue da task:** #19
- **Issue da feature:** #3
- **Spec:** `docs/specs/FEAT-002-job-status-lifecycle-ui.md`

Closes #19

## Definition of Done ✅

- [x] `frontend/src/components/JobLifecycleStepper.tsx` existe
- [x] Etapa `active` tem classe `animate-pulse`
- [x] Etapa `complete` exibe ícone CheckCircle
- [x] Props `steps=[]` retorna null sem erro
- [x] `npm run build` — 0 erros de TypeScript
- [x] `npm run lint` — 0 novos erros de lint
- [x] `npm run test -- --run` — todos os testes anteriores passando (31 testes)

## Como verificar

1. Importar `JobLifecycleStepper` e renderizar com `steps=[{label:'Contratado',status:'complete'},{label:'Chegada',status:'active'},{label:'Saída',status:'pending'}]` → exibe 3 círculos: verde com CheckCircle, azul pulsante, cinza
2. Renderizar com `steps=[]` → retorna null sem erro de JavaScript
3. Em mobile: layout `flex-col`; em desktop: layout `sm:flex-row` com conectores entre etapas