### PR TITLE
AUDIT-08-T1: Adicionar policy UPDATE para tabela Conversation

### DIFF
--- a/supabase/migrations/20260317012800_conversation_update_policy.sql
+++ b/supabase/migrations/20260317012800_conversation_update_policy.sql
@@ -1,0 +1,24 @@
+-- Migration: Adicionar UPDATE policy para Conversation
+-- Risk: LOW
+-- Backup required: NO
+--
+-- DOWN (rollback):
+-- DROP POLICY IF EXISTS "Participants can update conversations" ON "Conversation";
+
+-- UP (apply):
+CREATE POLICY "Participants can update conversations" ON "Conversation"
+    FOR UPDATE TO authenticated
+    USING (
+        application_uuid IN (
+            SELECT id FROM applications
+            WHERE worker_id = auth.uid()
+               OR job_id IN (SELECT id FROM jobs WHERE company_id = auth.uid())
+        )
+    )
+    WITH CHECK (
+        application_uuid IN (
+            SELECT id FROM applications
+            WHERE worker_id = auth.uid()
+               OR job_id IN (SELECT id FROM jobs WHERE company_id = auth.uid())
+        )
+    );


### PR DESCRIPTION
## O que foi implementado

Migration SQL que adiciona policy de UPDATE para tabela Conversation, seguindo mesmo pattern de participação.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `supabase/migrations/20260317012800_conversation_update_policy.sql` | Criado | Policy UPDATE para participantes |

Refs #141