### PR TITLE
FEAT-004-T2: Modificar Messages.tsx para adicionar indicador digitando via Supabase Presence

### DIFF
--- a/frontend/src/pages/Messages.tsx
+++ b/frontend/src/pages/Messages.tsx
@@ -42,6 +42,9 @@ export default function Messages() {
     const { addToast } = useToast();
 
     const messagesEndRef = useRef<HTMLDivElement>(null);
+    const presenceChannel = useRef<ReturnType<typeof supabase.channel> | null>(null);
+    const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const [isOtherTyping, setIsOtherTyping] = useState(false);
 
     const markAsRead = async (conversationId: string, userId: string) => {
         setConversations(prev => prev.map(c =>
@@ -223,8 +226,26 @@ export default function Messages() {
             })
             .subscribe();
 
+        // Presence channel for typing indicator
+        const pChannel = supabase.channel(`typing:${selectedConversation.id}`)
+        pChannel
+            .on('presence', { event: 'sync' }, () => {
+                const state = pChannel.presenceState();
+                setIsOtherTyping(
+                    Object.values(state).some(presences =>
+                        presences.some(p => {
+                            const pTyped = p as { typing?: boolean; userId?: string };
+                            return pTyped.typing === true && pTyped.userId !== currentUser;
+                        })
+                    )
+                );
+            })
+            .subscribe();
+        presenceChannel.current = pChannel;
+
         return () => {
             supabase.removeChannel(channel);
+            pChannel.unsubscribe();
         };
     }, [selectedConversation, currentUser]);
 
@@ -234,6 +255,10 @@ export default function Messages() {
         setSending(true);
         const messageContent = newMessage.trim();
         setNewMessage('');
+
+        // Stop typing indicator before sending
+        presenceChannel.current?.track({ typing: false, userId: currentUser });
+        if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
 
         const { error } = await supabase
             .from('Message')
@@ -406,13 +431,32 @@ export default function Messages() {
                                 <div ref={messagesEndRef} />
                             </div>
 
+                            {/* Typing Indicator */}
+                            {isOtherTyping && (
+                                <div className="px-4 py-2 text-xs text-gray-400 font-bold flex items-center gap-2">
+                                    <span className="animate-bounce">•</span>
+                                    <span className="animate-bounce" style={{ animationDelay: '0.1s' }}>•</span>
+                                    <span className="animate-bounce" style={{ animationDelay: '0.2s' }}>•</span>
+                                    Digitando...
+                                </div>
+                            )}
+
                             {/* Message Input */}
                             <div className="p-4 border-t-2 border-gray-100 bg-white">
                                 <div className="flex gap-3">
                                     <input
                                         type="text"
                                         value={newMessage}
-                                        onChange={(e) => setNewMessage(e.target.value)}
+                                        onChange={(e) => {
+                                            setNewMessage(e.target.value);
+                                            if (selectedConversation && currentUser) {
+                                                presenceChannel.current?.track({ typing: true, userId: currentUser });
+                                                if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
+                                                typingTimeoutRef.current = setTimeout(() => {
+                                                    presenceChannel.current?.track({ typing: false, userId: currentUser });
+                                                }, 3000);
+                                            }
+                                        }}
                                         onKeyPress={(e) => e.key === 'Enter' && !e.shiftKey && handleSendMessage()}
                                         placeholder="Digite sua mensagem..."
                                         className="flex-1 border-2 border-gray-200 rounded-xl px-4 py-3 focus:border-black focus:outline-none transition-colors font-medium"


### PR DESCRIPTION
## O que foi implementado

Adicionado indicador "Digitando..." em `Messages.tsx` usando Supabase Presence channels. Quando um participante digita, o outro vê três pontos animados acima do input de mensagem. O indicador some automaticamente após 3 segundos de inatividade ou quando uma mensagem é enviada. O canal Presence é criado ao selecionar uma conversa e descartado no cleanup do useEffect.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `frontend/src/pages/Messages.tsx` | Modificado | Adiciona presenceChannel ref, typingTimeoutRef, isOtherTyping state, canal Presence, tracking de typing no onChange e ao enviar, e indicador visual |

## Referências

- **Issue da task:** #29
- **Issue da feature:** #4
- **Spec:** `docs/specs/FEAT-004-realtime-messaging-enhancements.md`

Closes #29

## Definition of Done ✅

- [x] `npm run build` — 0 erros de TypeScript
- [x] `npm run lint` — 0 novos erros de lint
- [x] `npm run test -- --run` — 31 testes passando
- [x] `Messages.tsx` compila sem erros TypeScript
- [x] Estado `isOtherTyping` existe no componente
- [x] Indicador "Digitando..." renderizado quando `isOtherTyping === true`
- [x] Cleanup do Presence channel ocorre quando `selectedConversation` muda

## Como verificar

1. Abrir a mesma conversa em duas janelas distintas (worker e empresa)
2. Digitar no input da empresa → "Digitando..." aparece na janela do worker
3. Parar de digitar por 3s → indicador desaparece
4. Enviar mensagem → indicador desaparece imediatamente