### PR TITLE
FEAT-008-T2: Modificar Profile.tsx com seção Zona de Perigo e modal de exclusão de conta

### DIFF
--- a/frontend/src/components/EscrowStatusBadge.tsx
+++ b/frontend/src/components/EscrowStatusBadge.tsx
@@ -1,0 +1,21 @@
+interface EscrowStatusBadgeProps {
+  escrowStatus: 'reserved' | 'released' | null;
+}
+
+export default function EscrowStatusBadge({ escrowStatus }: EscrowStatusBadgeProps) {
+  if (escrowStatus === null) return null;
+
+  if (escrowStatus === 'reserved') {
+    return (
+      <span className="bg-yellow-100 border border-yellow-200 text-yellow-700 text-xs font-bold px-2 py-1 rounded-full">
+        Pagamento Reservado
+      </span>
+    );
+  }
+
+  return (
+    <span className="bg-green-100 border border-green-200 text-green-700 text-xs font-bold px-2 py-1 rounded-full">
+      Pagamento Liberado
+    </span>
+  );
+}

--- a/frontend/src/components/PageMeta.tsx
+++ b/frontend/src/components/PageMeta.tsx
@@ -1,0 +1,18 @@
+interface PageMetaProps {
+  title: string;
+  description?: string;
+  ogTitle?: string;
+  ogDescription?: string;
+}
+
+export default function PageMeta({ title, description, ogTitle, ogDescription }: PageMetaProps) {
+  const fullTitle = title.includes('Worki') ? title : `${title} — Worki`
+  return (
+    <>
+      <title>{fullTitle}</title>
+      {description && <meta name="description" content={description} />}
+      {ogTitle && <meta property="og:title" content={ogTitle} />}
+      {ogDescription && <meta property="og:description" content={ogDescription} />}
+    </>
+  )
+}

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -54,6 +54,11 @@ export default function Profile() {
         hoursWorked: 0
     });
 
+    // Account deletion states
+    const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+    const [deleteConfirmText, setDeleteConfirmText] = useState('');
+    const [deleting, setDeleting] = useState(false);
+
     useEffect(() => {
         const fetchProfile = async () => {
             const { data: { user } } = await supabase.auth.getUser();
@@ -177,6 +182,18 @@ export default function Profile() {
         }
     };
 
+    const handleDeleteAccount = async () => {
+        setDeleting(true);
+        const { error } = await supabase.functions.invoke('delete-account', { body: {} });
+        if (error) {
+            addToast(error.message || 'Erro ao excluir conta. Tente novamente.', 'error');
+            setDeleting(false);
+            return;
+        }
+        await supabase.auth.signOut();
+        navigate('/login');
+    };
+
     if (loading) return (
         <div className="flex justify-center items-center min-h-[50vh]">
             <Loader2 className="animate-spin" size={32} />
@@ -186,6 +203,7 @@ export default function Profile() {
     if (!profile) return <div className="text-center p-8">Erro ao carregar perfil.</div>;
 
     return (
+        <>
         <div className="flex flex-col gap-8 pb-12 font-sans text-accent max-w-4xl mx-auto">
 
             {/* Header / Cover */}
@@ -461,6 +479,68 @@ export default function Profile() {
                 </div>
 
             </div>
+
+            {/* Zona de Perigo */}
+            <div className="border-t-2 border-red-200 pt-8 mt-8">
+                <h3 className="text-red-600 font-black uppercase text-lg mb-4">Zona de Perigo</h3>
+                <p className="text-sm text-gray-600 mb-4">A exclusão da sua conta é irreversível. Todos os seus dados pessoais serão anonimizados.</p>
+                <button
+                    onClick={() => setDeleteModalOpen(true)}
+                    className="border-2 border-red-500 text-red-500 bg-white hover:bg-red-50 font-bold uppercase px-4 py-2 rounded-xl transition-colors"
+                >
+                    Excluir minha conta
+                </button>
+            </div>
+
         </div>
+
+        {/* Modal de confirmação de exclusão */}
+        {deleteModalOpen && (
+            <div className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4">
+                <div className="bg-white rounded-2xl w-full max-w-md p-6 border-2 border-black shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+                    <h2 className="text-xl font-black uppercase tracking-tight mb-4 text-red-600">Tem certeza? Esta ação é irreversível.</h2>
+                    <ul className="space-y-2 mb-6 text-sm text-gray-700">
+                        <li className="flex items-start gap-2">
+                            <span className="font-black text-red-500 mt-0.5">•</span>
+                            Seu perfil e dados pessoais serão anonimizados
+                        </li>
+                        <li className="flex items-start gap-2">
+                            <span className="font-black text-red-500 mt-0.5">•</span>
+                            Vagas e candidaturas ativas serão canceladas
+                        </li>
+                        <li className="flex items-start gap-2">
+                            <span className="font-black text-red-500 mt-0.5">•</span>
+                            Seu saldo restante na carteira será perdido
+                        </li>
+                    </ul>
+                    <label className="block text-sm font-bold mb-2">
+                        Digite <span className="font-black">EXCLUIR</span> para confirmar:
+                    </label>
+                    <input
+                        type="text"
+                        value={deleteConfirmText}
+                        onChange={(e) => setDeleteConfirmText(e.target.value)}
+                        className="w-full border-2 border-gray-300 rounded-xl px-4 py-2 mb-6 font-bold focus:border-red-500 outline-none"
+                        placeholder="EXCLUIR"
+                    />
+                    <div className="flex gap-3">
+                        <button
+                            onClick={() => { setDeleteModalOpen(false); setDeleteConfirmText(''); }}
+                            className="flex-1 py-3 border-2 border-black font-bold rounded-xl hover:bg-gray-50 transition-colors"
+                        >
+                            Cancelar
+                        </button>
+                        <button
+                            onClick={handleDeleteAccount}
+                            disabled={deleteConfirmText !== 'EXCLUIR' || deleting}
+                            className="flex-1 py-3 bg-red-600 text-white font-bold rounded-xl border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            {deleting ? 'Excluindo...' : 'Confirmar Exclusão'}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        )}
+        </>
     );
 }


### PR DESCRIPTION
## O que foi implementado

Adiciona a seção "Zona de Perigo" ao final da página de perfil do worker, com botão "Excluir minha conta" e modal de confirmação neo-brutalist que exige digitação de "EXCLUIR" antes de confirmar. O handler chama a Edge Function `delete-account` (FEAT-008-T1), faz signOut e redireciona para `/login` em caso de sucesso.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `frontend/src/pages/Profile.tsx` | Modificado | Adiciona estados de deleção, handler handleDeleteAccount, seção Zona de Perigo, e modal de confirmação |
| `frontend/src/components/PageMeta.tsx` | Criado | Dependência de build (ausente do main) |
| `frontend/src/components/EscrowStatusBadge.tsx` | Criado | Dependência de build (ausente do main) |

## Referências

- **Issue da task:** #47
- **Issue da feature:** #8
- **Spec:** `docs/specs/FEAT-008-account-deletion-lgpd.md`

Closes #47

## Definition of Done

- [x] Seção "Zona de Perigo" aparece no final da página
- [x] Clicar "Excluir minha conta" abre o modal
- [x] Botão "Confirmar Exclusão" desabilitado quando campo não contém "EXCLUIR"
- [x] Botão habilitado apenas quando campo contém exatamente "EXCLUIR"
- [x] Clicar "Cancelar" fecha modal e reseta o campo
- [x] `npm run build` — 0 erros
- [x] `npm run lint` — 0 novos erros

## Como verificar

1. Navegar para `/profile` → seção "Zona de Perigo" deve estar visível no final
2. Clicar "Excluir minha conta" → modal abre
3. Digitar qualquer texto que não seja "EXCLUIR" → botão "Confirmar Exclusão" desabilitado
4. Digitar "EXCLUIR" exatamente → botão ativa
5. Clicar "Cancelar" → modal fecha, campo reseta