### PR TITLE
FEAT-007-T1: Criar PageMeta componente para meta tags dinâmicos com React 19

### DIFF
--- a/frontend/src/components/EscrowStatusBadge.tsx
+++ b/frontend/src/components/EscrowStatusBadge.tsx
@@ -1,0 +1,21 @@
+interface EscrowStatusBadgeProps {
+  escrowStatus: 'reserved' | 'released' | null;
+}
+
+export default function EscrowStatusBadge({ escrowStatus }: EscrowStatusBadgeProps) {
+  if (escrowStatus === null) return null;
+
+  if (escrowStatus === 'reserved') {
+    return (
+      <span className="bg-yellow-100 border border-yellow-200 text-yellow-700 text-xs font-bold px-2 py-1 rounded-full">
+        Pagamento Reservado
+      </span>
+    );
+  }
+
+  return (
+    <span className="bg-green-100 border border-green-200 text-green-700 text-xs font-bold px-2 py-1 rounded-full">
+      Pagamento Liberado
+    </span>
+  );
+}

--- a/frontend/src/components/PageMeta.tsx
+++ b/frontend/src/components/PageMeta.tsx
@@ -1,0 +1,18 @@
+interface PageMetaProps {
+  title: string;
+  description?: string;
+  ogTitle?: string;
+  ogDescription?: string;
+}
+
+export default function PageMeta({ title, description, ogTitle, ogDescription }: PageMetaProps) {
+  const fullTitle = title.includes('Worki') ? title : `${title} — Worki`
+  return (
+    <>
+      <title>{fullTitle}</title>
+      {description && <meta name="description" content={description} />}
+      {ogTitle && <meta property="og:title" content={ogTitle} />}
+      {ogDescription && <meta property="og:description" content={ogDescription} />}
+    </>
+  )
+}


### PR DESCRIPTION
## O que foi implementado

Cria o componente `PageMeta` que usa a sintaxe nativa do React 19 para renderizar `<title>` e `<meta>` tags diretamente no render tree — o React 19 automaticamente hissa esses elementos para o `<head>` do documento. O sufixo "— Worki" é adicionado automaticamente ao título quando ainda não presente, evitando duplicação.

Também restaura `EscrowStatusBadge.tsx` que estava ausente do main mas referenciado por seu arquivo de testes, causando falha de build.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `frontend/src/components/PageMeta.tsx` | Criado | Componente stateless com props title, description, ogTitle, ogDescription — renderiza meta tags para o head |
| `frontend/src/components/EscrowStatusBadge.tsx` | Criado | Badge de status de escrow (restaurado — ausente do main) |

## Referências

- **Issue da task:** #42
- **Issue da feature:** #7
- **Spec:** `docs/specs/FEAT-007-seo-dynamic-meta-tags.md`

Closes #42

## Definition of Done

- [x] `frontend/src/components/PageMeta.tsx` existe
- [x] `<PageMeta title="Entrar" />` produz `<title>Entrar — Worki</title>` no DOM
- [x] `<PageMeta title="Entrar — Worki" />` NÃO duplica para "Entrar — Worki — Worki"
- [x] Props opcionais não renderizam tags quando undefined
- [x] `npm run build` — 0 erros de TypeScript
- [x] `npm run lint` — 0 novos erros de lint
- [x] `npm run test -- --run` — todos os testes anteriores passando (1 falha pre-existente em ProtectedRoute.test.tsx não relacionada a esta task)

## Como verificar

1. Importar `<PageMeta title="Entrar" />` em qualquer página → `document.title` deve ser "Entrar — Worki"
2. Importar `<PageMeta title="Worki — Marketplace" />` → título não deve duplicar "Worki"
3. `<PageMeta title="Test" description="desc" />` → `<meta name="description" content="desc">` presente no head
4. `<PageMeta title="Test" />` sem description → nenhuma tag `<meta name="description">` no head