### PR TITLE
AUDIT-13-T1: Adicionar og:image para preview social

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,6 +11,9 @@
     <meta property="og:description" content="Conecte-se a freelancers ou encontre oportunidades de trabalho." />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="pt_BR" />
+    <meta property="og:image" content="/og-image.svg" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/og-image.svg
+++ b/frontend/public/og-image.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <rect width="1200" height="630" fill="#F4F4F0"/>
+  <rect x="40" y="40" width="1120" height="550" rx="24" fill="white" stroke="black" stroke-width="4"/>
+  <rect x="48" y="48" width="1120" height="550" rx="24" fill="#00A651" opacity="0.1"/>
+  <text x="600" y="250" text-anchor="middle" font-family="Arial, sans-serif" font-size="72" font-weight="900" fill="#000" letter-spacing="-2">WORKI</text>
+  <text x="600" y="330" text-anchor="middle" font-family="Arial, sans-serif" font-size="32" font-weight="700" fill="#666">Marketplace de Freelancers</text>
+  <rect x="400" y="380" width="160" height="50" rx="12" fill="#00A651" stroke="black" stroke-width="3"/>
+  <text x="480" y="412" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" font-weight="800" fill="white">TRABALHAR</text>
+  <rect x="640" y="380" width="160" height="50" rx="12" fill="#2563EB" stroke="black" stroke-width="3"/>
+  <text x="720" y="412" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" font-weight="800" fill="white">CONTRATAR</text>
+  <text x="600" y="500" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" fill="#999">Conecte-se a freelancers ou encontre oportunidades</text>
+</svg>

--- a/frontend/src/components/PageMeta.tsx
+++ b/frontend/src/components/PageMeta.tsx
@@ -3,9 +3,10 @@ interface PageMetaProps {
   description?: string;
   ogTitle?: string;
   ogDescription?: string;
+  ogImage?: string;
 }
 
-export default function PageMeta({ title, description, ogTitle, ogDescription }: PageMetaProps) {
+export default function PageMeta({ title, description, ogTitle, ogDescription, ogImage }: PageMetaProps) {
   const fullTitle = title.includes('Worki') ? title : `${title} — Worki`
   return (
     <>
@@ -13,6 +14,7 @@ export default function PageMeta({ title, description, ogTitle, ogDescription }:
       {description && <meta name="description" content={description} />}
       {ogTitle && <meta property="og:title" content={ogTitle} />}
       {ogDescription && <meta property="og:description" content={ogDescription} />}
+      {ogImage && <meta property="og:image" content={ogImage} />}
     </>
   )
 }


### PR DESCRIPTION
## O que foi implementado

Adiciona imagem OG placeholder e meta tags para preview em compartilhamentos sociais (WhatsApp, LinkedIn, etc).

## Arquivos alterados

| Arquivo | Tipo | O que faz |
|---------|------|-----------|
| \`frontend/public/og-image.svg\` | Criado | Imagem OG placeholder 1200x630 |
| \`frontend/index.html\` | Modificado | Meta tags og:image |
| \`frontend/src/components/PageMeta.tsx\` | Modificado | Prop ogImage para override |

Refs #148