### PR TITLE
FEAT-001-T4: Testes unitários para EscrowStatusBadge e modal de confirmação de entrega

### DIFF
--- a/frontend/src/components/EscrowStatusBadge.test.tsx
+++ b/frontend/src/components/EscrowStatusBadge.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import EscrowStatusBadge from './EscrowStatusBadge'
+
+describe('EscrowStatusBadge', () => {
+  it('renderiza badge Pagamento Reservado quando escrowStatus=reserved', () => {
+    render(<EscrowStatusBadge escrowStatus="reserved" />)
+    expect(screen.getByText('Pagamento Reservado')).toBeInTheDocument()
+  })
+
+  it('renderiza badge Pagamento Liberado quando escrowStatus=released', () => {
+    render(<EscrowStatusBadge escrowStatus="released" />)
+    expect(screen.getByText('Pagamento Liberado')).toBeInTheDocument()
+  })
+
+  it('retorna null quando escrowStatus=null', () => {
+    const { container } = render(<EscrowStatusBadge escrowStatus={null} />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/frontend/src/pages/company/CompanyJobCandidates.test.tsx
+++ b/frontend/src/pages/company/CompanyJobCandidates.test.tsx
@@ -150,6 +150,102 @@ describe('CompanyJobCandidates — renderiza candidatos com status in_progress',
   })
 })
 
+describe('CompanyJobCandidates — modal de confirmação de entrega', () => {
+  it('modal de confirmação abre ao clicar botão Confirmar Entrega', async () => {
+    setupMocksWithApps(APP_IN_PROGRESS)
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('João Silva')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Confirmar Entrega'))
+
+    expect(screen.getByRole('heading', { name: /Confirmar Entrega/i })).toBeInTheDocument()
+    expect(screen.getByText(/O pagamento será liberado imediatamente ao profissional/)).toBeInTheDocument()
+  })
+
+  it('modal fecha ao clicar Cancelar sem chamar releaseEscrow', async () => {
+    setupMocksWithApps(APP_IN_PROGRESS)
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('João Silva')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Confirmar Entrega'))
+
+    expect(screen.getByText(/O pagamento será liberado imediatamente ao profissional/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Cancelar'))
+
+    await waitFor(() => {
+      expect(screen.queryByText(/O pagamento será liberado imediatamente ao profissional/)).not.toBeInTheDocument()
+    })
+
+    expect(WalletService.releaseEscrow).not.toHaveBeenCalled()
+  })
+
+  it('toast de sucesso aparece após releaseEscrow retornar sucesso', async () => {
+    const { mockAddToast } = setupMocksWithApps(APP_IN_PROGRESS)
+    vi.mocked(WalletService.releaseEscrow).mockResolvedValueOnce({ success: true })
+
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('João Silva')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Confirmar Entrega'))
+
+    await waitFor(() => {
+      expect(screen.getByText(/O pagamento será liberado imediatamente ao profissional/)).toBeInTheDocument()
+    })
+
+    // Get "Confirmar" button inside modal (not the list button)
+    const buttons = screen.getAllByRole('button')
+    const confirmarModal = buttons.find(b => b.textContent?.trim() === 'Confirmar')
+    expect(confirmarModal).toBeDefined()
+    fireEvent.click(confirmarModal!)
+
+    await waitFor(() => {
+      expect(mockAddToast).toHaveBeenCalledWith(
+        'Entrega confirmada! Pagamento liberado ao profissional.',
+        'success'
+      )
+    })
+  })
+
+  it('toast de erro aparece quando releaseEscrow retorna success=false', async () => {
+    const { mockAddToast } = setupMocksWithApps(APP_IN_PROGRESS)
+    vi.mocked(WalletService.releaseEscrow).mockResolvedValueOnce({ success: false, error: 'Falha no pagamento' })
+
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('João Silva')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Confirmar Entrega'))
+
+    await waitFor(() => {
+      expect(screen.getByText(/O pagamento será liberado imediatamente ao profissional/)).toBeInTheDocument()
+    })
+
+    const buttons = screen.getAllByRole('button')
+    const confirmarModal = buttons.find(b => b.textContent?.trim() === 'Confirmar')
+    expect(confirmarModal).toBeDefined()
+    fireEvent.click(confirmarModal!)
+
+    await waitFor(() => {
+      expect(mockAddToast).toHaveBeenCalledWith(
+        'Erro ao liberar pagamento. Tente novamente.',
+        'error'
+      )
+    })
+  })
+})
+
 describe('CompanyJobCandidates — modal de avaliação (review)', () => {
   it('handleSubmitReview exibe toast de review duplicado quando error.code === 23505', async () => {
     const mockAddToast = vi.fn()


### PR DESCRIPTION
## O que foi implementado

Criados testes unitários para `EscrowStatusBadge` e para os comportamentos do modal de confirmação de entrega em `CompanyJobCandidates`. Os testes do componente mockam supabase, WalletService e ToastContext para verificar o fluxo completo de confirmação de entrega de forma isolada. Esta branch inclui cherry-picks de T1 (EscrowStatusBadge) e T2 (CompanyJobCandidates) para compilar de forma independente.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `frontend/src/components/EscrowStatusBadge.test.tsx` | Criado | 3 testes: badge 'Pagamento Reservado', badge 'Pagamento Liberado', retorna null para escrowStatus null |
| `frontend/src/pages/company/CompanyJobCandidates.test.tsx` | Criado | 4 testes: modal abre, modal fecha sem chamar releaseEscrow, toast de sucesso, toast de erro |
| `frontend/src/components/EscrowStatusBadge.tsx` | Cherry-pick de T1 | Necessário para compilar |
| `frontend/src/pages/company/CompanyJobCandidates.tsx` | Cherry-pick de T2 | Necessário para testar comportamento de T2 |

## Referências

- **Issue da task:** #18
- **Issue da feature:** #1
- **Spec:** `docs/specs/FEAT-001-escrow-release-ui.md`

Closes #18

## Definition of Done ✅

- [x] `npm run build` — 0 erros de TypeScript
- [x] `npm run lint` — 0 novos erros de lint
- [x] `npm run test -- --run` — 38 testes passando (31 originais + 3 EscrowStatusBadge + 4 CompanyJobCandidates)
- [x] `frontend/src/components/EscrowStatusBadge.test.tsx` existe com 3 testes passando
- [x] Testes do modal de confirmação em `CompanyJobCandidates.test.tsx` passam (4 testes)

## Como verificar

Executar `cd frontend && npm run test -- --run` e verificar:
- 5 test files passando
- 38 testes passando
- EscrowStatusBadge.test.tsx: 3 testes
- CompanyJobCandidates.test.tsx: 4 testes