### PR TITLE
FEAT-005-T6: Testes unitários para TosGateModal e ProtectedRoute com TOS gate

### DIFF
--- a/frontend/src/components/ProtectedRoute.test.tsx
+++ b/frontend/src/components/ProtectedRoute.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import ProtectedRoute from './ProtectedRoute'
+
+// Mock supabase — factories use vi.fn() directly inside to avoid hoisting issues
+const mockUnsubscribe = vi.fn()
+
+vi.mock('../lib/supabase', () => {
+  const mockEq = vi.fn()
+  const mockSingle = vi.fn()
+  const mockSelect = vi.fn(() => ({ eq: mockEq }))
+  const mockFrom = vi.fn(() => ({ select: mockSelect }))
+
+  mockEq.mockImplementation(() => ({ single: mockSingle }))
+  mockSingle.mockResolvedValue({ data: null, error: null })
+
+  return {
+    supabase: {
+      auth: {
+        getSession: vi.fn(() =>
+          Promise.resolve({ data: { session: null } })
+        ),
+        onAuthStateChange: vi.fn(() => ({
+          data: { subscription: { unsubscribe: vi.fn() } },
+        })),
+      },
+      from: mockFrom,
+    },
+  }
+})
+
+// Mock TosGateModal to keep tests simple
+vi.mock('./TosGateModal', () => ({
+  default: ({ userRole }: { userRole: string }) => (
+    <div data-testid="tos-gate-modal">TosGateModal userRole={userRole}</div>
+  ),
+}))
+
+// Mock ToastContext
+vi.mock('../contexts/ToastContext', () => ({
+  useToast: () => ({
+    addToast: vi.fn(),
+    removeToast: vi.fn(),
+  }),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUnsubscribe.mockReset()
+})
+
+function renderProtectedRoute(children = <div data-testid="outlet-content">Conteúdo Protegido</div>) {
+  return render(
+    <MemoryRouter initialEntries={['/dashboard']}>
+      <Routes>
+        <Route element={<ProtectedRoute />}>
+          <Route path="/dashboard" element={children} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('ProtectedRoute — TOS gate', () => {
+  it('renderiza TosGateModal quando tosAccepted é false', async () => {
+    const { supabase } = await import('../lib/supabase')
+
+    // Session exists
+    vi.mocked(supabase.auth.getSession).mockResolvedValue({
+      data: { session: { user: { id: 'user-1' } } as never },
+      error: null,
+    })
+
+    // Worker with accepted_tos = false
+    vi.mocked(supabase.from).mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn(() =>
+            Promise.resolve({ data: { accepted_tos: false }, error: null })
+          ),
+        })),
+      })),
+    } as never)
+
+    renderProtectedRoute()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('tos-gate-modal')).toBeInTheDocument()
+    })
+  })
+
+  it('renderiza Outlet quando tosAccepted é true', async () => {
+    const { supabase } = await import('../lib/supabase')
+
+    // Session exists
+    vi.mocked(supabase.auth.getSession).mockResolvedValue({
+      data: { session: { user: { id: 'user-2' } } as never },
+      error: null,
+    })
+
+    // Worker with accepted_tos = true
+    vi.mocked(supabase.from).mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn(() =>
+            Promise.resolve({ data: { accepted_tos: true }, error: null })
+          ),
+        })),
+      })),
+    } as never)
+
+    renderProtectedRoute()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('outlet-content')).toBeInTheDocument()
+      expect(screen.queryByTestId('tos-gate-modal')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/components/TosGateModal.test.tsx
+++ b/frontend/src/components/TosGateModal.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import TosGateModal from './TosGateModal'
+
+// Mock supabase — use vi.fn() directly inside factory (hoisting safety)
+vi.mock('../lib/supabase', () => ({
+  supabase: {
+    from: vi.fn(() => ({
+      update: vi.fn(() => ({
+        eq: vi.fn(() => Promise.resolve({ error: null })),
+      })),
+    })),
+    auth: {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: { id: 'user-1' } } })
+      ),
+    },
+  },
+}))
+
+// Mock useToast — use vi.fn() directly inside factory
+vi.mock('../contexts/ToastContext', () => ({
+  useToast: () => ({
+    addToast: vi.fn(),
+    removeToast: vi.fn(),
+  }),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('TosGateModal', () => {
+  it('renderiza com checkbox desmarcado inicialmente', () => {
+    render(
+      <TosGateModal userRole="worker" onAccepted={vi.fn()} />
+    )
+
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement
+    expect(checkbox.checked).toBe(false)
+    expect(screen.getByText('Termos de Uso Atualizados')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /aceitar e continuar/i })).toBeInTheDocument()
+  })
+
+  it('botão desabilitado quando checkbox desmarcado', () => {
+    render(
+      <TosGateModal userRole="worker" onAccepted={vi.fn()} />
+    )
+
+    const button = screen.getByRole('button', { name: /aceitar e continuar/i })
+    expect(button).toBeDisabled()
+  })
+
+  it('botão habilitado quando checkbox marcado', () => {
+    render(
+      <TosGateModal userRole="company" onAccepted={vi.fn()} />
+    )
+
+    const checkbox = screen.getByRole('checkbox')
+    fireEvent.click(checkbox)
+
+    const button = screen.getByRole('button', { name: /aceitar e continuar/i })
+    expect(button).not.toBeDisabled()
+  })
+})


### PR DESCRIPTION
## O que foi implementado

Criados testes unitários para `TosGateModal` (3 testes) e `ProtectedRoute` com TOS gate (2 testes). O branch inclui cherry-picks de T2 (TosGateModal) e T3 (ProtectedRoute) para compilação independente.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `frontend/src/components/TosGateModal.test.tsx` | Criado | 3 testes: checkbox inicial, botão desabilitado sem aceite, botão habilitado após aceite |
| `frontend/src/components/ProtectedRoute.test.tsx` | Criado | 2 testes: TosGateModal exibido quando `accepted_tos=false`, Outlet exibido quando `accepted_tos=true` |

## Referências

- **Issue da task:** #37
- **Issue da feature:** #5
- **Spec:** `docs/specs/FEAT-005-tos-acceptance-gate.md`
- **Depende de:** PR #87 (T2 — TosGateModal), PR #88 (T3 — ProtectedRoute TOS gate)

Closes #37

## Definition of Done

- [x] `TosGateModal.test.tsx` existe com 3 testes passando
- [x] 2 testes de TOS gate em `ProtectedRoute.test.tsx` passando
- [x] `cd frontend && npm run test -- --run` — 36 testes passando (0 falhas)
- [x] `cd frontend && npm run build` — 0 erros de TypeScript
- [x] `cd frontend && npm run lint` — 0 novos erros de lint

## Como verificar

```bash
cd frontend && npm run test -- --run
# Deve mostrar: 5 test files passed, 36 tests passed
```