### PR TITLE
FEAT-004-T3: Modificar CompanyMessages.tsx com indicador digitando

### DIFF
--- a/frontend/src/pages/company/CompanyMessages.tsx
+++ b/frontend/src/pages/company/CompanyMessages.tsx
@@ -41,6 +41,9 @@ export default function CompanyMessages() {
     const { addToast } = useToast();
 
     const messagesEndRef = useRef<HTMLDivElement>(null);
+    const presenceChannel = useRef<ReturnType<typeof supabase.channel> | null>(null);
+    const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const [isOtherTyping, setIsOtherTyping] = useState(false);
 
     const [refreshTrigger, setRefreshTrigger] = useState(0);
 
@@ -259,8 +262,26 @@ export default function CompanyMessages() {
             })
             .subscribe();
 
+        // Presence channel for typing indicator
+        const pChannel = supabase.channel(`typing:${selectedConversation.id}`)
+        pChannel
+            .on('presence', { event: 'sync' }, () => {
+                const state = pChannel.presenceState();
+                setIsOtherTyping(
+                    Object.values(state).some(presences =>
+                        presences.some(p => {
+                            const pTyped = p as { typing?: boolean; userId?: string };
+                            return pTyped.typing === true && pTyped.userId !== currentUser;
+                        })
+                    )
+                );
+            })
+            .subscribe();
+        presenceChannel.current = pChannel;
+
         return () => {
             supabase.removeChannel(channel);
+            pChannel.unsubscribe();
         };
     }, [selectedConversation, currentUser]);
 
@@ -270,6 +291,10 @@ export default function CompanyMessages() {
         setSending(true);
         const messageContent = newMessage.trim();
         setNewMessage('');
+
+        // Stop typing indicator before sending
+        presenceChannel.current?.track({ typing: false, userId: currentUser });
+        if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
 
         const { error } = await supabase
             .from('Message')
@@ -443,12 +468,31 @@ export default function CompanyMessages() {
                                 <div ref={messagesEndRef} />
                             </div>
 
+                            {/* Typing Indicator */}
+                            {isOtherTyping && (
+                                <div className="px-4 py-2 text-xs text-gray-400 font-bold flex items-center gap-2">
+                                    <span className="animate-bounce">•</span>
+                                    <span className="animate-bounce" style={{ animationDelay: '0.1s' }}>•</span>
+                                    <span className="animate-bounce" style={{ animationDelay: '0.2s' }}>•</span>
+                                    Digitando...
+                                </div>
+                            )}
+
                             <div className="p-4 border-t-2 border-gray-100 bg-white">
                                 <div className="flex gap-3">
                                     <input
                                         type="text"
                                         value={newMessage}
-                                        onChange={(e) => setNewMessage(e.target.value)}
+                                        onChange={(e) => {
+                                            setNewMessage(e.target.value);
+                                            if (selectedConversation && currentUser) {
+                                                presenceChannel.current?.track({ typing: true, userId: currentUser });
+                                                if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
+                                                typingTimeoutRef.current = setTimeout(() => {
+                                                    presenceChannel.current?.track({ typing: false, userId: currentUser });
+                                                }, 3000);
+                                            }
+                                        }}
                                         onKeyPress={(e) => e.key === 'Enter' && !e.shiftKey && handleSendMessage()}
                                         placeholder="Digite sua mensagem..."
                                         className="flex-1 border-2 border-gray-200 rounded-xl px-4 py-3 focus:border-blue-500 focus:outline-none transition-colors font-medium"


### PR DESCRIPTION
## O que foi implementado

Adicionado indicador de digitação em tempo real em `CompanyMessages.tsx` usando Supabase Presence channels. O padrão é idêntico ao implementado em T2 para `Messages.tsx` — adaptado apenas os nomes de variáveis existentes no componente da empresa.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `frontend/src/pages/company/CompanyMessages.tsx` | Modificado | Adiciona `presenceChannel` ref, `typingTimeoutRef` ref, estado `isOtherTyping`, setup/cleanup do Presence channel, debounce de 3s no onChange, stop de typing antes do envio, e JSX do indicador "• • • Digitando..." |

## Referências

- **Issue da task:** #30
- **Issue da feature:** #4
- **Spec:** `docs/specs/FEAT-004-realtime-messaging-enhancements.md`

Closes #30

## Definition of Done

- [x] `CompanyMessages.tsx` compila sem erros TypeScript
- [x] Estado `isOtherTyping` existe no componente
- [x] Indicador "Digitando..." renderizado quando `isOtherTyping === true`
- [x] Markup do indicador é idêntica à de Messages.tsx (três pontos animados + "Digitando...")
- [x] `cd frontend && npm run build` — 0 erros de TypeScript
- [x] `cd frontend && npm run lint` — 0 novos erros de lint
- [x] `cd frontend && npm run test -- --run` — 31 testes passando

## Como verificar

1. Abrir `/company/messages` como empresa e selecionar uma conversa → indicador não aparece
2. Em outra aba/sessão como worker na mesma conversa, começar a digitar → empresa vê "• • • Digitando..." abaixo das mensagens
3. Worker para de digitar por 3s → indicador desaparece automaticamente
4. Worker envia mensagem → indicador desaparece imediatamente

**Nota:** Esta task depende de T2 (FEAT-004-T2, PR #83) que implementa o mesmo padrão em `Messages.tsx`.