### PR TITLE
FEAT-009-T1: Configurar source maps hidden no vite.config.ts para Sentry

### DIFF
--- a/frontend/src/components/EscrowStatusBadge.tsx
+++ b/frontend/src/components/EscrowStatusBadge.tsx
@@ -1,0 +1,21 @@
+interface EscrowStatusBadgeProps {
+  escrowStatus: 'reserved' | 'released' | null;
+}
+
+export default function EscrowStatusBadge({ escrowStatus }: EscrowStatusBadgeProps) {
+  if (escrowStatus === null) return null;
+
+  if (escrowStatus === 'reserved') {
+    return (
+      <span className="bg-yellow-100 border border-yellow-200 text-yellow-700 text-xs font-bold px-2 py-1 rounded-full">
+        Pagamento Reservado
+      </span>
+    );
+  }
+
+  return (
+    <span className="bg-green-100 border border-green-200 text-green-700 text-xs font-bold px-2 py-1 rounded-full">
+      Pagamento Liberado
+    </span>
+  );
+}

--- a/frontend/src/components/PageMeta.tsx
+++ b/frontend/src/components/PageMeta.tsx
@@ -1,0 +1,18 @@
+interface PageMetaProps {
+  title: string;
+  description?: string;
+  ogTitle?: string;
+  ogDescription?: string;
+}
+
+export default function PageMeta({ title, description, ogTitle, ogDescription }: PageMetaProps) {
+  const fullTitle = title.includes('Worki') ? title : `${title} — Worki`
+  return (
+    <>
+      <title>{fullTitle}</title>
+      {description && <meta name="description" content={description} />}
+      {ogTitle && <meta property="og:title" content={ogTitle} />}
+      {ogDescription && <meta property="og:description" content={ogDescription} />}
+    </>
+  )
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    sourcemap: 'hidden',
+  },
 })


### PR DESCRIPTION
## O que foi implementado

Adiciona `build: { sourcemap: 'hidden' }` ao `vite.config.ts`. Com `sourcemap: 'hidden'`, o Vite gera arquivos `.js.map` na pasta `dist/assets/` mas não inclui o comentário `//# sourceMappingURL=` nos bundles JS, impedindo que navegadores (e usuários) acessem os source maps enquanto o Sentry ainda pode carregá-los via upload direto.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `frontend/vite.config.ts` | Modificado | Adiciona `build: { sourcemap: 'hidden' }` |
| `frontend/src/components/PageMeta.tsx` | Criado | Dependência de build (ausente do main) |
| `frontend/src/components/EscrowStatusBadge.tsx` | Criado | Dependência de build (ausente do main) |

## Referências

- **Issue da task:** #50
- **Issue da feature:** #9

Closes #50

## Definition of Done

- [x] `vite.config.ts` contém `sourcemap: 'hidden'` no objeto `build`
- [x] `npm run build` passa com 0 erros
- [x] Pasta `dist/assets/` contém arquivos `.js.map` após o build
- [x] `npm run lint` — 0 novos erros

## Como verificar

Após `npm run build`, verificar `ls dist/assets/*.map` — deve listar múltiplos arquivos `.js.map`.