### PR TITLE
AUDIT-01-T1: Habilitar RLS na tabela Message com policies SELECT e INSERT

### DIFF
--- a/supabase/migrations/20260317012423_message_rls.sql
+++ b/supabase/migrations/20260317012423_message_rls.sql
@@ -1,0 +1,39 @@
+-- Migration: Habilitar RLS na tabela Message
+-- Risk: LOW
+-- Backup required: NO
+--
+-- DOWN (rollback):
+-- DROP POLICY IF EXISTS "Participants can view messages" ON "Message";
+-- DROP POLICY IF EXISTS "Participants can insert messages" ON "Message";
+-- ALTER TABLE "Message" DISABLE ROW LEVEL SECURITY;
+
+-- UP (apply):
+ALTER TABLE "Message" ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: participantes da conversa podem ver mensagens
+CREATE POLICY "Participants can view messages" ON "Message"
+    FOR SELECT TO authenticated
+    USING (
+        conversation_id IN (
+            SELECT id FROM "Conversation"
+            WHERE application_uuid IN (
+                SELECT id FROM applications
+                WHERE worker_id = auth.uid()
+                   OR job_id IN (SELECT id FROM jobs WHERE company_id = auth.uid())
+            )
+        )
+    );
+
+-- INSERT: participantes da conversa podem enviar mensagens
+CREATE POLICY "Participants can insert messages" ON "Message"
+    FOR INSERT TO authenticated
+    WITH CHECK (
+        conversation_id IN (
+            SELECT id FROM "Conversation"
+            WHERE application_uuid IN (
+                SELECT id FROM applications
+                WHERE worker_id = auth.uid()
+                   OR job_id IN (SELECT id FROM jobs WHERE company_id = auth.uid())
+            )
+        )
+    );


### PR DESCRIPTION
## O que foi implementado

Migration SQL que habilita Row Level Security na tabela "Message" e cria policies de SELECT e INSERT restritas a participantes da conversa.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `supabase/migrations/20260317012423_message_rls.sql` | Criado | Habilita RLS, cria policies SELECT e INSERT para participantes |

## Referências

- **Issue da task:** #135
- **Issue da feature:** #116
- **Spec:** `docs/specs/FEAT-001-message-rls.md`

Refs #135

## Definition of Done

- [x] Migration file existe com RLS habilitado e policies
- [x] DOWN script incluso
- [x] `npm run build` — 0 erros