### PR TITLE
AUDIT-10-T1: Adicionar security headers (X-Frame-Options, HSTS)

### DIFF
--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -1,0 +1,5 @@
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Strict-Transport-Security: max-age=63072000; includeSubDomains


### PR DESCRIPTION
## O que foi implementado

Cria arquivo _headers com security headers padrão para Netlify.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| `frontend/public/_headers` | Criado | Security headers: X-Frame-Options, nosniff, Referrer-Policy, HSTS |

Refs #143