### PR TITLE
FEAT-001-T3: Modificar MyJobs para exibir status de garantia de pagamento

### DIFF
--- a/frontend/src/pages/MyJobs.tsx
+++ b/frontend/src/pages/MyJobs.tsx
@@ -395,6 +395,11 @@ export default function MyJobs() {
                                             <MapPin size={14} /> {job.location}
                                         </span>
                                     </div>
+                                    {job.status === 'in_progress' && (
+                                        <p className="text-xs text-yellow-600 font-bold flex items-center gap-1 mt-1">
+                                            Pagamento em garantia até confirmação da empresa
+                                        </p>
+                                    )}
                                 </div>
                             </div>
 


### PR DESCRIPTION
## O que foi implementado

Adicionado texto informativo "Pagamento em garantia até confirmação da empresa" na aba "Em Andamento" de `MyJobs.tsx` para jobs com `status === 'in_progress'`. O texto aparece abaixo das badges de informação do job com estilo amarelo para indicar ao worker que o pagamento está seguro, aguardando a confirmação de entrega pela empresa.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `frontend/src/pages/MyJobs.tsx` | Modificado | Adiciona texto de garantia de pagamento condicionalmente para `status === 'in_progress'` na aba "Em Andamento" |

## Referências

- **Issue da task:** #17
- **Issue da feature:** #1
- **Spec:** `docs/specs/FEAT-001-escrow-release-ui.md`

Closes #17

## Definition of Done ✅

- [x] `npm run build` — 0 erros de TypeScript
- [x] `npm run lint` — 0 novos erros de lint
- [x] `npm run test -- --run` — 31 testes passando
- [x] `MyJobs.tsx` compilando sem erros TypeScript
- [x] Na aba "Em Andamento", cards com `status === 'in_progress'` exibem o texto "Pagamento em garantia até confirmação da empresa"
- [x] Cards com outros status NÃO exibem o texto
- [x] O badge "Pago" na aba "Histórico" permanece inalterado

## Como verificar

1. Acessar `/my-jobs` na aba "Em Andamento" com um job de `status === 'in_progress'` → texto "Pagamento em garantia até confirmação da empresa" em amarelo aparece abaixo das badges de informação
2. Jobs com `status === 'hired'` (agendados que aparecem em andamento por horário) → texto NÃO aparece
3. Aba "Histórico" → badge "Pago" para jobs `completed` permanece inalterado