### PR TITLE
FEAT-005-T5: Modificar CompanyOnboarding para exigir checkbox de TOS no passo final

### DIFF
--- a/frontend/src/pages/company/CompanyOnboarding.tsx
+++ b/frontend/src/pages/company/CompanyOnboarding.tsx
@@ -13,6 +13,7 @@ export default function CompanyOnboarding() {
     const [step, setStep] = useState(1);
     const [cnpjError, setCnpjError] = useState('');
     const [userId, setUserId] = useState<string | null>(null);
+    const [tosAccepted, setTosAccepted] = useState(false);
 
     const TOTAL_STEPS = 2;
 
@@ -80,7 +81,7 @@ export default function CompanyOnboarding() {
     const canProceed = () => {
         switch (step) {
             case 1: return formData.name && formData.cnpj.replace(/\D/g, '').length === 14 && formData.companyType && formData.industry && formData.city;
-            case 2: return formData.hiringGoal && formData.hiringVolume;
+            case 2: return formData.hiringGoal && formData.hiringVolume && tosAccepted;
             default: return true;
         }
     };
@@ -116,7 +117,10 @@ export default function CompanyOnboarding() {
                     industry: formData.industry,
                     city: formData.city,
                     size: formData.hiringVolume,
-                    onboarding_completed: true
+                    onboarding_completed: true,
+                    accepted_tos: true,
+                    tos_version: 'v1',
+                    tos_accepted_at: new Date().toISOString()
                 });
 
             if (error) throw error;
@@ -283,6 +287,22 @@ export default function CompanyOnboarding() {
                                                 </label>
                                             ))}
                                         </div>
+                                    </div>
+
+                                    <div className="flex items-start gap-3 mt-6">
+                                        <input
+                                            type="checkbox"
+                                            id="tos"
+                                            checked={tosAccepted}
+                                            onChange={e => setTosAccepted(e.target.checked)}
+                                            className="w-5 h-5 border-2 border-black rounded accent-primary mt-0.5 flex-shrink-0"
+                                        />
+                                        <label htmlFor="tos" className="text-sm text-gray-700">
+                                            Li e aceito os{' '}
+                                            <a href="/termos" target="_blank" rel="noopener noreferrer" className="text-primary underline font-bold">Termos de Uso</a>
+                                            {' '}e a{' '}
+                                            <a href="/privacidade" target="_blank" rel="noopener noreferrer" className="text-primary underline font-bold">Política de Privacidade</a>
+                                        </label>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## O que foi implementado

Adicionado checkbox de aceite dos Termos de Uso no step 2 (Objetivos) do `CompanyOnboarding`. O botão "Finalizar" permanece desabilitado até o checkbox ser marcado. Ao finalizar, os campos `accepted_tos`, `tos_version` e `tos_accepted_at` são incluídos no upsert para a tabela `companies`. Padrão idêntico ao implementado em T4 para `WorkerOnboarding`.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `frontend/src/pages/company/CompanyOnboarding.tsx` | Modificado | Adiciona `tosAccepted` state, checkbox no step 2, validação em `canProceed()`, e campos TOS no upsert |

## Referências

- **Issue da task:** #36
- **Issue da feature:** #5
- **Spec:** `docs/specs/FEAT-005-tos-acceptance-gate.md`
- **Depende de:** PR #86 (T1 — migration com colunas `accepted_tos`)

Closes #36

## Definition of Done

- [x] `CompanyOnboarding.tsx` compila sem erros TypeScript
- [x] Step 2 (último) exibe o checkbox de TOS com links para /termos e /privacidade
- [x] Botão "Finalizar" desabilitado quando checkbox desmarcado
- [x] Upsert inclui `accepted_tos`, `tos_version`, `tos_accepted_at`
- [x] `cd frontend && npm run build` — 0 erros de TypeScript
- [x] `cd frontend && npm run lint` — 0 novos erros de lint

## Como verificar

1. Navegar para `/company/onboarding` como usuário empresa
2. Preencher step 1 → avançar para step 2
3. Selecionar objetivos → botão "Finalizar" ainda fica desabilitado (sem checkbox)
4. Marcar o checkbox "Li e aceito..." → botão "Finalizar" fica ativo
5. Clicar "Finalizar" → `companies.accepted_tos = true` no DB, redirect para `/company/dashboard`

**Nota:** Aplicar migration T1 (PR #86) antes de testar: `supabase db push`