### PR TITLE
AUDIT-02-T1: Adicionar verificação de service_role em send-notification

### DIFF
--- a/supabase/functions/send-notification/index.ts
+++ b/supabase/functions/send-notification/index.ts
@@ -11,6 +11,25 @@ serve(async (req) => {
         return new Response('ok', { headers: corsHeaders });
     }
 
+    // Auth validation: only service_role can call this function
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+        return new Response(
+            JSON.stringify({ error: 'Authorization header required' }),
+            { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+    }
+
+    const token = authHeader.replace('Bearer ', '');
+    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+    if (token !== serviceRoleKey) {
+        return new Response(
+            JSON.stringify({ error: 'Service role required' }),
+            { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+    }
+
     try {
         const supabaseAdmin = createClient(
             Deno.env.get('SUPABASE_URL') ?? '',


### PR DESCRIPTION
## O que foi implementado

Adiciona verificação de Authorization header e validação de service_role key na edge function send-notification. Requests sem auth retornam 401, requests com JWT normal retornam 403.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `supabase/functions/send-notification/index.ts` | Modificado | Auth validation com service_role check |

Refs #136

## Definition of Done

- [x] Auth validation presente
- [x] 401 para requests sem header
- [x] 403 para tokens não service_role
- [x] `npm run build` — 0 erros