### PR TITLE
FEAT-005-T4: Modificar WorkerOnboarding para exigir checkbox de TOS no passo final

### DIFF
--- a/frontend/src/pages/worker/WorkerOnboarding.tsx
+++ b/frontend/src/pages/worker/WorkerOnboarding.tsx
@@ -12,6 +12,7 @@ export default function WorkerOnboarding() {
     const { addToast } = useToast();
     const [step, setStep] = useState(1);
     const [userId, setUserId] = useState<string | null>(null);
+    const [tosAccepted, setTosAccepted] = useState(false);
 
     const TOTAL_STEPS = 3;
 
@@ -106,7 +107,7 @@ export default function WorkerOnboarding() {
         switch (step) {
             case 1: return formData.fullName && formData.phone && formData.cpf.replace(/\D/g, '').length === 11 && formData.birthDate && formData.city;
             case 2: return formData.roles.length > 0 && formData.experienceYears;
-            case 3: return formData.availability.length > 0;
+            case 3: return formData.availability.length > 0 && tosAccepted;
             default: return true;
         }
     };
@@ -139,7 +140,10 @@ export default function WorkerOnboarding() {
                     bio: formData.bio,
                     availability: formData.availability,
                     goal: formData.goal,
-                    onboarding_completed: true
+                    onboarding_completed: true,
+                    accepted_tos: true,
+                    tos_version: 'v1',
+                    tos_accepted_at: new Date().toISOString()
                 });
 
             if (error) throw error;
@@ -367,6 +371,22 @@ export default function WorkerOnboarding() {
                                                 </button>
                                             ))}
                                         </div>
+                                    </div>
+
+                                    <div className="flex items-start gap-3 mt-6">
+                                        <input
+                                            type="checkbox"
+                                            id="tos"
+                                            checked={tosAccepted}
+                                            onChange={e => setTosAccepted(e.target.checked)}
+                                            className="w-5 h-5 border-2 border-black rounded accent-primary mt-0.5 flex-shrink-0"
+                                        />
+                                        <label htmlFor="tos" className="text-sm text-gray-700">
+                                            Li e aceito os{' '}
+                                            <a href="/termos" target="_blank" rel="noopener noreferrer" className="text-primary underline font-bold">Termos de Uso</a>
+                                            {' '}e a{' '}
+                                            <a href="/privacidade" target="_blank" rel="noopener noreferrer" className="text-primary underline font-bold">Política de Privacidade</a>
+                                        </label>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## O que foi implementado

Adicionado checkbox de aceite dos Termos de Uso no step 3 (Objetivos) do `WorkerOnboarding`. O botão "Finalizar" permanece desabilitado até o checkbox ser marcado. Ao finalizar, os campos `accepted_tos`, `tos_version` e `tos_accepted_at` são incluídos no upsert para a tabela `workers`.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `frontend/src/pages/worker/WorkerOnboarding.tsx` | Modificado | Adiciona `tosAccepted` state, checkbox no step 3, validação em `canProceed()`, e campos TOS no upsert |

## Referências

- **Issue da task:** #35
- **Issue da feature:** #5
- **Spec:** `docs/specs/FEAT-005-tos-acceptance-gate.md`
- **Depende de:** PR #86 (T1 — migration com colunas `accepted_tos`)

Closes #35

## Definition of Done

- [x] `WorkerOnboarding.tsx` compila sem erros TypeScript
- [x] Step 3 exibe o checkbox de TOS com links para /termos e /privacidade
- [x] Botão "Finalizar" desabilitado quando checkbox desmarcado
- [x] Botão habilitado quando checkbox marcado (e demais validações passam)
- [x] `cd frontend && npm run build` — 0 erros de TypeScript
- [x] `cd frontend && npm run lint` — 0 novos erros de lint

## Como verificar

1. Navegar para `/worker/onboarding` como usuário worker sem onboarding completo
2. Preencher steps 1 e 2 → avançar para step 3
3. Selecionar disponibilidade → botão "Finalizar" ainda fica desabilitado (sem checkbox)
4. Marcar o checkbox "Li e aceito os Termos de Uso..." → botão "Finalizar" fica ativo
5. Clicar "Finalizar" → `workers.accepted_tos = true` no DB, redirect para `/dashboard`

**Nota:** Aplicar migration T1 (PR #86) antes de testar: `supabase db push`