### PR TITLE
FEAT-004-T1: Criar migration SQL com trigger de notificação em novas mensagens

### DIFF
--- a/supabase/migrations/20260312000000_notify_on_new_message.sql
+++ b/supabase/migrations/20260312000000_notify_on_new_message.sql
@@ -1,0 +1,73 @@
+-- Migration: Criar notificação de nova mensagem via trigger
+-- File: supabase/migrations/20260312000000_notify_on_new_message.sql
+
+-- Função que insere notificação para o destinatário de uma nova mensagem
+CREATE OR REPLACE FUNCTION notify_new_message()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_conversation_id UUID;
+    v_recipient_id UUID;
+    v_sender_name TEXT;
+    v_app_id UUID;
+    v_worker_id UUID;
+    v_job_company_id UUID;
+BEGIN
+    v_conversation_id := NEW.conversationid;
+
+    -- Get the application linked to this conversation
+    SELECT c.application_uuid INTO v_app_id
+    FROM "Conversation" c
+    WHERE c.id = v_conversation_id;
+
+    IF v_app_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    -- Get worker_id and job's company_id from the application
+    SELECT a.worker_id, j.company_id INTO v_worker_id, v_job_company_id
+    FROM applications a
+    JOIN jobs j ON j.id = a.job_id
+    WHERE a.id = v_app_id;
+
+    -- Determine recipient: if sender is worker -> recipient is company; if sender is company -> recipient is worker
+    IF NEW.senderid = v_worker_id THEN
+        v_recipient_id := v_job_company_id;
+    ELSE
+        v_recipient_id := v_worker_id;
+    END IF;
+
+    -- Get sender name for notification message
+    SELECT COALESCE(w.full_name, comp.name, 'Usuário')
+    INTO v_sender_name
+    FROM auth.users u
+    LEFT JOIN workers w ON w.id = u.id
+    LEFT JOIN companies comp ON comp.id = u.id
+    WHERE u.id = NEW.senderid;
+
+    -- Insert in-app notification for the recipient
+    INSERT INTO notifications (user_id, type, title, message, link, read_at, created_at)
+    VALUES (
+        v_recipient_id,
+        'message',
+        'Nova mensagem de ' || COALESCE(v_sender_name, 'Usuário'),
+        LEFT(NEW.content, 100),
+        '/messages?conversation=' || v_conversation_id::text,
+        NULL,
+        NOW()
+    )
+    ON CONFLICT DO NOTHING;
+
+    RETURN NEW;
+END;
+$$;
+
+-- Trigger: fires AFTER each new message inserted
+DROP TRIGGER IF EXISTS trg_notify_new_message ON "Message";
+CREATE TRIGGER trg_notify_new_message
+    AFTER INSERT ON "Message"
+    FOR EACH ROW
+    EXECUTE FUNCTION notify_new_message();


### PR DESCRIPTION
## O que foi implementado

Criado arquivo de migration SQL com a função PL/pgSQL `notify_new_message()` e o trigger `trg_notify_new_message` que cria automaticamente uma notificação na tabela `notifications` para o destinatário quando uma nova mensagem é inserida na tabela `Message`. O trigger determina o destinatário fazendo join com `Conversation`, `applications` e `jobs` — se o remetente é o worker, o destinatário é a empresa, e vice-versa.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `supabase/migrations/20260312000000_notify_on_new_message.sql` | Criado | Função notify_new_message() e trigger trg_notify_new_message para criar notificações automáticas |

## Referências

- **Issue da task:** #28
- **Issue da feature:** #4
- **Spec:** `docs/specs/FEAT-004-realtime-messaging-enhancements.md`

Closes #28

## Definition of Done ✅

- [x] `npm run build` — 0 erros de TypeScript
- [x] `npm run lint` — 0 novos erros de lint
- [x] `npm run test -- --run` — 31 testes passando
- [x] `supabase/migrations/20260312000000_notify_on_new_message.sql` existe
- [x] O arquivo contém a função `notify_new_message()` e o trigger `trg_notify_new_message`
- [x] O timestamp `20260312000000` é maior que todas as migrations existentes (última: `20260311200000`)

## Como verificar

Aplicar migration: `supabase db push`

Após aplicar:
1. Inserir uma nova mensagem em `Message` como worker → verificar que uma notificação do tipo `message` é criada em `notifications` para o `company_id` correspondente
2. Inserir uma nova mensagem como empresa → verificar que a notificação é criada para o `worker_id`
3. O link da notificação deve ser `/messages?conversation={conversationId}`