### PR TITLE
FEAT-003-T2: Modificar NotificationBell para adicionar link Ver todas as notificações

### DIFF
--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -108,6 +108,14 @@ export default function NotificationBell({ className = "" }: { className?: strin
                             </div>
                         )}
                     </div>
+                    <div className="border-t border-gray-100 p-3 text-center">
+                        <button
+                            onClick={() => { setIsOpen(false); navigate('/notifications'); }}
+                            className="text-sm font-bold text-primary hover:underline"
+                        >
+                            Ver todas as notificações
+                        </button>
+                    </div>
                 </div>
             )}
         </div>


### PR DESCRIPTION
## O que foi implementado

Adicionado rodapé no dropdown do `NotificationBell.tsx` com botão "Ver todas as notificações" que fecha o dropdown e navega para `/notifications`. Mudança cirúrgica — apenas 8 linhas adicionadas, sem alteração no comportamento existente.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `frontend/src/components/NotificationBell.tsx` | Modificado | Adiciona rodapé no dropdown com link para `/notifications` |

## Referências

- **Issue da task:** #25
- **Issue da feature:** #2
- **Spec:** `docs/specs/FEAT-003-notification-center.md`

Closes #25

## Definition of Done ✅

- [x] `npm run build` — 0 erros de TypeScript
- [x] `npm run lint` — 0 novos erros de lint
- [x] `npm run test -- --run` — 31 testes passando
- [x] `NotificationBell.tsx` compila sem erros TypeScript
- [x] O dropdown exibe o texto "Ver todas as notificações" no rodapé
- [x] Clicar no texto fecha o dropdown e navega para `/notifications`

## Como verificar

1. Abrir o dropdown de notificações (clicar no sino) → texto "Ver todas as notificações" aparece no rodapé
2. Clicar "Ver todas as notificações" → dropdown fecha e navega para `/notifications`

Nota: A rota `/notifications` ainda não está no App.tsx (pertence a T3).