### PR TITLE
FEAT-006-T1: Criar migration SQL com trigger de atualização automática de rating do worker

### DIFF
--- a/supabase/migrations/20260312200000_auto_update_worker_rating.sql
+++ b/supabase/migrations/20260312200000_auto_update_worker_rating.sql
@@ -1,0 +1,62 @@
+-- Migration: Auto-atualizar rating_average e reviews_count do worker ao receber review
+-- File: supabase/migrations/20260312200000_auto_update_worker_rating.sql
+
+-- 1. Adicionar coluna reviews_count se não existir (rating_average já existe)
+ALTER TABLE workers
+    ADD COLUMN IF NOT EXISTS reviews_count INTEGER DEFAULT 0 NOT NULL;
+
+-- 2. Inicializar reviews_count para workers existentes baseado na tabela reviews
+UPDATE workers w
+SET reviews_count = (
+    SELECT COUNT(*) FROM reviews r WHERE r.reviewed_id = w.id
+);
+
+-- 3. Inicializar rating_average para workers existentes baseado na tabela reviews
+UPDATE workers w
+SET rating_average = (
+    SELECT COALESCE(AVG(r.rating), 0) FROM reviews r WHERE r.reviewed_id = w.id
+)
+WHERE EXISTS (SELECT 1 FROM reviews r WHERE r.reviewed_id = w.id);
+
+-- 4. Constraint de unicidade: uma empresa não pode avaliar o mesmo worker no mesmo job
+ALTER TABLE reviews
+    ADD CONSTRAINT reviews_unique_per_job
+    UNIQUE (job_id, reviewer_id, reviewed_id);
+
+-- 5. Constraint: reviewer e reviewed não podem ser a mesma pessoa
+ALTER TABLE reviews
+    ADD CONSTRAINT reviews_no_self_review
+    CHECK (reviewer_id <> reviewed_id);
+
+-- 6. Função trigger para atualizar rating do worker
+CREATE OR REPLACE FUNCTION update_worker_rating_on_review()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    UPDATE workers
+    SET
+        rating_average = (
+            SELECT ROUND(AVG(rating)::numeric, 1)
+            FROM reviews
+            WHERE reviewed_id = NEW.reviewed_id
+        ),
+        reviews_count = (
+            SELECT COUNT(*)
+            FROM reviews
+            WHERE reviewed_id = NEW.reviewed_id
+        )
+    WHERE id = NEW.reviewed_id;
+
+    RETURN NEW;
+END;
+$$;
+
+-- 7. Trigger AFTER INSERT
+DROP TRIGGER IF EXISTS trg_update_worker_rating ON reviews;
+CREATE TRIGGER trg_update_worker_rating
+    AFTER INSERT ON reviews
+    FOR EACH ROW
+    EXECUTE FUNCTION update_worker_rating_on_review();


### PR DESCRIPTION
## O que foi implementado

Migration SQL que automatiza a atualização de `rating_average` e `reviews_count` em `workers` via trigger PostgreSQL. Inclui backfill dos dados existentes, constraints de unicidade de review por job e prevenção de auto-avaliação.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `supabase/migrations/20260312200000_auto_update_worker_rating.sql` | Criado | Adiciona `reviews_count`, constraints de unicidade e self-review, função trigger e trigger AFTER INSERT em `reviews` |

## Referências

- **Issue da task:** #38
- **Issue da feature:** #6
- **Spec:** `docs/specs/FEAT-006-worker-rating-review-system.md`

Closes #38

## Definition of Done

- [x] `supabase/migrations/20260312200000_auto_update_worker_rating.sql` existe
- [x] Contém `ALTER TABLE workers ADD COLUMN IF NOT EXISTS reviews_count`
- [x] Contém constraint `reviews_unique_per_job` UNIQUE
- [x] Contém constraint `reviews_no_self_review` CHECK
- [x] Contém função `update_worker_rating_on_review()` e trigger `trg_update_worker_rating`
- [x] Timestamp `20260312200000` maior que o da migration mais recente (`20260311200000`)
- [x] `cd frontend && npm run build` — 0 erros de TypeScript
- [x] `cd frontend && npm run lint` — 0 novos erros de lint

## Como verificar

Aplicar a migration antes de testar as tasks subsequentes (T2, T3):

```bash
supabase db push
```

Após aplicar:
1. Inserir uma review na tabela `reviews` para um worker → `workers.rating_average` e `workers.reviews_count` devem ser atualizados automaticamente
2. Tentar inserir segunda review do mesmo `reviewer_id` para o mesmo `reviewed_id` e `job_id` → deve falhar com constraint `reviews_unique_per_job`
3. Tentar inserir review com `reviewer_id = reviewed_id` → deve falhar com constraint `reviews_no_self_review`