### PR TITLE
FEAT-005-T1: Criar migration SQL com colunas accepted_tos em workers e companies

### DIFF
--- a/supabase/migrations/20260312100000_add_tos_acceptance.sql
+++ b/supabase/migrations/20260312100000_add_tos_acceptance.sql
@@ -1,0 +1,18 @@
+-- Migration: Adicionar campos de aceite de TOS em workers e companies
+-- File: supabase/migrations/20260312100000_add_tos_acceptance.sql
+
+-- Workers
+ALTER TABLE workers
+    ADD COLUMN IF NOT EXISTS accepted_tos BOOLEAN DEFAULT FALSE NOT NULL,
+    ADD COLUMN IF NOT EXISTS tos_version TEXT DEFAULT NULL,
+    ADD COLUMN IF NOT EXISTS tos_accepted_at TIMESTAMPTZ DEFAULT NULL;
+
+-- Companies
+ALTER TABLE companies
+    ADD COLUMN IF NOT EXISTS accepted_tos BOOLEAN DEFAULT FALSE NOT NULL,
+    ADD COLUMN IF NOT EXISTS tos_version TEXT DEFAULT NULL,
+    ADD COLUMN IF NOT EXISTS tos_accepted_at TIMESTAMPTZ DEFAULT NULL;
+
+-- RLS: as políticas existentes de workers e companies já permitem UPDATE pelo próprio usuário
+-- ("Workers can update their own profile" e "Companies can update their own profile")
+-- Nenhuma nova política de RLS necessária.


### PR DESCRIPTION
## O que foi implementado

Migration SQL que adiciona as colunas de aceite dos Termos de Serviço nas tabelas `workers` e `companies`. As políticas de RLS existentes já cobrem UPDATE pelo próprio usuário — nenhuma nova política necessária.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `supabase/migrations/20260312100000_add_tos_acceptance.sql` | Criado | Adiciona `accepted_tos`, `tos_version` e `tos_accepted_at` em `workers` e `companies` |

## Referências

- **Issue da task:** #32
- **Issue da feature:** #5
- **Spec:** `docs/specs/FEAT-005-tos-acceptance-gate.md`

Closes #32

## Definition of Done

- [x] `supabase/migrations/20260312100000_add_tos_acceptance.sql` existe
- [x] O arquivo contém ALTER TABLE para `workers` e `companies` com as 3 colunas
- [x] O timestamp `20260312100000` é maior que o da migration mais recente (`20260311200000`)
- [x] `cd frontend && npm run build` — 0 erros de TypeScript
- [x] `cd frontend && npm run lint` — 0 novos erros de lint

## Como verificar

Aplicar a migration antes de testar as tasks subsequentes (T2–T5):

```bash
supabase db push
# ou
supabase migration up
```

Após aplicar, verificar no Supabase Dashboard → Table Editor → `workers` e `companies` que as 3 colunas existem:
- `accepted_tos` — boolean, default false
- `tos_version` — text, nullable
- `tos_accepted_at` — timestamptz, nullable