### PR TITLE
FEAT-006-T3: Modificar CompanyJobCandidates para tratar erro de review duplicado (23505)

### DIFF
--- a/frontend/src/components/EscrowStatusBadge.tsx
+++ b/frontend/src/components/EscrowStatusBadge.tsx
@@ -1,0 +1,21 @@
+interface EscrowStatusBadgeProps {
+  escrowStatus: 'reserved' | 'released' | null;
+}
+
+export default function EscrowStatusBadge({ escrowStatus }: EscrowStatusBadgeProps) {
+  if (escrowStatus === null) return null;
+
+  if (escrowStatus === 'reserved') {
+    return (
+      <span className="bg-yellow-100 border border-yellow-200 text-yellow-700 text-xs font-bold px-2 py-1 rounded-full">
+        Pagamento Reservado
+      </span>
+    );
+  }
+
+  return (
+    <span className="bg-green-100 border border-green-200 text-green-700 text-xs font-bold px-2 py-1 rounded-full">
+      Pagamento Liberado
+    </span>
+  );
+}

--- a/frontend/src/pages/company/CompanyJobCandidates.tsx
+++ b/frontend/src/pages/company/CompanyJobCandidates.tsx
@@ -145,7 +145,15 @@ export default function CompanyJobCandidates() {
             });
 
             if (reviewError) {
-                console.error('Review insert failed:', reviewError);
+                if (reviewError.code === '23505') {
+                    addToast('Você já avaliou este profissional para este job.', 'error');
+                } else {
+                    addToast('Erro ao salvar avaliação. Tente novamente.', 'error');
+                }
+                setSubmittingReview(false);
+                setRatingModalOpen(false);
+                fetchCandidates();
+                return;
             }
 
             addToast('Job finalizado e pagamento liberado!', 'success');


### PR DESCRIPTION
## O que foi implementado

Adicionado tratamento específico do código de erro PostgreSQL 23505 (unique constraint violation) no handleSubmitReview de CompanyJobCandidates.tsx. Quando a empresa tenta avaliar o mesmo worker no mesmo job mais de uma vez, o toast exibe mensagem específica em vez de erro genérico. Segue a constraint reviews_unique_per_job criada na migration FEAT-006-T1.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| frontend/src/pages/company/CompanyJobCandidates.tsx | Modificado | Adiciona verificação de reviewError.code === '23505' com toast específico de avaliação duplicada |
| frontend/src/components/EscrowStatusBadge.tsx | Criado | Restaura componente ausente em main (necessário para build) |

## Referências

- Issue da task: #40
- Issue da feature: #6
- Spec: docs/specs/FEAT-006-worker-rating-review-system.md

Closes #40

## Definition of Done

- [x] npm run build — 0 erros de TypeScript
- [x] npm run lint — 0 novos erros de lint
- [x] npm run test -- --run — testes anteriores passando (5 falhas pré-existentes não causadas por esta PR)
- [x] Ao receber error.code === '23505' do INSERT de review: toast 'Você já avaliou este profissional para este job.'
- [x] Outros erros de review exibem toast genérico 'Erro ao salvar avaliação. Tente novamente.'
- [x] Botão "Avaliar" visível apenas para status === 'completed'

## Como verificar

1. Avaliar o mesmo worker no mesmo job duas vezes — segundo envio exibe toast "Você já avaliou este profissional para este job."
2. Simular outro erro de insert de review — toast "Erro ao salvar avaliação. Tente novamente." é exibido
3. Verificar que botão "Avaliar" aparece apenas para candidatos com status === 'completed'