### PR TITLE
FEAT-005-T2: Criar TosGateModal componente não-fechável de aceite dos Termos

### DIFF
--- a/frontend/src/components/TosGateModal.tsx
+++ b/frontend/src/components/TosGateModal.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import { supabase } from '../lib/supabase';
+import { useToast } from '../contexts/ToastContext';
+
+interface TosGateModalProps {
+    userRole: 'worker' | 'company';
+    onAccepted: () => void;
+}
+
+export default function TosGateModal({ userRole, onAccepted }: TosGateModalProps) {
+    const [checked, setChecked] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const { addToast } = useToast();
+
+    const handleAccept = async () => {
+        if (!checked || loading) return;
+
+        setLoading(true);
+
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) {
+            addToast('Sessão expirada. Faça login novamente.', 'error');
+            setLoading(false);
+            return;
+        }
+
+        const table = userRole === 'worker' ? 'workers' : 'companies';
+        const { error } = await supabase
+            .from(table)
+            .update({
+                accepted_tos: true,
+                tos_version: 'v1',
+                tos_accepted_at: new Date().toISOString()
+            })
+            .eq('id', user.id);
+
+        if (error) {
+            addToast('Erro ao salvar aceite dos termos. Tente novamente.', 'error');
+            setLoading(false);
+            return;
+        }
+
+        addToast('Termos aceitos com sucesso. Bem-vindo!', 'success');
+        onAccepted();
+    };
+
+    return (
+        <div className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4">
+            <div className="bg-white rounded-2xl w-full max-w-lg p-8 border-2 border-black shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+                <h2 className="text-2xl font-black uppercase mb-4">Termos de Uso Atualizados</h2>
+
+                <p className="text-gray-700 mb-4 leading-relaxed">
+                    Para continuar usando a Worki, você precisa aceitar nossos Termos de Uso. Eles definem suas responsabilidades e direitos na plataforma.
+                </p>
+
+                <a
+                    href="/termos"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary underline font-bold"
+                >
+                    Ler os Termos de Uso
+                </a>
+
+                <div className="flex items-start gap-3 mt-6 mb-6">
+                    <input
+                        type="checkbox"
+                        id="tos-checkbox"
+                        className="w-5 h-5 border-2 border-black rounded accent-primary mt-0.5 flex-shrink-0"
+                        checked={checked}
+                        onChange={(e) => setChecked(e.target.checked)}
+                    />
+                    <label htmlFor="tos-checkbox" className="text-sm font-medium text-gray-800 cursor-pointer">
+                        Li e aceito os Termos de Uso e a Política de Privacidade
+                    </label>
+                </div>
+
+                <button
+                    onClick={handleAccept}
+                    disabled={!checked || loading}
+                    className={`w-full py-4 font-black uppercase tracking-tight text-white rounded-xl border-2 border-black transition-all ${
+                        !checked || loading
+                            ? 'bg-gray-400 opacity-50 cursor-not-allowed'
+                            : 'bg-primary shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1'
+                    }`}
+                >
+                    {loading ? 'Salvando...' : 'Aceitar e Continuar'}
+                </button>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## O que foi implementado

Criado `TosGateModal` — modal fullscreen bloqueante para aceite dos Termos de Uso. O modal não pode ser fechado (sem backdrop click, sem botão X). O botão "Aceitar e Continuar" fica desabilitado até o checkbox ser marcado, e persiste o aceite no DB atualizando `accepted_tos`, `tos_version` e `tos_accepted_at` na tabela correta (`workers` ou `companies`) via prop `userRole`.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `frontend/src/components/TosGateModal.tsx` | Criado | Modal neo-brutalist não-fechável com checkbox de aceite e UPDATE no DB |

## Referências

- **Issue da task:** #33
- **Issue da feature:** #5
- **Spec:** `docs/specs/FEAT-005-tos-acceptance-gate.md`
- **Depende de:** PR #86 (FEAT-005-T1 — migration com colunas `accepted_tos`)

Closes #33

## Definition of Done

- [x] `TosGateModal.tsx` existe e compila sem erros TypeScript
- [x] Checkbox inicialmente desmarcado (`useState(false)`)
- [x] Botão desabilitado quando checkbox desmarcado (`disabled={!checked || loading}`)
- [x] Botão habilitado quando checkbox marcado
- [x] Sem botão X e sem fechamento ao clicar fora do modal
- [x] `cd frontend && npm run build` — 0 erros de TypeScript
- [x] `cd frontend && npm run lint` — 0 novos erros de lint
- [x] `cd frontend && npm run test -- --run` — 31 testes passando

## Como verificar

1. Montar `<TosGateModal userRole="worker" onAccepted={() => console.log('accepted')} />` → modal aparece sobre tudo, sem X, sem fechar ao clicar fora
2. Tentar clicar em "Aceitar e Continuar" com checkbox desmarcado → botão está desabilitado (cinza, `cursor-not-allowed`)
3. Marcar checkbox → botão fica verde e clicável
4. Clicar "Aceitar e Continuar" → `workers.accepted_tos` vira `true`, toast de sucesso, `onAccepted()` chamado

**Nota:** Aplicar migration FEAT-005-T1 (PR #86) antes de testar: `supabase db push`