### PR TITLE
AUDIT-05-T1: Corrigir testes falhando com ToastProvider mock

### DIFF
--- a/frontend/src/components/ProtectedRoute.onboarding.test.tsx
+++ b/frontend/src/components/ProtectedRoute.onboarding.test.tsx
@@ -22,6 +22,14 @@ vi.mock('../lib/logger', () => ({
     logError: vi.fn(),
 }))
 
+// Mock ToastContext
+vi.mock('../contexts/ToastContext', () => ({
+    useToast: () => ({
+        addToast: vi.fn(),
+        removeToast: vi.fn(),
+    }),
+}))
+
 import ProtectedRoute from './ProtectedRoute'
 
 function renderRoute(path = '/dashboard') {

--- a/frontend/src/components/__tests__/ProtectedRoute.test.tsx
+++ b/frontend/src/components/__tests__/ProtectedRoute.test.tsx
@@ -35,6 +35,13 @@ vi.mock('../../lib/logger', () => ({
   logError: vi.fn(),
 }))
 
+vi.mock('../../contexts/ToastContext', () => ({
+  useToast: () => ({
+    addToast: vi.fn(),
+    removeToast: vi.fn(),
+  }),
+}))
+
 describe('ProtectedRoute', () => {
   beforeEach(() => {
     vi.clearAllMocks()


### PR DESCRIPTION
## O que foi implementado

Adiciona mock de ToastContext nos 2 arquivos de teste do ProtectedRoute que faltavam. Corrige 4 falhas de ToastProvider.

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| \`frontend/src/components/__tests__/ProtectedRoute.test.tsx\` | Modificado | Mock de useToast |
| \`frontend/src/components/ProtectedRoute.onboarding.test.tsx\` | Modificado | Mock de useToast |

Refs #138

Nota: 4 testes restantes falham por razões pré-existentes não relacionadas ao ToastProvider.