### PR TITLE
FEAT-009-T3: Associar usuário autenticado ao Sentry em AuthContext.tsx

### DIFF
--- a/frontend/src/components/EscrowStatusBadge.tsx
+++ b/frontend/src/components/EscrowStatusBadge.tsx
@@ -1,0 +1,21 @@
+interface EscrowStatusBadgeProps {
+  escrowStatus: 'reserved' | 'released' | null;
+}
+
+export default function EscrowStatusBadge({ escrowStatus }: EscrowStatusBadgeProps) {
+  if (escrowStatus === null) return null;
+
+  if (escrowStatus === 'reserved') {
+    return (
+      <span className="bg-yellow-100 border border-yellow-200 text-yellow-700 text-xs font-bold px-2 py-1 rounded-full">
+        Pagamento Reservado
+      </span>
+    );
+  }
+
+  return (
+    <span className="bg-green-100 border border-green-200 text-green-700 text-xs font-bold px-2 py-1 rounded-full">
+      Pagamento Liberado
+    </span>
+  );
+}

--- a/frontend/src/components/PageMeta.tsx
+++ b/frontend/src/components/PageMeta.tsx
@@ -1,0 +1,18 @@
+interface PageMetaProps {
+  title: string;
+  description?: string;
+  ogTitle?: string;
+  ogDescription?: string;
+}
+
+export default function PageMeta({ title, description, ogTitle, ogDescription }: PageMetaProps) {
+  const fullTitle = title.includes('Worki') ? title : `${title} — Worki`
+  return (
+    <>
+      <title>{fullTitle}</title>
+      {description && <meta name="description" content={description} />}
+      {ogTitle && <meta property="og:title" content={ogTitle} />}
+      {ogDescription && <meta property="og:description" content={ogDescription} />}
+    </>
+  )
+}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import type { User } from '@supabase/supabase-js';
+import * as Sentry from '@sentry/react';
 import { supabase } from '../lib/supabase';
 
 interface AuthContextType {
@@ -19,6 +20,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         const getSession = async () => {
             const { data: { session } } = await supabase.auth.getSession();
             setUser(session?.user ?? null);
+            if (session?.user) {
+                Sentry.setUser({ id: session.user.id });
+            } else {
+                Sentry.setUser(null);
+            }
             setLoading(false);
         };
 
@@ -27,6 +33,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         // Listen for changes on auth state (logged in, signed out, etc.)
         const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
             setUser(session?.user ?? null);
+            if (session?.user) {
+                Sentry.setUser({ id: session.user.id });
+            } else {
+                Sentry.setUser(null);
+            }
             setLoading(false);
         });
 


### PR DESCRIPTION
## O que foi implementado

Adiciona `Sentry.setUser()` em `AuthContext.tsx` em dois pontos: no `getSession` inicial (verificação de sessão existente ao carregar a app) e no listener `onAuthStateChange` (mudanças de estado de autenticação). Com isso, todos os erros capturados pelo Sentry após o login ficam associados ao ID do usuário, facilitando debugging e rastreamento em produção.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `frontend/src/contexts/AuthContext.tsx` | Modificado | Adiciona import Sentry e chamadas setUser nos pontos de autenticação |
| `frontend/src/components/PageMeta.tsx` | Criado | Dependência de build (ausente do main) |
| `frontend/src/components/EscrowStatusBadge.tsx` | Criado | Dependência de build (ausente do main) |

## Referências

- **Issue da task:** #52
- **Issue da feature:** #9

Closes #52

## Definition of Done

- [x] `AuthContext.tsx` importa `@sentry/react`
- [x] `Sentry.setUser({ id: user.id })` chamado após login detectado
- [x] `Sentry.setUser(null)` chamado após logout
- [x] `npm run build` — 0 erros
- [x] `npm run lint` — 0 novos erros