### PR TITLE
FEAT-006-T2: Modificar WorkerPublicProfile para exibir data, contagem e empty state de reviews

### DIFF
--- a/frontend/src/components/EscrowStatusBadge.tsx
+++ b/frontend/src/components/EscrowStatusBadge.tsx
@@ -1,0 +1,21 @@
+interface EscrowStatusBadgeProps {
+  escrowStatus: 'reserved' | 'released' | null;
+}
+
+export default function EscrowStatusBadge({ escrowStatus }: EscrowStatusBadgeProps) {
+  if (escrowStatus === null) return null;
+
+  if (escrowStatus === 'reserved') {
+    return (
+      <span className="bg-yellow-100 border border-yellow-200 text-yellow-700 text-xs font-bold px-2 py-1 rounded-full">
+        Pagamento Reservado
+      </span>
+    );
+  }
+
+  return (
+    <span className="bg-green-100 border border-green-200 text-green-700 text-xs font-bold px-2 py-1 rounded-full">
+      Pagamento Liberado
+    </span>
+  );
+}

--- a/frontend/src/pages/company/WorkerPublicProfile.tsx
+++ b/frontend/src/pages/company/WorkerPublicProfile.tsx
@@ -17,6 +17,8 @@ export default function WorkerPublicProfile() {
         xp?: number;
         completed_jobs_count?: number;
         recommendation_score?: number;
+        rating_average?: number;
+        reviews_count?: number;
         tags?: string[];
         created_at: string;
         avatar_url?: string;
@@ -62,7 +64,7 @@ export default function WorkerPublicProfile() {
             // Fetch Profile
             const { data: profileData, error: profileError } = await supabase
                 .from('workers')
-                .select('id, full_name, bio, city, level, xp, completed_jobs_count, recommendation_score, tags, created_at, avatar_url')
+                .select('id, full_name, bio, city, level, xp, completed_jobs_count, recommendation_score, rating_average, reviews_count, tags, created_at, avatar_url')
                 .eq('id', id)
                 .single();
 
@@ -116,7 +118,7 @@ export default function WorkerPublicProfile() {
             setHistory(historyData || []);
 
         } catch (error) {
-            console.error('Error fetching worker profile:', error);
+            console.error('Erro ao carregar perfil do worker:', error);
         } finally {
             setLoading(false);
         }
@@ -180,7 +182,12 @@ export default function WorkerPublicProfile() {
                         </div>
                         <div className="bg-gray-50 p-4 rounded-xl border-2 border-gray-100">
                             <div className="flex items-center gap-2 text-gray-400 font-bold mb-1 text-xs uppercase"><Star size={14} /> Avaliação</div>
-                            <div className="text-2xl font-black text-yellow-500">{(profile.recommendation_score ?? 0) > 0 ? ((profile.recommendation_score ?? 0) / 20).toFixed(1) : 'N/A'}</div>
+                            <div className="text-2xl font-black text-yellow-500">
+                                {(profile.reviews_count ?? 0) > 0 && (profile.rating_average ?? 0) > 0
+                                    ? Number(profile.rating_average).toFixed(1)
+                                    : '—'}
+                            </div>
+                            <p className="text-xs text-gray-500">({profile.reviews_count ?? 0} avaliações)</p>
                         </div>
                         <div className="bg-gray-50 p-4 rounded-xl border-2 border-gray-100">
                             <div className="flex items-center gap-2 text-gray-400 font-bold mb-1 text-xs uppercase"><Award size={14} /> XP Total</div>
@@ -235,10 +242,13 @@ export default function WorkerPublicProfile() {
                                         ))}
                                     </div>
                                 </div>
-                                <p className="text-sm text-gray-600 font-medium">"{r.comment}"</p>
+                                <p className="text-sm text-gray-600 font-medium">"{r.comment || 'Sem comentário'}"</p>
+                                <p className="text-xs text-gray-400 mt-1">
+                                    {format(new Date(r.created_at), "d 'de' MMM. 'de' yyyy", { locale: ptBR })}
+                                </p>
                             </div>
                         )) : (
-                            <p className="text-gray-400 italic font-medium">Nenhuma avaliação ainda.</p>
+                            <p className="text-sm text-gray-400 italic text-center py-4">Nenhuma avaliação ainda. Seja o primeiro a avaliar!</p>
                         )}
                     </div>
                 </div>


### PR DESCRIPTION
## O que foi implementado

Modificado WorkerPublicProfile.tsx com 4 melhorias do sistema de avaliação: (1) data formatada em português para cada review; (2) substituição de 'N/A' por '—' no empty state de avaliação; (3) adição de '(N avaliações)' abaixo da nota média; (4) empty state melhorado na seção Comentários. Também restaurado EscrowStatusBadge.tsx ausente em main.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| frontend/src/pages/company/WorkerPublicProfile.tsx | Modificado | Adiciona data formatada em reviews, substitui N/A por —, adiciona contagem de avaliações, melhora empty state |
| frontend/src/components/EscrowStatusBadge.tsx | Criado | Restaura componente ausente em main (necessário para build de FEAT-001) |

## Referências

- Issue da task: #39
- Issue da feature: #6
- Spec: docs/specs/FEAT-006-worker-rating-review-system.md

Closes #39

## Definition of Done

- [x] npm run build — 0 erros de TypeScript
- [x] npm run lint — 0 novos erros de lint
- [x] npm run test -- --run — testes anteriores passando (4 falhas pré-existentes em CompanyJobCandidates.test.tsx não causadas por esta PR)
- [x] Cada review exibe data no formato "12 de mar. de 2026"
- [x] Stats grid exibe "—" quando reviews_count === 0
- [x] Stats grid exibe "(N avaliações)" abaixo da nota
- [x] Empty state exibe "Nenhuma avaliação ainda. Seja o primeiro a avaliar!" quando sem reviews

## Como verificar

1. Acessar /company/worker/{workerId} com worker que tenha reviews — cada review exibe data formatada em português
2. Acessar /company/worker/{workerId} com worker sem reviews — seção Comentários exibe "Nenhuma avaliação ainda. Seja o primeiro a avaliar!" e seção Avaliação exibe "—"
3. Worker com reviews_count=7 — exibe "(7 avaliações)" abaixo da nota