### PR TITLE
Piloto empresa-primeiro: pagamento opcional (modo A) + BI + Elenco/Carteira + convites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,7 @@ jobs:
 
       - name: Testes unitarios
         run: cd frontend && npm test
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,3 @@ jobs:
 
       - name: Testes unitarios
         run: cd frontend && npm test
-        env:
-          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
-          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
-          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}

--- a/.harness/memory-bank/architecture.md
+++ b/.harness/memory-bank/architecture.md
@@ -47,7 +47,7 @@ Browser (SPA React 19)
 | `pages/`, `pages/company/`, `pages/worker/` | Telas de rota por papel. Lógica de tela + fetch direto. |
 | `components/` | UI reutilizável cross-papel (cards, modais, navegação, guards). |
 | `contexts/` | Estado global de sessão, notificações, toasts. |
-| `services/` | Lógica de negócio não-UI: `walletService` (escrow prepago/postpago, ramificação por `kind`), `paymentMethodService` (tokenize, capture, release-hold de cartão), `teamConnectionService` (equipe/relações), `shiftInviteService` (convites push), `analytics`, `api` (edge functions). |
+| `services/` | Lógica de negócio não-UI: `walletService` (escrow prepago/postpago, ramificação por `kind`), `paymentMethodService` (tokenize, capture, release-hold de cartão), `paymentRecordService` (modo A — registro de pagamento externo, sem mover saldo), `teamConnectionService` (equipe/relações), `shiftInviteService` (convites push), `financialBIService` (BI unificado: escrow + shift_payments), `spendLimitService` (teto de gasto + alerta), `analytics`, `api` (edge functions). |
 | `lib/` | Config e utilitários: `supabase` (client), `gamification`, `validation`, `logger`. |
 | `types/` | Contrato de tipos do domínio (à mão — fonte da verdade). |
 | `supabase/functions/` | Operações privilegiadas (Asaas, admin, notificações) — Deno + service_role. |
@@ -121,6 +121,9 @@ Cancelamento/no-show ──→ asaas-release-hold ──→ release_hold_postpag
 
 - **`payment_methods`** (nova tabela): `(id, company_id, asaas_credit_card_token, brand, last4, is_default, created_at)`.
   RLS por `company_id`. NUNCA carrega PAN/CVV (Article 10).
+- **`shift_payments`** (modo A — pagamento externo registrado): `(id, job_id, worker_id, company_id, application_id, amount, source, paid_at, status, recorded_by_company_at, confirmed_by_worker_at, note, created_at)`.
+  UNIQUE parcial `(job_id)` WHERE `status='recorded'` — garante 1 registro pago por turno.
+  RLS bilateral: empresa vê seu registro, worker vê seu recibo. **NUNCA toca saldo** (auditoria, não liquidação).
 - **`escrow_transactions`** (estendida):
   - `kind`: `'prepaid'` (default) | `'postpaid'`
   - `status`: `'reserved' | 'authorized' | 'captured' | 'released' | 'refunded'`
@@ -179,16 +182,16 @@ Empresa acessa BI sobre gasto mensal, horas por freela, ratio de custo, no-show 
 6. Notificação chega em tempo real via Realtime (NotificationContext).
 7. WhatsApp = Slice 4 (pendente).
 
-**BI (Business Intelligence) — derivado de escrow_transactions, sem views:**
-- **BI-1: Gasto acumulado** — SUM(amount) WHERE status IN ('released','captured') no período (COALESCE(captured_at, released_at, created_at)).
-- **BI-2: Gasto + horas por freela** — agrupado por worker_id. Horas reais se checkout_at/checkin_at existem; fallback jobs.estimated_hours.
+**BI (Business Intelligence) — unificado: escrow + shift_payments, sem views:**
+- **BI-1: Gasto acumulado** — UNION de (escrow released/captured) + (shift_payments recorded), dedupe por job_id (escrow precede).
+- **BI-2: Gasto + horas por freela** — agrupado por worker_id, fonte unificada. Horas reais se checkout_at/checkin_at existem; fallback jobs.estimated_hours.
 - **BI-3: Ratio custo/hora + custo-%-faturamento** — custo/horas; custo/faturamento declarado (null se não informado).
-- **BI-4: Custo de no-show estimado** — heurística v1, rotulado como estimativa (application com status='hired'/invitation_response='accepted', turno passou, sem checkout).
+- **BI-4: Custo de no-show estimado** — heurística v1, rotulado como estimativa (application com status='hired'/invitation_response='accepted', turno passou, sem checkout e sem registro de pagamento).
 - **BI-5: Flag de concentração de horas/dias** — worker flagged se >= 150h AND >= 20 dias (constantes de produto em service, não DB). Sinaliza risco de vínculo trabalhista.
 
 **Services:**
-- **`spendLimitService`** — CRUD de teto + revenue, `evaluateSpendAlert(companyId, now?)` idempotente (fora da RPC, best-effort).
-- **`financialBIService`** — 4 queries paralelas (getAccumulatedSpend, getSpendByWorker, getCostRatio, getNoShowCost, getConcentrationFlags), método `getAllBI` reutiliza para evitar dupla execução. Sem React Query (Article 5).
+- **`financialBIService`** — queries paralelas (getAccumulatedSpend, getSpendByWorker, getCostRatio, getNoShowCost, getConcentrationFlags), método `getAllBI` reutiliza. Unifica escrow + shift_payments. Sem React Query (Article 5).
+- **`spendLimitService`** — CRUD de teto + revenue, `evaluateSpendAlert(companyId, now?)` idempotente (fora da RPC, best-effort). Delega a `financialBIService` para gasto unificado. Alerta dispara após qualquer registro de gasto (captura/liberação OU shift_payment).
 
 **UI:**
 - Nova página `pages/company/CompanyFinancial` (`/company/financeiro`) com cards de BI, alertas, input de faturamento, config de teto.

--- a/.harness/memory-bank/architecture.md
+++ b/.harness/memory-bank/architecture.md
@@ -83,6 +83,15 @@ push é o **Slice 2: postpago** (cartão on-file + captura na conclusão, sem de
 
 ## Modelo de pagamento (carteira central + escrow + postpago Slice 2)
 
+> ⚠️ **REVISADO por ADR-20260630-pagamento-opcional-piloto (2026-06-30).** No piloto o pagamento pelo Worki é
+> **OPCIONAL**. Três modos coexistem: **(A) pagamento externo registrado** — default do piloto, Worki registra
+> PIX/dinheiro fora + recibo, **sem mover saldo** (novo marcador de pagamento por turno, fora de
+> `escrow_transactions`); **(B) PIX-único → distribuição** — conveniência opt-in, 1 PIX da empresa distribuído
+> a N freelas via RPC atômica idempotente; **(C) postpago cartão on-file** — o fluxo descrito abaixo, agora
+> **opt-in / semente da expansão**, não o trilho padrão. Article 8/9 seguem valendo para B/C (todo movimento
+> de saldo por RPC atômica). O modo A não toca saldo. O BI de gasto passa a unir escrow (B/C) + marcador (A).
+> Diagramas abaixo = caminho postpago histórico, preservado.
+
 ### Fluxo prepago (Slice 1 — pull legado; intacto)
 
 ```
@@ -212,3 +221,6 @@ Empresa acessa BI sobre gasto mensal, horas por freela, ratio de custo, no-show 
 - Mover lógica privilegiada do Edge Function para o frontend.
 - Trocar o modelo de isolamento de papel (worker/company).
 - Mudar a direção postpago (Slice 1) para prepago — Slice 2 trata dessa migração.
+- Tornar o pagamento pelo Worki **obrigatório** de novo (reabrir postpago/hold como default), criar o marcador
+  de pagamento externo, ou a RPC de distribuição PIX-único — ver ADR-20260630 (pagamento opcional no piloto)
+  e seus gatilhos de reabertura.

--- a/.harness/memory-bank/decisions/ADR-20260630-pagamento-opcional-piloto.md
+++ b/.harness/memory-bank/decisions/ADR-20260630-pagamento-opcional-piloto.md
@@ -1,0 +1,195 @@
+# ADR-20260630 — Pagamento pelo Worki é OPCIONAL no piloto (controle+dado > trilho financeiro)
+
+## Status
+ACEITO — 2026-06-30 (architect, gate de contrato de pagamento). Formaliza decisão do owner (jun/2026).
+**SUPERA parcialmente** o `ADR-20260622-pagamento-postpago.md` (postpago/hold obrigatório via cartão) e os
+requisitos R4/R7/R9 do spec, que passam de **obrigatórios** a **opção de conveniência**. NÃO revoga o
+postpago: ele fica preservado como caminho opt-in e como base da fase de expansão (reabrível por gate).
+Toca **ponto sensível** (`architecture.md` "Pontos sensíveis" + constitution Art. 8/9) — por isso este ADR.
+
+> **Escopo desta etapa:** só ADR + revisão de docs (spec/architecture). NENHUM código de saldo/escrow,
+> migration ou RPC muda aqui. Trabalho de implementação decorrente fica listado como subsequente, com gate.
+
+## Contexto
+
+O `ADR-20260622-pagamento-postpago` estabeleceu o piloto como **postpago obrigatório (modelo Uber)**: a
+empresa cadastra cartão on-file (R4), o aceite do convite dispara pré-autorização/hold (R7), e a conclusão
+captura o cartão e paga o freela (R9). O pagamento pelo Worki era **pré-requisito** do fluxo push.
+
+O owner revisou o modelo (jun/2026, memória `mvp-model-revised-2026-06.md` + tese seção "Postura de
+pagamento no piloto"). A tese amadureceu: o **wedge do dia 1 é controle + dado** (histórico, recibo,
+avaliação, fechar a vaga pelo app, dono da relação), **não o trilho financeiro**. A régua-mestra do piloto
+é *menos fricção que WhatsApp+PIX*; exigir cartão on-file e cobrança obrigatória adiciona fricção e um
+gate de adoção (cadastro de cartão) antes de a empresa sentir o valor. Take permanece **0**.
+
+A operação real (MOMMA e similares) já paga o freela direto — por PIX/dinheiro, na hora ou no fim do mês.
+Forçar esse dinheiro a passar pelo Worki no dia 1 não fortalece o cavalo (entrada) nem a carga (moat de
+reputação); só cria atrito. O que fortalece a carga é o **registro** de que o trabalho aconteceu e foi pago
+— independente de por onde o dinheiro passou.
+
+## Decisão
+
+### 1. Pagamento pelo Worki é OPCIONAL, com três modos coexistentes
+
+O ciclo de contratação (convite → aceite → check-in/checkout → confirmação → avaliação) **fecha pelo Worki
+sempre**. O **pagamento** tem três modos, escolhidos por turno/período:
+
+| Modo | Movimenta saldo no Worki? | Take | Substrato |
+|---|---|---|---|
+| **A. Pagamento externo (default do piloto)** | **NÃO** | 0 | Worki só **registra** que houve pagamento fora (PIX/dinheiro) e emite recibo. Nenhuma RPC de saldo. |
+| **B. PIX-único → distribuição (opt-in, conveniência)** | **SIM** | 0 | Empresa faz **1 PIX ao Worki**; o Worki **distribui automaticamente** aos freelas do período via RPC atômica idempotente. |
+| **C. Postpago cartão on-file (opt-in / futuro)** | **SIM** | 0 | O fluxo do `ADR-20260622` — cartão on-file + hold/captura. Preservado como opção; **não é o default**. |
+
+O **default do piloto é o modo A** (pagamento externo registrado). B é a conveniência quando há muitas
+contas/muitos freelas. C deixa de ser o trilho padrão e vira opt-in / semente da fase de expansão.
+
+### 2. "Registrar pagamento externo" (modo A) — registro sem movimento de saldo
+
+Quando o pagamento é direto, o Worki grava um **marcador de pagamento por turno** (fonte da verdade do
+gasto, independente do escrow) e **emite recibo**. Este marcador:
+- **NÃO** cria linha em `escrow_transactions`, **NÃO** chama nenhuma RPC de saldo, **NÃO** toca `wallets`.
+- Carrega: turno (`job_id`), freela, valor pago, quando, e o **método declarado** (`external_pix` |
+  `cash` | `other`) + quem confirmou (empresa e/ou freela).
+- É o insumo do BI de gasto quando o dinheiro não passou pelo Worki (ver seção "Impacto no BI").
+- É **auditoria**, não dinheiro: sem `ON DELETE CASCADE` a partir de tabela financeira; imutável após
+  confirmação (correção via novo registro/estorno lógico, não UPDATE destrutivo).
+
+> **Direção arquitetural, não schema final:** o marcador será uma **tabela nova** (ex.: `shift_payments` ou
+> `payment_records`) com RLS por empresa e por freela (ambos os lados veem o próprio registro), `job_id`
+> único por turno pago, e um `status`/`source` que discrimina external vs. worki-rail. O schema exato,
+> constraints e RLS são **trabalho subsequente com gate architect** (ver "Trabalho subsequente").
+
+### 3. "Pagar via Worki" (modos B e C) — continua 100% sob Article 8/9
+
+Qualquer centavo que **entre ou se mova dentro do Worki** segue as regras duras, sem exceção:
+- **PIX-único → distribuição (B):** o crédito do PIX da empresa e cada repasse ao freela passam por **RPC
+  Postgres atômica** (`SECURITY DEFINER`, `SET search_path=''`, `GRANT EXECUTE ... TO service_role,
+  authenticated`). A distribuição a N freelas é **um lote idempotente**: cada repasse tem `reference_id`
+  estável (ex.: `payout_batch_id:worker_id` ou `period:worker_id`), respeitando UNIQUE
+  `(wallet_id, reference_id)` — reprocessar o lote nunca paga em dobro (Article 9). Saldo nunca negativo.
+- **Postpago (C):** inalterado — as RPCs `authorize_escrow_postpago`/`capture_escrow_postpago`/
+  `release_hold_postpago` do `ADR-20260622` seguem válidas para quem opta pelo cartão on-file.
+- O **modo A não toca nada disso** — é a fronteira: registro ≠ movimento de saldo.
+
+### 4. R4/R7/R9 deixam de ser obrigatórios; a máquina de estados perde o acoplamento a pagamento
+
+O aceite do convite (R7) e a conclusão (R9) **não disparam mais cobrança obrigatoriamente**. O ciclo
+avança por **confirmação da relação** (aceite, check-in/checkout, confirmação da empresa, avaliação);
+o pagamento é um passo **paralelo e opcional** que anexa um registro (modo A) ou dispara uma RPC (B/C).
+A confirmação de conclusão **não depende** de captura de cartão bem-sucedida.
+
+## Consequências
+
+### Positivas
+- **Menos fricção de adoção:** empresa entra e roda o loop sem cadastrar cartão nem depositar. Alinha com a
+  régua-mestra ("menos trabalho que zap+PIX") e com a métrica polar (turnos que passam pelo Worki).
+- **Wedge correto no dia 1:** o valor entregue é controle + dado (recibo/histórico/avaliação), que é o moat.
+- **Article 6/7/8/9/10 intactos:** nada de novo gateway, nada de subconta, e todo movimento de saldo real
+  (B/C) continua por RPC atômica idempotente. O modo A simplesmente **não move saldo**.
+- **Postpago preservado, não jogado fora:** o investimento do Slice 2 vira opção/semente da fase de
+  expansão, reabrível sem retrabalho.
+
+### Negativas / Trade-offs
+- **Fonte da verdade do gasto se bifurca:** BI de gasto não pode mais assumir `escrow_transactions` como
+  única fonte (ver "Impacto no BI"). Precisa unir escrow (B/C) + marcador de pagamento externo (A). Mais
+  superfície de query e risco de dupla contagem se um turno for registrado nas duas fontes — mitigado por
+  `job_id` único como pagamento e por rótulo de fonte.
+- **Registro externo é auto-declarado:** o valor "pago fora" é o que a empresa (e idealmente o freela)
+  declara — o Worki não tem prova bancária no modo A. Aceitável no piloto embedded/confiável; é dado de
+  controle, não liquidação garantida. A confirmação bilateral (empresa declara + freela confirma) reduz
+  divergência.
+- **Reversibilidade difícil:** muda contrato de pagamento em doc de produto e cria uma nova fonte de verdade
+  financeira (marcador) — por isso este ADR. Reabrir o postpago obrigatório é decisão consciente (gate).
+- **Recibo em dois regimes:** recibo de pagamento externo (declaratório) vs. recibo de pagamento pelo Worki
+  (com trilha Asaas) têm garantias diferentes; a UI/documento deve deixar claro qual é qual.
+
+## Impacto nos requisitos e contratos
+
+| Item | Antes (postpago obrigatório) | Depois (este ADR) |
+|---|---|---|
+| **R3.5 check-in/checkout** | Passo do ciclo; insumo de horas reais p/ BI | **Inalterado como ciclo.** Ganha peso: com pagamento fora do Worki, check-in/checkout + confirmação viram a **evidência primária** de que o turno aconteceu (base do registro e do recibo), já que não há mais captura de cartão como prova. |
+| **R4 (cartão on-file obrigatório)** | Pré-requisito: empresa cadastra cartão 1x | **Vira opt-in (modo C).** Não é gate de adoção. Default do piloto não pede cartão. |
+| **R7 (reserva/hold no aceite)** | Aceite → hold no cartão obrigatório | **Deixa de ser obrigatório.** Aceite confirma a relação e a agenda; hold só no modo C. Recusa continua neutra. |
+| **R9 (captura na conclusão)** | Conclusão → captura obrigatória do cartão | **Vira opcional.** Conclusão confirma o turno e habilita o **registro de pagamento** (modo A) OU a captura/distribuição (C/B). Auto-processamento de captura só se aplica ao modo C. |
+| **Modelo de pagamento (spec/arch)** | Postpago é o trilho | **Três modos coexistentes** (A default, B/C opt-in). Postpago = evolução da expansão. |
+| **Contrato BI de gasto (BI-1..BI-5)** | Gasto = `escrow_transactions.status IN ('released','captured')` | **Fonte da verdade se amplia** (ver abaixo). Escrow deixa de ser a única fonte. |
+
+### Impacto no BI de gasto (BI-1..BI-5) — a mudança de contrato mais crítica
+
+O rodapé do spec define gasto como `escrow_transactions` com `status IN ('released','captured')`. **No modo
+A (default do piloto) NÃO existe linha de escrow** — logo o BI enxergaria gasto **zero** para turnos pagos
+fora, o que é falso e quebra R12/R13/R14/R15.
+
+**Direção arquitetural (sem projetar schema final):**
+- A **fonte da verdade do gasto passa a ser a UNIÃO de duas fontes**, discriminadas por rótulo:
+  1. **Trilho Worki (B/C):** `escrow_transactions` com `status IN ('released','captured')` — como hoje.
+  2. **Pagamento externo (A):** o novo **marcador de pagamento por turno** (valor pago + data + `source`
+     external). Carimbo de período = a data do pagamento declarado (fallback data de conclusão do turno).
+- **Anti-dupla-contagem:** `job_id` é a chave de dedupe — um turno é pago por **exatamente uma** fonte
+  (external OU worki-rail). O BI soma escrow + marcador com `job_id` disjuntos; se ambos existirem para o
+  mesmo turno (anomalia), o marcador worki-rail (escrow) tem precedência e o external é ignorado na soma.
+- **BI-1 (gasto acumulado):** `SUM(escrow released/captured)` + `SUM(marcador external do período)`.
+- **BI-2 (gasto+horas por freela):** idem, agrupado por freela; horas continuam de check-in/checkout
+  (real) ou `estimated_hours` (fallback) — **inalterado**, e ganha relevância (única evidência de esforço
+  no modo A).
+- **BI-3 (ratio custo/hora, custo-%-faturamento):** numerador passa a ser o gasto unificado; denominador
+  inalterado.
+- **BI-4 (custo de no-show):** inalterado na heurística; note que no modo A não há hold a liberar, então
+  no-show = turno aceito sem checkout **e sem registro de pagamento**.
+- **BI-5 (concentração→vínculo):** inalterado (deriva de horas/dias, não de pagamento).
+- **Alerta de teto (R12):** o gatilho de avaliação deixa de ser só "após captura/liberação de escrow" —
+  passa a ser **após qualquer registro de gasto** (captura/liberação OU marcador de pagamento externo
+  confirmado), mantendo a idempotência por `link` já especificada. O gasto acumulado usa a fonte unificada.
+
+> Estes ajustes de BI são **contrato para o builder do slice financeiro**, não implementação aqui. Enquanto
+> o marcador não existir, o BI reflete **apenas o trilho Worki** (documentar como limitação conhecida).
+
+## Alternativas consideradas
+
+- **Manter postpago obrigatório (status quo do ADR-20260622):** rejeitada pelo owner — adiciona fricção de
+  cadastro de cartão antes do valor, contra a régua-mestra do piloto; o calote é ~inexistente no embedded,
+  então a garantia upfront paga pouco e cobra caro em adoção.
+- **Registrar pagamento externo dentro de `escrow_transactions` (linha `external`/`paid`, sem tocar saldo):**
+  rejeitada — polui a tabela financeira com linhas que não representam movimento de saldo, arrisca as RPCs e
+  o CHECK de status/o índice "um ativo por job", e confunde auditoria (o que é dinheiro do Worki vs. o que é
+  só registro). Separar em marcador próprio mantém `escrow_transactions` = movimento real de saldo.
+- **Abolir o postpago e o escrow do piloto de vez:** rejeitada — jogaria fora o Slice 2 e o trilho que a
+  fase de expansão vai precisar; a decisão é tornar **opcional**, não remover.
+- **Pagamento sempre pelo Worki, mas take 0 (sem modo externo):** rejeitada — ainda força cadastro de
+  método/depósito, mantendo a fricção que o owner quer eliminar no dia 1.
+
+## Reversibilidade / gatilho de reabrir o postpago obrigatório
+
+Esta decisão é **reversível por nova decisão consciente**, não por deriva. Reabrir o **postpago (modo C)
+como obrigatório** — ou mudar a distribuição/marcador — exige **gate `harness-architect` + novo ADR**, e
+dispara quando qualquer um destes sinais aparecer no piloto/expansão:
+1. **Calote/atraso material** no pagamento externo (freela reclama que não recebeu / empresa some) — sinal
+   de que a garantia upfront (hold) volta a pagar sua fricção.
+2. **Expansão para além de relações confiáveis** (empresa #2/#3 não-embedded, marketplace semi-aberto) —
+   quando o pressuposto "todos se conhecem, calote ~zero" deixa de valer.
+3. **Monetização entra** (take rate > 0 / cartão-parcela como receita) — exige que o dinheiro passe pelo
+   trilho para cobrar/floatar.
+Até um desses disparar, o default é o modo A (externo registrado), com B/C opt-in. Article 6 (Asaas-only) e
+Article 7 (carteira central) permanecem válidos para B/C.
+
+## Trabalho subsequente (com gate — NÃO implementado aqui)
+
+1. **Migration do marcador de pagamento** (tabela nova, ex.: `shift_payments`): RLS por empresa+freela,
+   `job_id` único, `source`/`status`, `amount`, `paid_at`, confirmadores. **Sem** `ON DELETE CASCADE` de
+   tabela financeira; imutável pós-confirmação. → **gate architect** (é auditoria financeira, mesmo sem
+   mover saldo) antes do builder.
+2. **RPC de distribuição PIX-único (modo B):** crédito do PIX (reuso de `credit_deposit`) + lote de repasses
+   idempotentes por `reference_id` estável. → **gate architect** (Article 8/9) — provavelmente ADR próprio.
+3. **Contrato de BI unificado** (escrow ∪ marcador) e ajuste do gatilho de alerta de teto. → contrato no
+   spec do slice financeiro; builder implementa no `FinancialBIService`.
+4. **UI de "registrar pagamento" + recibo** (modo A) e toggle de modo de pagamento por turno/período. →
+   frontend-builder, sob design neo-brutalista.
+
+## Referências
+- Owner (jun/2026): `~/.claude/.../memory/mvp-model-revised-2026-06.md` (item 1 e 5).
+- Tese: `.harness/thesis.md` — seção "Postura de pagamento no piloto (revisado jun/2026 — owner)".
+- Spec revisado: `.harness/spec/v1-operacao-freelancer/spec.md` (R4, R7, R9, workflow, rodapé de BI).
+- ADR superado parcialmente: `.harness/memory-bank/decisions/ADR-20260622-pagamento-postpago.md`.
+- Architecture: `.harness/memory-bank/architecture.md` — "Modelo de pagamento" e "Pontos sensíveis".
+- Constitution: Art. 6 (Asaas-only), 7 (carteira central), 8 (saldo só por RPC + GRANT), 9 (idempotência),
+  10 (service_role só em Edge Function).

--- a/.harness/memory-bank/glossary.md
+++ b/.harness/memory-bank/glossary.md
@@ -136,3 +136,21 @@ Limiares são constantes de produto no service, não no DB (CONCENTRATION_HOURS_
 **Idempotência de alerta (Slice 3)** — Alerta de teto usa link estável `/company/financeiro?alert=<companyId>:<YYYYMM>:<threshold>`
 como chave de idempotência. SELECT-before-INSERT verifica se já existe notificação com este link no user_id (company owner).
 Se existe, skip; caso contrário, insere. Protege contra duplicação se avaliação roda multiplas vezes no período.
+
+**Modo A / Pagamento externo registrado (Slice 3)** — Default do piloto (ADR-20260630). Empresa paga worker direto
+(PIX/dinheiro, fora do Worki); o Worki registra o pagamento em `shift_payments` (marcador de auditoria, SEM mover saldo).
+Confirmação bilateral: empresa declara → worker confirma no recibo (`ReceiptView`). **Nunca toca `wallets` ou `escrow_transactions`.**
+
+**Modo B / PIX-único → distribuição (Slice 3 futuro)** — Opt-in de conveniência. Empresa faz 1 PIX ao Worki; o Worki
+distribui automaticamente a N freelancers via RPC atômica idempotente. Entra saldo em `wallets`; cada repasse tem
+`reference_id` estável para idempotência.
+
+**Modo C / Postpago cartão on-file (Slice 2 — agora opt-in)** — Fluxo original do `ADR-20260622`. Empresa cadastra cartão;
+no aceite de convite, hold no cartão; na conclusão, captura. Reservado para expansão além de relações confiáveis.
+
+**Recibo / Receipt** — Documento gerado após registro de pagamento externo (modo A). Página `ReceiptView` (`/recibo/:jobId`)
+exibe detalhes do turno, valor, método (PIX/dinheiro/outro), confirmação bilateral, para auditoria/arquivo.
+
+**Shift payment / Marcador de pagamento** — Registro em `shift_payments` indicando que um turno foi pago fora do Worki
+(modo A). Tabela: `(id, job_id, worker_id, company_id, application_id, amount, source, paid_at, status, recorded_by_company_at,
+confirmed_by_worker_at, note)`. UNIQUE `(job_id)` WHERE `status='recorded'` garante 1 pagamento por turno. NUNCA move saldo.

--- a/.harness/memory-bank/product.md
+++ b/.harness/memory-bank/product.md
@@ -4,8 +4,9 @@
 
 **Worki** é um marketplace de trabalho freelance/diária para o mercado brasileiro. Conecta dois lados:
 **empresas** que publicam vagas/turnos e **trabalhadores** (workers) que se candidatam, executam e
-recebem. O dinheiro circula por uma **carteira central Asaas** com modelo de **escrow** (garantia):
-a empresa deposita, o valor fica reservado, e é liberado ao trabalhador quando o trabalho é confirmado.
+recebem. O dinheiro pode circular por uma **carteira central Asaas** (opcional) com modelo de **escrow**
+(Slice 2, opt-in), ou ser registrado como **pagamento externo** (Slice 3, default do piloto): empresa
+paga direto (PIX/dinheiro) e o Worki emite recibo para auditoria/histórico, sem mover saldo.
 
 SPA React 19 + Supabase (PostgreSQL + RLS + Auth + Edge Functions Deno) + Asaas (pagamentos PIX/Boleto/Cartão).
 Mono-produto, multi-papel: a mesma base serve workers e empresas, com isolamento de papel reforçado
@@ -26,11 +27,13 @@ no roteamento (`ProtectedRoute`) e no banco (RLS).
 1. **Descoberta & candidatura** — Feed de vagas (`Jobs`, `JobCard`), match score, candidatura
    (`useJobApplication`), acompanhamento (`MyJobs`).
 2. **Ciclo de vida da vaga** — Empresa cria vaga (`CompanyCreateJob`), recebe candidatos
-   (`CompanyJobCandidates`), contrata → **escrow reservado**; turno acontece (check-in do worker,
-   checkout confirmado pela empresa) → **escrow liberado**; avaliação mútua (`RateModal`).
-3. **Carteira & pagamentos (Asaas, escrow)** — Depósito da empresa (`DepositModal` → `asaas-deposit`),
-   reserva/liberação/estorno de escrow (atômico no DB via `walletService`), saque do worker
-   (`asaas-withdraw`), reconciliação via webhook (`asaas-webhook`).
+   (`CompanyJobCandidates`), contrata; turno acontece (check-in do worker, checkout confirmado pela empresa);
+   **pagamento** (modo A default: registro de pagamento externo via `paymentRecordService` + recibo `ReceiptView`;
+   modo B/C opt-in: escrow/cartão); avaliação mútua (`RateModal`).
+3. **Carteira & pagamentos (modo A — pagamento externo default)** — Empresa registra pagamento PIX/dinheiro
+   (`CompanyJobCandidates` → modal "Registrar Pagamento"), worker confirma recibo (`ReceiptView` → `/recibo/:jobId`).
+   **Modo B/C (opt-in):** Depósito da empresa (`DepositModal` → `asaas-deposit`), reserva/liberação/estorno de
+   escrow (atômico no DB via `walletService`), saque do worker (`asaas-withdraw`), reconciliação via webhook (`asaas-webhook`).
 4. **Mensageria & notificações** — Chat worker↔empresa (`Messages`/`CompanyMessages`), notificações em
    tempo real (`NotificationContext`, Supabase Realtime), centro de notificações (`Notifications`).
 5. **Onboarding & confiança** — Onboarding separado por papel (`WorkerOnboarding`/`CompanyOnboarding`),
@@ -39,18 +42,17 @@ no roteamento (`ProtectedRoute`) e no banco (RLS).
 ## Anti-vision
 
 - NÃO é rede social (sem feed de posts, curtidas, seguidores).
-- NÃO é folha de pagamento/CLT — é trabalho por diária/freela com pagamento por escrow.
-- NÃO usa subcontas Asaas — **uma carteira central** detém os fundos; saldo por usuário vive no DB.
+- NÃO é folha de pagamento/CLT — é trabalho por diária/freela com pagamento por escrow ou registro de pagamento externo.
+- NÃO usa subcontas Asaas — **uma carteira central** detém os fundos (quando dinheiro passa pelo Worki); saldo por usuário vive no DB.
 - NÃO expõe `service_role` no frontend — toda operação privilegiada passa por Edge Function.
 - NÃO é multi-gateway — **Asaas é o único** provedor de pagamento (Stripe foi 100% removido).
-- NÃO replica fluxos manuais de pagamento — escrow e auditoria são parte do produto, não opcionais.
+- Modo A (pagamento externo registrado, default piloto) não move saldo — é auditoria/recibo. Escrow (modo B/C) é caminho opt-in.
 
 ## Direção atual (MVP — 2026)
 
-Foco em **lançar o MVP com fluxo de pagamento confiável**:
-- Asaas-only (Stripe removido por decisão do owner).
-- Carteira central + escrow atômico (RPCs `reserve_escrow`, `release_escrow`, `refund_escrow`,
-  `credit_deposit`, `update_wallet_balance`).
+Foco em **lançar o MVP com fluxo de contrato + operação confiável**:
+- **Modo A (default piloto):** Pagamento externo registrado (PIX/dinheiro) com recibo e confirmação bilateral (`paymentRecordService`, `ReceiptView`).
+- **Modos B/C (opt-in/expansão):** Asaas carteira central + escrow atômico (RPCs) ou cartão on-file; reabríveis por gatilho de ADR-20260630.
 - Check-in/checkout que cruza a meia-noite, CORS das funções Asaas para origens locais.
 - Notificações, deploy (Vercel: `worki-opal.vercel.app`), Termos/Privacidade, SEO (`PageMeta`).
 - Qualidade: subir cobertura de testes (Vitest + Playwright E2E), limpar warnings de lint.

--- a/.harness/memory-bank/tech.md
+++ b/.harness/memory-bank/tech.md
@@ -21,6 +21,7 @@
   TanStack React Query 5.90.20 está no `package.json` e um `QueryClient` é montado em `App.tsx`, mas
   **as páginas NÃO usam `useQuery` na prática.** Seguir o padrão existente (useState/useEffect) ao
   implementar features novas, salvo decisão explícita de migrar.
+- **Services de negócio:** `walletService` (escrow), `paymentMethodService` (cartão on-file), **`paymentRecordService`** (modo A — registro de pagamento externo, sem mover saldo), `teamConnectionService` (equipe), `shiftInviteService` (convites push), `financialBIService` (BI unificado), `spendLimitService` (teto + alerta).
 - **Toda query autenticada começa com** `supabase.auth.getUser()` → redireciona para `/login` se `null`.
 - **Backend:** Supabase (PostgREST + Realtime + Auth + Storage + Edge Functions Deno)
 - **Supabase JS:** 2.91.0 — client em `frontend/src/lib/supabase.ts` (`VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`)
@@ -37,7 +38,7 @@
 - **Cores tokens:** `primary #00A651` (verde worker), `accent #111111` (preto brutalista), `border rgba(0,0,0,.1)`,
   `glass-surface`/`glass-border`
 - **Ícones:** Lucide React 0.562.0
-- **QR code:** `qrcode.react` 4.2.0 (geração de QR em `<QRCodeSVG>` para links de convite)
+- **QR code:** `qrcode.react` 4.2.0 (geração em `<QRCodeSVG>` para links de convite); **`html5-qrcode` 2.3.8** (leitura de QR/Worki ID via câmera, aba QR em team connections)
 - **Util:** `clsx` + `tailwind-merge` + `class-variance-authority`; datas via `date-fns`
 - **Fonte:** Inter (sans-serif), pesos pesados (`font-black`, `uppercase`)
 
@@ -73,6 +74,7 @@
 | `asaas-release-hold` | liberar hold (cancel/no-show) → release_hold_postpago RPC | normal |
 | `delete-account` | exclusão de conta | normal |
 | `send-notification` | enviar notificação | normal |
+| `expire-invites` | marcar convites expirados como declined (batch automático) | normal |
 
 ## Banco de dados
 

--- a/.harness/spec/v1-operacao-freelancer/plan-modo-a.md
+++ b/.harness/spec/v1-operacao-freelancer/plan-modo-a.md
@@ -1,0 +1,184 @@
+# Plano de implementação — Piloto #1: Marcador de pagamento externo (modo A) + recibo
+
+> **Fonte:** ADR-20260630-pagamento-opcional-piloto (decisão-mãe) · spec `v1-operacao-freelancer` (R9 + rodapé "Fonte da verdade do GASTO") · diagnóstico do evaluator.
+> **Autor:** harness-planner · **Data:** 2026-06-30 · **Estado:** aguardando HALT (aprovação humana).
+> **Escala estimada:** **L** (1 migration nova + tipos + service novo + UI de 2 pontos + tela de recibo; cruza empresa e freela via RLS). Não é XL: não move saldo, não tem RPC de escrow, não tem edge function.
+
+---
+
+## 1. Objetivo e escopo
+
+### Objetivo
+Permitir que a empresa, ao **confirmar a conclusão de um turno**, **registre que o pagamento foi feito por fora do Worki** (PIX/dinheiro), gerando um **marcador de pagamento por turno** (fonte da verdade do gasto no modo A) e um **recibo** consultável in-app pelos dois lados. Tudo **sem mover saldo** — é auditoria/registro, não liquidação.
+
+Este é o **default do piloto** (modo A do ADR). Substitui, no caminho externo, a captura de escrow como evidência de gasto.
+
+### Entra neste plano (in-scope)
+- Tabela nova `shift_payments` (marcador de pagamento por turno) + RLS empresa+freela + imutabilidade.
+- Tipos à mão em `types/index.ts`.
+- Service novo `paymentRecordService` (registrar, ler por turno, ler recibo).
+- UI: botão/modal **"Registrar pagamento"** pós-conclusão em `CompanyJobCandidates.tsx` (empresa).
+- **Recibo** in-app: tela renderizável a partir do marcador, acessível empresa e freela.
+- Deixar o gasto do modo A **consultável** (marcador legível por query filtrável por empresa/período/`job_id`) para o BI consumir depois.
+
+### NÃO entra (out-of-scope — explícito)
+- **BI unificado (escrow ∪ marcador)** e ajuste do gatilho de alerta de teto → **item #2** do piloto (contrato no ADR "Impacto no BI"). Aqui só garantimos que o dado existe e é consultável; **não** alteramos `financialBIService.ts`.
+- **PIX-único → distribuição (modo B)** → **item #7** (RPC atômica, ADR próprio).
+- **Postpago / cartão on-file (modo C)** → permanece opt-in, intocado.
+- **Confirmação de recebimento pelo freela como gate** — pode entrar como campo opcional (ver §4), mas o registro **não depende** dela no v1.
+- **Recibo fiscal (nota/NF-e, série fiscal)** — recibo v1 é **declaratório informal**, não documento fiscal.
+- **Edge function** — não há operação privilegiada; INSERT autenticado sob RLS basta (Article 10 satisfeito por não haver service_role).
+- **Pagamento parcial/parcelado** por turno — decisão de produto a confirmar (§4); recomendação é **1 registro por turno** no v1.
+
+---
+
+## 2. Desenho da tabela `shift_payments` — **PROPOSTA (architect valida no gate)**
+
+> Marcado como proposta. O schema final, constraints e RLS são responsabilidade do **harness-architect** no gate. Segue o padrão de identidade já consolidado no projeto: `companies.id = companies.owner_id = auth.uid() = jobs.company_id = wallets.user_id`; freela = `applications.worker_id = auth.uid()`.
+
+| Coluna | Tipo | Constraint / nota |
+|---|---|---|
+| `id` | `uuid` | PK, `DEFAULT gen_random_uuid()` |
+| `job_id` | `uuid` | **`NOT NULL REFERENCES jobs(id)`** `ON DELETE RESTRICT` `[architect ajustou: RESTRICT explícito — auditoria não some em cascata com o turno]`. **UNIQUE PARCIAL** `WHERE status='recorded'` (não UNIQUE simples — permite re-registrar após void; ver §Idempotência). |
+| `company_id` | `uuid` | `NOT NULL REFERENCES companies(id)` `ON DELETE RESTRICT` `[architect ajustou: RESTRICT]`. Dono do registro; base do RLS empresa. |
+| `worker_id` | `uuid` | `NOT NULL REFERENCES workers(id)` `ON DELETE RESTRICT` `[architect ajustou: ganha FK → workers(id) p/ integridade referencial + proteção de auditoria; o plano listava só jobs/applications/companies]`. Freela pago; base do RLS worker (`= auth.uid()`). |
+| `application_id` | `uuid` | `REFERENCES applications(id)` `ON DELETE SET NULL` (nullable) `[architect ajustou: SET NULL — preserva o recibo se a candidatura sumir]`. Liga ao ciclo/turno específico p/ evidência. |
+| `source` | `text` | `NOT NULL CHECK (source IN ('external_pix','cash','other'))`. Método **declarado** (não prova bancária). |
+| `amount` | `numeric(12,2)` | `NOT NULL CHECK (amount > 0)`. Valor declarado pago. |
+| `paid_at` | `timestamptz` | `NOT NULL`. Quando o pagamento aconteceu (declarado). Carimbo de período do BI (fallback = conclusão). |
+| `recorded_by` | `uuid` | `NOT NULL DEFAULT auth.uid()`. Quem registrou (empresa no v1). |
+| `worker_confirmed_at` | `timestamptz` | nullable. Se/quando o freela confirmou recebimento (bilateral opcional — ver §4). |
+| `note` | `text` | nullable. Observação livre (ex.: "pago em 2x", referência PIX). |
+| `status` | `text` | `NOT NULL DEFAULT 'recorded' CHECK (status IN ('recorded','voided'))`. Correção = estorno lógico (novo status `voided`), **nunca UPDATE destrutivo do valor**. |
+| `voided_at` / `void_reason` | `timestamptz` / `text` | nullable. Trilha do estorno lógico. |
+| `created_at` | `timestamptz` | `NOT NULL DEFAULT now()`. |
+
+### Idempotência (Article 9, adaptado — não é `wallet_transactions`)
+- **`[architect DECIDIU: UNIQUE PARCIAL]`** `CREATE UNIQUE INDEX ... ON shift_payments (job_id) WHERE status = 'recorded'`. No máximo UMA linha `recorded` por turno; N linhas `voided` permitidas. Um turno é pago por **exatamente uma** fonte ativa no modo A. Casa com o dedupe do BI (`job_id` disjunto entre escrow e marcador; se ambos, escrow tem precedência).
+- **Justificativa da decisão:** UNIQUE simples impediria a correção — como correção = estorno lógico (`voided`) + novo registro, o parcial deixa o par estorna-e-recadastra funcionar sem violar a constraint. Não é `wallet_transactions` → não usa `(wallet_id, reference_id)` (Article 9 adaptado).
+
+### RLS (empresa + freela veem o próprio registro)
+- **SELECT:** `company_id IN (SELECT id FROM companies WHERE owner_id = auth.uid())` **OR** `worker_id = auth.uid()`. Ambos os lados leem — base do recibo bilateral.
+- **INSERT:** `WITH CHECK (company_id IN (SELECT id FROM companies WHERE owner_id = auth.uid()))` — só a empresa dona registra (v1). Se produto decidir que o freela também registra, expandir aqui.
+- **UPDATE:** restrito ao estorno lógico (`status`, `voided_at`, `void_reason`, e `worker_confirmed_at` pelo freela). **Colunas de valor/fonte/paid_at NÃO são atualizáveis** — imutabilidade. Preferir política de UPDATE mínima + `CHECK`/trigger que rejeite mudança de colunas materiais (architect define a forma: coluna-a-coluna via trigger `BEFORE UPDATE` que compara OLD/NEW, padrão já usado no projeto).
+- **DELETE:** **negado** (sem policy DELETE) — auditoria não se apaga; correção via `voided`.
+- `REVOKE ALL FROM anon` · `GRANT SELECT, INSERT, UPDATE ON ... TO authenticated` · `GRANT ALL ... TO service_role` (padrão do projeto; service_role para leitura futura do BI/edge, embora o modo A não precise dele para escrever).
+
+### Imutabilidade / auditoria (ADR §2)
+- Sem `ON DELETE CASCADE` a partir de tabela financeira (`escrow_transactions`/`wallets` não referenciam esta tabela; a FK vai de `shift_payments → jobs`, não o contrário).
+- Correção = novo registro ou `status='voided'` + `void_reason`, nunca UPDATE destrutivo do `amount`/`source`/`paid_at`. Trigger `BEFORE UPDATE` bloqueia mutação das colunas materiais.
+- `updated_at` **não** necessário se o registro é imutável salvo estorno; um `voided_at` basta. (Architect confirma.)
+
+---
+
+## 3. Camadas e steps (ordem canônica)
+
+> Ordem: migration → tipos → service → UI (registrar) → recibo → consultabilidade p/ BID. Cada step com arquivo-alvo e tamanho.
+
+### Step 1 — Migration `shift_payments` (+ RLS + imutabilidade) — **M** — gate architect
+- **Arquivo:** `supabase/migrations/<ts>_shift_payments.sql` (criar).
+- **Conteúdo:** tabela §2, índices (`job_id` UNIQUE/parcial, `company_id`, `worker_id`, `paid_at`), RLS empresa+freela, trigger de imutabilidade, GRANT/REVOKE. **DOWN:** `DROP TABLE IF EXISTS public.shift_payments CASCADE;`
+- **Done:** aplica sem erro; empresa insere o próprio registro e lê; freela lê o próprio; nenhum dos dois lê registro do outro (isolamento); UPDATE de `amount`/`source` é rejeitado; DELETE negado; **nenhuma** referência a `wallets`/`escrow_transactions`/RPC de saldo.
+
+### Step 2 — Tipos à mão — **S**
+- **Arquivo:** `frontend/src/types/index.ts` (modificar).
+- **Conteúdo:** `interface ShiftPayment` (campos §2), `type PaymentSource = 'external_pix' | 'cash' | 'other'`, `type ShiftPaymentStatus = 'recorded' | 'voided'`.
+- **Done:** `types/index.ts` reflete o schema; build TS verde.
+
+### Step 3 — Service `paymentRecordService` — **M**
+- **Arquivo:** `frontend/src/services/paymentRecordService.ts` (criar). Padrão: `supabase.from(...)` direto (Article 5), `logError`, imports relativos, tipos à mão (espelha `spendLimitService.ts`).
+- **API proposta:**
+  - `recordExternalPayment({ jobId, workerId, applicationId, source, amount, paidAt, note }): Promise<{ success; payment?; error? }>` — INSERT idempotente (trata violação de UNIQUE `job_id` → retorna `alreadyRecorded`). **Não** toca saldo, **não** chama RPC.
+  - `getPaymentByJob(jobId): Promise<ShiftPayment | null>` — para a UI saber se o turno já foi registrado (esconder/mostrar botão) e para o recibo.
+  - `getReceipt(paymentId | jobId)` — retorna o marcador + dados de exibição (empresa, freela, turno, valor, fonte, data) para renderizar o recibo (join leve com `jobs`, `companies`, worker profile — só leitura sob RLS).
+  - `confirmReceiptByWorker(paymentId)` — seta `worker_confirmed_at` (se produto habilitar confirmação bilateral; senão fica dormant).
+  - `voidPayment(paymentId, reason)` — estorno lógico (`status='voided'`).
+- **Done:** funções tipadas, sem `any`; registrar e reler funcionam sob RLS; build+lint verdes.
+
+### Step 4 — UI "Registrar pagamento" (empresa) — **M** — gate frontend-reviewer
+- **Arquivo:** `frontend/src/pages/company/CompanyJobCandidates.tsx` (modificar) — âncora `handleConfirmDelivery` (linha ~103) e o modal de confirmação de entrega (linha ~503+).
+- **Comportamento:**
+  - No modo A (default do piloto), **confirmar conclusão NÃO chama `WalletService.releaseOrCaptureEscrow`** — em vez disso apresenta o modal **"Registrar pagamento"**: fonte (`external_pix`/`cash`/`other`), valor (pré-preenchido com o valor do turno), data (`paid_at`, default agora), nota opcional.
+  - Ao confirmar → `paymentRecordService.recordExternalPayment(...)` → marca `applications.status='completed'` → toast → oferece "Ver recibo" e o fluxo de avaliação (R10) segue igual.
+  - Coexistência: se o turno for de um caminho postpago (`escrow.kind='postpaid'`, opt-in C), manter o caminho de captura atual. A escolha modo A vs C por turno é decisão de produto (§4) — no v1 o default é A. **Não** quebrar o caminho de escrow existente.
+  - Design neo-brutalista (Article 13): bordas pretas 2px, sombra offset sólida, caixa-alta nos CTAs, cor empresa. Reusar o estilo do modal de confirmação já presente no arquivo.
+- **Guardas de gasto sem lastro:** botão só habilita se o turno está **concluído** (checkout/confirmação — ver §4 sobre pré-requisito); rótulo explícito "Pagamento feito por fora do Worki — registro declaratório".
+- **Done:** empresa registra pós-conclusão; botão some/vira "Ver recibo" quando `getPaymentByJob` já retorna registro; sem regressão no caminho escrow.
+
+### Step 5 — Recibo in-app (renderizável) — **M** — gate frontend-reviewer
+- **Decisão v1 (proposta):** recibo = **tela in-app renderizável** (rota dedicada), **não** PDF. Conteúdo mínimo:
+  - Cabeçalho "RECIBO DE PAGAMENTO — registro Worki (declaratório)".
+  - Empresa (nome), Freela (nome), Turno (função, data/hora, local), Valor pago, Fonte declarada (PIX/dinheiro/outro), Data do pagamento (`paid_at`), Identificador do registro (`id` curto), carimbo de emissão.
+  - **Disclaimer explícito:** "O Worki registra a declaração de pagamento entre as partes; o dinheiro não passou pela plataforma. Não é documento fiscal." (mitiga o risco de "afirmação de pagamento").
+  - Botão imprimir (window.print / CSS print) como aproximação de "salvar PDF" sem lib nova.
+- **Arquivo:** `frontend/src/pages/ReceiptView.tsx` (criar, cross-papel — acessível empresa e freela, RLS garante) + rota em `frontend/src/App.tsx` sob `<ProtectedRoute>` (modificar). Rota proposta: `/recibo/:jobId` ou `/recibo/:paymentId`.
+- **Done:** empresa e freela abrem o recibo do próprio turno; quem não é parte recebe vazio (RLS); disclaimer presente; layout neo-brutalista imprimível.
+
+### Step 6 — Gasto consultável para o BI (sem tocar BI) — **S**
+- **Não** altera `financialBIService.ts` (item #2). Apenas **garante** que o marcador é consultável: índice por `company_id` + `paid_at`, `job_id` disjunto documentado, e um comentário no service/migration apontando o contrato do ADR ("BI-1 soma escrow released/captured ∪ marcador external por `job_id` disjunto; escrow tem precedência em anomalia").
+- **Arquivo:** coberto pela migration (índices) + docstring no `paymentRecordService`. Deixa um TODO rastreável para o item #2.
+- **Done:** query "gasto externo do período por empresa" roda sob RLS filtrando `paid_at` + `status='recorded'`; documentação do contrato de dedupe presente.
+
+### Step 7 — Testes + smoke — **S/M**
+- **Vitest co-located:** `paymentRecordService.test.ts` (idempotência por `job_id`, mapeamento de tipos, rejeição de void inexistente).
+- **Smoke manual:** registrar como empresa, ver recibo como empresa e como freela (2 contas), verificar isolamento cruzado, verificar que saldo/`wallets` **não** mudou.
+- **Done:** `cd frontend && npm run build` + `npm run lint` verdes (A9).
+
+---
+
+## 4. Decisões de produto a confirmar no HALT
+
+> **✅ HALT RESOLVIDO (2026-06-30, owner):**
+> 1. Recibo = **tela in-app + `window.print`** (sem PDF lib).
+> 2. **Empresa registra + freela confirma recebimento** (bilateral ATIVO): `worker_confirmed_at` deixa de ser dormant — freela dá 1 toque "recebi". **Não bloqueia** o ciclo/avaliação (é sinal de confiança). RLS de UPDATE deve permitir o freela setar `worker_confirmed_at` no próprio registro.
+> 3. Fontes = `external_pix` + `cash` + `other` (proposta mantida).
+> 4. Registrar **EXIGE turno concluído** (checkout/confirmação antes de habilitar).
+> 5. **1 registro por turno** (`UNIQUE job_id`, índice parcial p/ re-registro após void).
+> 6. Recibo **informal**, sem série fiscal (id curto como referência).
+> 7. Confirmação bilateral **não bloqueia** ciclo/avaliação.
+> 8. Piloto roda **só modo A** (sem toggle de modo no v1).
+
+1. **Recibo = tela in-app (com imprimir) ou PDF gerado?** Proposta: tela in-app + `window.print` no v1 (sem lib de PDF). Confirmar.
+2. **Quem registra o pagamento?** Só a empresa (proposta v1) ou o freela também pode registrar/confirmar recebimento? Se bilateral, `worker_confirmed_at` vira fluxo ativo (mitiga "freela alega não-pagamento").
+3. **Fontes aceitas:** `external_pix` + `cash` + `other` cobre? Adicionar "transferência bancária" / "cheque"? Proposta: os três + `other` com nota livre.
+4. **Registrar pagamento exige turno concluído?** Proposta: sim — exige checkout/confirmação de conclusão antes de habilitar o registro (evita registro sem lastro de trabalho). Confirmar se pode registrar antes (ex.: pago adiantado).
+5. **Um registro por turno, ou permitir parcial/múltiplo?** Proposta: **1 por turno** (`UNIQUE job_id`), correção via estorno lógico + novo registro. Confirmar (pagamento em 2x mudaria o modelo para 1:N).
+6. **Recibo precisa de número/série fiscal?** Proposta: **não** no MVP — recibo declaratório informal com `id` curto como referência. Confirmar (se precisar de sequência, muda schema).
+7. **Confirmação bilateral bloqueia o ciclo/avaliação?** Proposta: **não** — registro e avaliação seguem independentes da confirmação do freela; a confirmação é sinal de confiança, não gate.
+8. **Escolha do modo (A vs C) por turno:** no v1 o default é A e não há UI de toggle de modo. Confirmar que o piloto roda **só modo A** por ora (toggle de modo = trabalho separado do ADR §Trabalho subsequente #4).
+
+---
+
+## 5. Risk matrix
+
+| Risco | Prob | Impacto | Mitigação |
+|---|---|---|---|
+| **Registro sem lastro** — Worki afirma um pagamento que não ocorreu | M | A | Pré-requisito de turno concluído (§4.4); recibo com **disclaimer declaratório** explícito ("dinheiro não passou pelo Worki, não é documento fiscal"); confirmação bilateral opcional do freela (`worker_confirmed_at`) como sinal de verdade. |
+| **Freela alega não-pagamento** (sem garantia de recebimento no modo A) | M | M | Confirmação bilateral opcional (freela confirma recebimento); trilha imutável de quem/quando registrou (`recorded_by`, `paid_at`); é a natureza do modo A por decisão do owner (ADR — reabrir postpago é o gatilho se calote virar material). |
+| **RLS cruzada empresa/freela** — um lado vê registro do outro | M | A | SELECT restrito a `company owner OR worker_id=auth.uid()`; testar como empresa E como freela com contas distintas; espelhar isolamento; security-reviewer no gate. |
+| **Mutação/apagamento de auditoria** (UPDATE destrutivo do valor, DELETE) | B | A | Imutabilidade por trigger `BEFORE UPDATE` (bloqueia colunas materiais); DELETE sem policy (negado); correção só via `voided` + `void_reason`. |
+| **Dupla contagem no BI** (turno com escrow E marcador) | B | M | `UNIQUE(job_id)` no marcador; contrato de dedupe do ADR (escrow tem precedência); documentado no Step 6 para o item #2 consumir. |
+| **Contaminar o trilho financeiro** (marcador virar linha de escrow) | B | A | Tabela **separada**, sem FK para/de `escrow_transactions`/`wallets`, sem RPC de saldo, sem service_role para escrever — Article 8 intacto (alternativa "escrow com status external" foi **rejeitada** no ADR). |
+| **Regressão no caminho postpago (C)** ao alterar `handleConfirmDelivery` | B | M | Ramificar por `escrow.kind`; manter `releaseOrCaptureEscrow` no caminho C; smoke dos dois caminhos; frontend-reviewer. |
+
+---
+
+## 6. Gates (Phase 3.5)
+
+| Gate | Dispara? | Motivo |
+|---|---|---|
+| **harness-architect** (gate) | **SIM — obrigatório** | Migration nova de **auditoria financeira** (mesmo sem mover saldo). Valida schema/constraints/RLS/imutabilidade de `shift_payments`, o UNIQUE de idempotência (`job_id` vs parcial) e a fronteira "registro ≠ saldo" (Article 8). ADR-mãe já lista isto como "gate architect antes do builder". |
+| **harness-security-reviewer** | **SIM** | Toca `supabase/migrations/**` + RLS cruzada empresa/freela + imutabilidade/auditoria + LGPD (dados de pagamento entre pessoas). Verifica isolamento de papel e ausência de service_role no front. |
+| **harness-frontend-reviewer** | **SIM** | Toca `pages/company/CompanyJobCandidates.tsx`, nova `pages/ReceiptView.tsx` e `App.tsx` (UI neo-brutalista, isolamento de papel no ProtectedRoute). |
+| harness-builder | — | Executa migration (pós-architect), tipos, service; e a UI vai ao **harness-frontend-builder** (Gemini). |
+
+### Sequência de execução sugerida (pós-aprovação)
+1. `harness-architect` valida/ajusta o schema §2 → libera a migration.
+2. `harness-builder`: Step 1 (migration) → Step 2 (tipos) → Step 3 (service) → Step 6 (índices/docstring) → Step 7 (testes service).
+3. `harness-frontend-builder`: Step 4 (registrar) + Step 5 (recibo + rota).
+4. Paralelo: `harness-frontend-reviewer` (UI) + `harness-security-reviewer` (migration/RLS) → `harness-evaluator`.
+
+---
+
+## Rollback
+`git revert <hash>` + migration DOWN: `DROP TABLE IF EXISTS public.shift_payments CASCADE;`. Sem impacto em saldo/escrow (nenhuma RPC tocada), sem dado financeiro real a reconciliar — só o registro declaratório é descartado.

--- a/.harness/spec/v1-operacao-freelancer/spec.md
+++ b/.harness/spec/v1-operacao-freelancer/spec.md
@@ -64,7 +64,13 @@ freela é forçado pela empresa a criar conta e usar — e ganha valor mínimo r
     validada no service — ADR-001), `blockConnection(id)` (→blocked, idempotente). Hooks: `useWorkerStores`.
 - [ ] **R3 — Criar turno.** Operador cria turno com: data, hora início-fim, função, **modelo de pagamento =
   FIXO por turno (v1)**, valor, local, **briefing** (texto/regras/cardápio). 
-- [ ] **R4 — Pagamento postpago (modelo Uber, sem valor antecipado).** Sem depósito prévio. A empresa
+> ⚠️ **REVISADO por ADR-20260630-pagamento-opcional-piloto (2026-06-30).** R4/R7/R9 abaixo descrevem o
+> postpago **obrigatório**; o owner tornou o pagamento pelo Worki **OPCIONAL** no piloto. Default do piloto =
+> **pagamento externo registrado** (Worki registra que houve PIX/dinheiro fora + recibo, sem mover saldo).
+> Postpago (cartão on-file, R4/R7/R9) vira **opt-in / evolução da expansão**; PIX-único→distribuição é
+> conveniência opt-in. O texto histórico abaixo fica preservado como o caminho opt-in C. Ver o ADR.
+
+- [ ] **R4 — Pagamento postpago (modelo Uber, sem valor antecipado).** _[opt-in — ver ADR-20260630]_ Sem depósito prévio. A empresa
   cadastra **um método uma vez** (cartão on-file ou PIX). Cria o turno e convida — nada mais. Na **conclusão**,
   o Worki cobra o método da empresa e paga o freela. Onde o Asaas suportar, fazer **pré-autorização (hold) no
   aceite + captura na conclusão** (como o Uber) — garante o freela sem depósito. Worki **não adianta dinheiro**
@@ -89,6 +95,8 @@ freela é forçado pela empresa a criar conta e usar — e ganha valor mínimo r
   - [x] _Service-layer (Slice 1, parcial):_ app + e-mail entregues por `inviteWorkerToShift`. WhatsApp = Slice 4.
 - [ ] **R7 — Aceite/recusa.** Freela aceita ou recusa. **Aceite → escrow RESERVA** (RPC atômica) + turno
   confirmado nas duas agendas + no-show passa a contar. **Recusa → slot reabre, NEUTRO (zero punição).**
+  > _[REVISADO por ADR-20260630]_ A **reserva/hold no aceite deixa de ser obrigatória**. O aceite confirma a
+  > relação e a agenda; hold só no modo postpago opt-in (C). Recusa segue neutra.
   - [x] _Camada de dados (parcial):_ status `invited`/`declined` + colunas de resposta em `applications`
     (`invitation_response`, `invitation_responded_at`) — `20260622000100_invite_columns_applications.sql`.
     A reserva de escrow no aceite é **Slice 2** (postpago); aqui o aceite só muda status.
@@ -102,6 +110,9 @@ freela é forçado pela empresa a criar conta e usar — e ganha valor mínimo r
 - [ ] **R9 — Conclusão → cobrança + pagamento.** Operador confirma conclusão → Worki **captura o cartão
   on-file (ou cobra o PIX) da empresa** e **paga o freela** (RPCs atômicas no ledger, idempotentes).
   **Auto-processamento** após janela de carência pós-conclusão protege o freela de inação da empresa.
+  > _[REVISADO por ADR-20260630]_ A cobrança na conclusão **deixa de ser obrigatória**. Conclusão confirma o
+  > turno e habilita o **registro de pagamento** (modo A externo, sem mover saldo) OU a captura/distribuição
+  > (modos C/B opt-in). Auto-processamento de captura só se aplica ao modo postpago (C).
   - [x] _Camada de dados (Slice 2):_ RPC atômica idempotente `capture_escrow_postpago` (captura o hold:
     `authorized`→`released` + credita o worker via reuso de `escrow_release`, idempotência `(wallet_id,
     reference_id=job_id)`) e `release_hold_postpago` (cancel/no-show antes da captura: `authorized`→`refunded`,
@@ -148,6 +159,12 @@ freela é forçado pela empresa a criar conta e usar — e ganha valor mínimo r
 - [ ] **R17 — (concierge) Importar histórico da MOMMA** da ferramenta interna → BI nasce cheio no dia 1.
 
 ## Workflow canônico (máquina de estados) — decisões A–G resolvidas
+
+> ⚠️ **REVISADO por ADR-20260630 (2026-06-30):** o passo [0.5] (cadastrar método) e a cobrança nos passos
+> [2]/[5] passam a ser **opcionais** (postpago = opt-in C). No default do piloto o ciclo avança por
+> confirmação da relação (aceite → check-in/checkout → conclusão → avaliação) e o **pagamento é um passo
+> paralelo**: registrar pagamento externo (modo A, sem saldo) OU pagar via Worki (B/C). Diagrama abaixo
+> descreve o caminho postpago histórico.
 
 ```
 [0] Popular equipe ── QR scan │ link │ telefone ──► conexão ACEITA (handshake 1x) ──► freela na equipe
@@ -262,6 +279,11 @@ freela é forçado pela empresa a criar conta e usar — e ganha valor mínimo r
   read-heavy no dashboard → pertencem ao service (consistente com o resto do projeto). **Builder NÃO cria view.**
 
 ### Fonte da verdade do GASTO (usada por R12, R13, R14, R15)
+> ⚠️ **REVISADO por ADR-20260630.** Com pagamento OPCIONAL, o gasto tem **duas fontes** unidas por `job_id`
+> disjunto: (1) trilho Worki = `escrow_transactions` (abaixo); (2) **pagamento externo** = novo marcador de
+> pagamento por turno (modo A default do piloto), carimbo = data do pagamento declarado / conclusão. Dedupe
+> por `job_id` (um turno é pago por uma fonte; se ambos, escrow tem precedência). Enquanto o marcador não
+> existir (trabalho subsequente com gate), o BI reflete só o trilho Worki — limitação conhecida. Ver o ADR.
 - Gasto = `escrow_transactions` com `status IN ('released','captured')` (dinheiro efetivamente comprometido/pago
   ao freela). `amount` é o valor. **NÃO** somar `reserved`/`authorized` (ainda não virou gasto) nem `refunded`.
 - Carimbo de período: `COALESCE(captured_at, released_at, created_at)` (postpago usa captured_at; prepaid legado

--- a/.harness/thesis.md
+++ b/.harness/thesis.md
@@ -43,6 +43,12 @@ provar que é confiável. Os dois querem a mesma coisa — **uma camada de confi
 
 > Metáfora pro freela (marketing, nunca jurídico): "a sua carteira de trabalho portátil que ninguém tira".
 
+### Naming (decidido jun/2026, com pesquisa de mercado)
+
+O produto trata cada lado como premium do seu jeito (naming assimétrico):
+- **Empresa** → sua lista de freelas se chama **"Meu Elenco"** (elenco curado que ela dirige/aciona — nunca "equipe"/"colaboradores").
+- **Freela** → sua lista de empresas se chama **"Carteira de Clientes"** — enquadra o freela como **empresário de si mesmo** (ter carteira de clientes = ter negócio). É o que mais converte ("freela não é bico, é carreira"; Brasil 3º em autônomos, formalizando CNPJ/MEI).
+
 ## O wedge (entrada) e o moat (defesa)
 
 - **Wedge (o cavalo de Troia):** **valor financeiro pra empresa** — centralizar a operação de freelancer
@@ -97,6 +103,14 @@ Fase 3 (financeirização) → cartão/parcela (banco floata), depois crédito/f
 | v1.5+ | **Processamento de cartão + parcela** (banco emissor da empresa floata; Asaas processa) | zero capital Worki |
 | Fase 2+ | **SaaS** de controle/BI/formalização (empresa paga pra reduzir risco e organizar) | baixo |
 | Fase 3 | Crédito/float/antecipação, produtos financeiros (regulado, exige capital + licença) | alto — futuro |
+
+### Postura de pagamento no piloto (revisado jun/2026 — owner)
+
+Pagamento pelo Worki é **opcional, não obrigatório**, no piloto. Empresa e freela **fecham pelo Worki** (avaliação,
+histórico, recibo, controle da relação/dado) mas **podem pagar direto entre si**. Take **0**. O trilho financeiro
+é *conveniência opt-in*, não pré-requisito: a empresa pode fazer **1 PIX ao Worki** e o Worki **distribui automático**
+a todos os freelas (útil quando são muitas contas). O valor do dia 1 é **controle + dado**, não custódia. A cobrança
+obrigatória via cartão (postpago/hold) é evolução posterior — reabri-la muda o contrato de pagamento (gate architect + ADR).
 
 ## Métrica polar
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/).
 
 ### Adicionado
 
+#### Modo A — Pagamento Externo (Piloto 2026-07-01)
+
+**Empresa e Freelancer:**
+- **Registrar pagamento feito por fora:** ao concluir um turno, a empresa registra que pagou o freelancer por PIX/dinheiro (fora do Worki)
+- **Recibo in-app:** geração automática de recibo declaratório acessível por empresa e freelancer
+- **Confirmação de recebimento (bilateral):** o freelancer pode confirmar que recebeu o pagamento
+- **Inteligência financeira unificada:** o painel financeiro e alertas de teto agora contam tanto pagamentos via Worki quanto registrados por fora
+
+**Empresa:**
+- Botão "Registrar pagamento" na tela de conclusão de turno (campo "Pagamento feito por fora do Worki")
+- Seleção de fonte de pagamento: PIX, dinheiro em espécie ou outro método
+- Confirmação e emissão automática de recibo
+- Rastreamento do pagamento no histórico de turnos
+
+**Freelancer:**
+- Visualização de recibos de pagamentos registrados
+- Confirmação de recebimento (gera valor comprovado no recibo bilateral)
+
 #### Slice 1 — Loop Relacional (MVP)
 
 **Empresa:**

--- a/docs/features-empresa-meu-elenco.md
+++ b/docs/features-empresa-meu-elenco.md
@@ -1,0 +1,224 @@
+# Meu Elenco (Empresa) e Carteira de Clientes (Freelancer)
+
+Novo sistema de gerenciamento de conexões bilaterais no Worki — você constrói sua equipe e os freelancers controlam com quem trabalham.
+
+---
+
+## Para a Empresa: "Meu Elenco"
+
+**"Meu Elenco"** é a lista de freelancers que você trabalha regularmente. Diferente do feed marketplace, aqui você convida pessoas que já conhece — fechado e confiável.
+
+### Acessar "Meu Elenco"
+
+1. Vá para o menu **"Empresa"**
+2. Clique em **"Meu Elenco"** (ou **Team** em inglês)
+3. Você vê sua lista atual
+
+### Adicionar Freelancer ao Elenco
+
+Existem 3 formas de convidar:
+
+#### 1️⃣ Por QR do Perfil
+
+Mais rápido se você está pessoalmente com o freelancer:
+
+1. Clique **"Adicionar por QR"**
+2. Aponte a câmera para o código QR do perfil do freelancer
+3. O app reconhece e convida instantaneamente
+4. Freelancer aceita → entra no seu elenco
+
+#### 2️⃣ Por Link de Convite
+
+Se você quer enviar por WhatsApp, SMS ou e-mail:
+
+1. Selecione um freelancer já no seu elenco (que você quer referenciar)
+2. Clique **"Compartilhar Link de Contato"**
+3. Um link é gerado (ex: `worki.app/convite/abc123xyz`)
+4. Compartilhe esse link com novos freelancers
+5. Quando eles clicam, entram no seu elenco direto
+
+#### 3️⃣ Manualmente por ID Worki (Futura)
+
+Digitar o Worki ID do freelancer (v1.1).
+
+### Status do Convite
+
+Quando você convida alguém, aparece com status:
+
+| Status | O Que Significa |
+|---|---|
+| **Pendente** | Freelancer ainda não respondeu (48 horas máximo) |
+| **Aceito** | Freelancer aceitou; agora faz parte da sua equipe |
+| **Não respondeu (expirado)** | Passaram 48h; o convite expirou; você pode convidar outro |
+| **Bloqueado** | O freelancer saiu ou bloqueou você |
+
+### Convidar para Turnos
+
+Após o freelancer estar **"Aceito"** no elenco:
+
+1. Quando você cria um novo turno, em vez de deixar aberto no feed, escolha **"Convidar do meu elenco"**
+2. Selecione os freelancers
+3. Eles recebem convite direto (app + e-mail)
+4. Aceita ou recusa (recusar é neutro — não afeta reputação)
+
+### Remover Alguém do Elenco
+
+1. Na lista de elenco, encontre a pessoa
+2. Clique os **3 pontos** (⋮) ou **"Remover"**
+3. Escolha **"Sair da equipe"** ou **"Bloquear"**
+4. Confirmação
+
+**Diferença:**
+- **Sair:** simples desvinculação — você ou eles podem reconectar depois
+- **Bloquear:** mais forte — nem você nem eles podem se reconectar sem explicitamente desbloquear
+
+---
+
+## Para o Freelancer: "Carteira de Clientes"
+
+**"Carteira de Clientes"** (ou **"Minhas Lojas"**) é a lista de empresas que você trabalha regularmente. Você controla quem entra e quem sai.
+
+### Acessar "Carteira de Clientes"
+
+1. Vá para o seu **Perfil**
+2. Clique em **"Minhas Lojas"** ou **"Carteira de Clientes"**
+3. Você vê todas as empresas conectadas
+
+### Aceitar Convite de Empresa
+
+Empresas te adicionam de 3 formas (mencionadas acima). Quando um convite chega:
+
+#### Pelo App
+
+1. Você recebe **notificação** (sino no app)
+2. Clique em **"Ver Convite"**
+3. Vê dados da empresa (nome, logo, avaliação)
+4. Botões: **"Aceitar"** ou **"Recusar"**
+
+#### Pelo Link (Por E-mail/WhatsApp/SMS)
+
+1. Você recebe um link de convite (ex: `worki.app/convite/abc123xyz`)
+2. Clique no link
+3. O app abre automaticamente
+4. Vê a empresa + botões **"Aceitar"** ou **"Recusar"**
+
+#### Pelo QR (Quando a Empresa Escaneia)
+
+1. Você exibe seu QR de perfil
+2. A empresa escaneia com a câmera do Worki
+3. Você recebe notificação instantaneamente (aceitar/recusar)
+
+### Status da Conexão
+
+| Status | Significado |
+|---|---|
+| **Pendente** | Empresa te convidou; você ainda não respondeu |
+| **Aceito** | Você aceitou; agora vocês trabalham juntos |
+| **Expirado** | Passou 48h sem responder; o convite expirou (eles podem convidar de novo) |
+| **Bloqueado** | Você saiu ou bloqueou a empresa |
+
+### Recusar um Convite
+
+1. Clique **"Recusar"** no convite
+2. **Isso é neutro** — não afeta sua reputação
+3. A empresa pode convidar de novo depois
+
+### Sair ou Bloquear uma Empresa
+
+1. Na lista de clientes, encontre a empresa
+2. Clique **⋮** (3 pontos) ou **"Sair"**
+3. Escolha:
+   - **"Sair"** — simples desvinculação
+   - **"Bloquear"** — você não quer mais trabalhos deles
+
+### Meu QR de Identidade
+
+**Seu código QR único** identifica você no Worki:
+
+1. Vá para **"Meu Perfil"**
+2. Clique no ícone **QR** (canto superior)
+3. **Compartilhe** — é seguro (não expõe dados, só sua identidade no Worki)
+4. Empresas podem:
+   - Escanear com a câmera e te adicionar (futuro v1.1)
+   - Digitar o código manualmente
+   - Compartilhar o QR com outros
+
+---
+
+## Ciclo Completo: De Convite a Turno
+
+```
+Empresa convida você (QR/link/ID)
+         ↓
+Você aceita ("Aceitar")
+         ↓
+Você entra em seu "Carteira de Clientes" (status "Aceito")
+Empresa vê você em "Meu Elenco" (status "Aceito")
+         ↓
+Próxima vez que a empresa criar turno...
+Empresa convida você para o turno (não precisa novo handshake)
+         ↓
+Você recebe "Convite de Turno" em Meus Jobs
+         ↓
+Você aceita ou recusa (neutro)
+         ↓
+Se aceitar: trabalha, faz check-in/checkout, conclui
+         ↓
+Ganha, avalia empresa, repete
+```
+
+---
+
+## Perguntas Frequentes
+
+### P: Qual é a diferença entre "Sair" e "Bloquear"?
+
+R: 
+- **Sair:** você pode voltar a trabalhar com eles se eles te convidarem de novo
+- **Bloquear:** você não quer mais ver convites deles (mais permanente; ambos precisam concordar em desbloquear)
+
+### P: Se eu recuso um convite, a empresa vê?
+
+R: Sim, a empresa vê que você recusou. MAS **recusar não afeta sua reputação** — é neutro. Só faltar após aceitar é que penaliza.
+
+### P: Posso estar no elenco de múltiplas empresas?
+
+R: **Sim!** Você pode trabalhar com quantas quiser — é como ter clientes diferentes.
+
+### P: O que acontece se a empresa bloqueia você?
+
+R: Você é removido do "Carteira de Clientes" dela e não vê mais convites.
+
+### P: Como companho meus ganhos por empresa?
+
+R: Na **Carteira** (seu saldo), você vê histórico de ganhos por turno. Se quiser detalhe por empresa, é no histórico de "Meus Jobs".
+
+### P: Vejo convites com prazo (48h)?
+
+R: Sim! Se você não responder em 48 horas, o convite expira e a empresa pode convidar outro. Mas você continua recebendo notificações até expirar.
+
+### P: Posso compartilhar meu QR com qualquer um?
+
+R: Sim, é **seguro**! O QR só identifica seu perfil no Worki — não expõe CPF, contatos, dados pessoais.
+
+---
+
+## Resumo da Tabela
+
+| Aspecto | Empresa ("Meu Elenco") | Freelancer ("Carteira de Clientes") |
+|---|---|---|
+| **Vê quem?** | Freelancers que trabalha | Empresas que trabalha |
+| **Convida por** | QR, Link, ID | App recebe convite |
+| **Aceita por** | Aceitam convite | Você aceita convite |
+| **Cria turno** | Escolhe do elenco | Recebe convite de turno |
+| **Sai** | Remove do elenco | Sai da equipe |
+| **Bloqueia** | Bloqueia freelancer | Bloqueia empresa |
+
+---
+
+## Suporte
+
+Dúvidas?
+- **Chat no app** — fale com o time Worki
+- **E-mail:** [suporte@worki.com]
+- **Horário:** Segunda a sexta, 9h–18h (horário de Brasília)

--- a/docs/features-empresa-pagamento-modo-a.md
+++ b/docs/features-empresa-pagamento-modo-a.md
@@ -1,0 +1,164 @@
+# Pagamento Externo (Modo A) — Guia da Empresa e Freelancer
+
+Bem-vindo ao novo modo de pagamento **Modo A** do Worki! Este guia explica como registrar pagamentos feitos **fora da plataforma**.
+
+---
+
+## O que é Modo A (Pagamento Externo)?
+
+No modelo **Modo A**, você paga o freelancer **direto** — por PIX, dinheiro em espécie ou outro método — **sem que o dinheiro passe pelo Worki**. O Worki então **registra** que o pagamento aconteceu e **emite um recibo** para ambos os lados.
+
+**Características:**
+- Você paga direto ao freelancer (fora do Worki)
+- O Worki registra a declaração de pagamento
+- Gera um recibo bilateralmente confirmável
+- Zero taxa do Worki (por enquanto)
+
+**Nota:** O recibo é um **registro declaratório**, não um documento fiscal. O Worki não tem prova bancária do pagamento — é o registro de que vocês dois acordaram que o trabalho foi feito e pago.
+
+---
+
+## Como Funciona na Prática
+
+### Fluxo Passo a Passo
+
+```
+1. Freelancer trabalha (check-in → turno → checkout)
+   ↓
+2. Você (empresa) confirma que o turno foi concluído
+   ↓
+3. Botão "Registrar Pagamento" aparece
+   ↓
+4. Você preenche: quanto pagou, como (PIX/dinheiro/outro), quando
+   ↓
+5. Recibo gerado no app (acessível por você e o freelancer)
+   ↓
+6. Freelancer pode confirmar "recebi" (opcional, mas recomendado)
+```
+
+---
+
+## Para a Empresa: Registrar o Pagamento
+
+### Passo 1: Concluir o Turno
+
+1. Vá para o turno concluído na aba **"Vagas"** ou histórico
+2. Clique em **"Confirmar Conclusão"** (após checkout)
+3. A tela de conclusão abre
+
+### Passo 2: Preencher o Registro de Pagamento
+
+Após confirmar a conclusão, você vê:
+
+**"Registrar Pagamento — Pagamento feito por fora do Worki"**
+
+Preencha:
+- **Fonte de pagamento:** Escolha uma:
+  - PIX (recomendado — mais rápido)
+  - Dinheiro em espécie
+  - Outro (transferência, cheque, etc.)
+- **Valor pago (BRL):** Ex: 150,00
+- **Data do pagamento:** Quando você pagou (default = hoje)
+- **Observação (opcional):** Ex: "Pago via PIX no dia 30", "Referência: ABC123"
+
+### Passo 3: Confirmar e Gerar Recibo
+
+1. Clique em **"Confirmar e Gerar Recibo"**
+2. O recibo é criado instantaneamente
+3. Você e o freelancer podem acessar no app
+
+### Passo 4: Acompanhar no BI
+
+O pagamento **automaticamente aparece no seu Painel Financeiro** (`/company/financeiro`):
+- **Gasto do mês** — inclui este pagamento
+- **Gasto por freelancer** — credita o valor a este freelancer
+- **Alertas de teto** — se você atingir 80%, 90% ou 100% do teto, recebe alerta (inclui pagamentos por fora)
+
+---
+
+## Para o Freelancer: Confirmar Recebimento
+
+### Acessar o Recibo
+
+1. Vá para **"Meus Jobs"**
+2. Localize o turno concluído
+3. Clique em **"Ver Recibo"**
+
+### O Recibo Mostra
+
+- Empresa (nome)
+- Seu nome (freelancer)
+- Turno (função, data/hora, local)
+- Valor pago
+- Fonte declarada (PIX/dinheiro/outro)
+- Data do pagamento
+- Quem registrou (a empresa)
+
+### Confirmar Recebimento (Opcional)
+
+Se você já recebeu, pode confirmar no recibo:
+
+1. Clique **"Confirmar que recebi"**
+2. Seu carimbo é adicionado ao recibo (timestamp)
+3. O recibo mostra que ambas as partes confirmaram
+
+**Nota:** Confirmar é recomendado, mas **não é obrigatório** para o turno avançar ou você ser avaliado.
+
+---
+
+## Perguntas Frequentes
+
+### P: Por que não usar dinheiro do Worki?
+
+R: Você pode! Mas no piloto, o **Modo A é o padrão** — pagar direto é menos fricção. Se quiser usar o Worki para pagar (futuro Modo B/C), poderá escolher.
+
+### P: Como eu provo que paguei?
+
+R: O recibo é um **registro bilateral**. Se o freelancer confirmar recebimento, fica registrado no app que vocês dois concordam que o pagamento aconteceu. Para prova bancária, o PIX é mais seguro que dinheiro em espécie.
+
+### P: O recibo é legal / fiscal?
+
+R: **Não.** O recibo é um **registro declaratório informal** dentro do Worki — não é um documento fiscal oficial (não tem série, número de nota, etc.). Ele serve para:
+- Confirmar que vocês dois concordam que o trabalho foi feito e pago
+- Gerar histórico no app
+- Contar no BI de gasto da empresa
+
+Se você precisa de documento fiscal, converse com o freelancer sobre emitir uma recibo/RPA fora do Worki.
+
+### P: E se o freelancer alegar que não recebeu?
+
+R: Daí entra a confirmação bilateral. Se você pagou por PIX, há comprovação no banco/app de pagamento. Se foi dinheiro, o recibo serve como registro de que vocês dois concordaram no valor/data — o resto é entre vocês.
+
+### P: Posso editar o recibo depois de criado?
+
+R: **Não.** O recibo é imutável uma vez criado — garante que ninguém mude o histórico. Se errou algo, você pode criar um novo registro (correção) ou entrar em contato com o suporte.
+
+### P: O pagamento conta no Painel Financeiro?
+
+R: **Sim!** Totalmente. Seu gasto mensal, alertas de teto e BI de horas/custo incluem pagamentos por fora automaticamente.
+
+### P: Qual é a taxa do Worki no Modo A?
+
+R: **Zero** — enquanto no piloto. O Worki só registra e gera recibo; sem movimento de dinheiro, sem taxa.
+
+---
+
+## Recibo Bilateral (Resumo)
+
+| Item | Empresa Vê | Freelancer Vê |
+|---|---|---|
+| Dados do turno | ✅ | ✅ |
+| Valor + método | ✅ | ✅ |
+| Data do pagamento | ✅ | ✅ |
+| Quem registrou | ✅ | ✅ |
+| Confirmação freelancer | ✅ | ✅ |
+| **Resultado:** Ambos veem o histórico completo — prova bilateral no app |
+
+---
+
+## Suporte
+
+Dúvidas ou problemas?
+- **Chat no app** — fale com o time Worki
+- **E-mail:** [suporte@worki.com]
+- **Horário:** Segunda a sexta, 9h–18h (horário de Brasília)

--- a/docs/features-worker-convites-turno.md
+++ b/docs/features-worker-convites-turno.md
@@ -1,0 +1,208 @@
+# Convites de Turno — Guia do Freelancer
+
+Você recebe convites de turno das empresas que você trabalha. Este guia explica como responder.
+
+---
+
+## Como Recebe Convites?
+
+Você é notificado de **3 formas:**
+
+1. **Notificação no App** (sino 🔔) — é o mais importante
+2. **E-mail** — confirmação + detalhes
+3. **WhatsApp** (em breve v1.2) — mensagem rápida
+
+---
+
+## Convite em Tela Cheia
+
+Quando você recebe um convite importante, ele aparece em **destaque na tela do app** — não fica perdido nas abas.
+
+### O que você vê
+
+**Cabeçalho:**
+- Logo e nome da empresa
+- Sua reputação (⭐ avaliação)
+
+**Detalhes do turno:**
+- **Função:** Ex. "Garçom", "Auxiliar de Cozinha"
+- **Data e hora:** Quando é o turno
+- **Local:** Endereço/estabelecimento
+- **Valor:** Quanto você vai ganhar
+- **Duração:** Estimativa de horas
+
+**Briefing (Novo!):**
+- Regras específicas da empresa
+- Dress code (ex: "uniforme preto, sapato fechado")
+- Procedimentos especiais
+
+**Seus botões:**
+- ✅ **ACEITAR** — confirma que você vai trabalhar
+- ❌ **RECUSAR** — passa para outro freelancer (neutro, sem punição)
+
+---
+
+## Respondendo ao Convite
+
+### Você Tem 48 Horas
+
+Você precisa responder em **48 horas** a partir da notificação. Passado esse tempo:
+- O convite expira
+- Status muda para **"Não respondeu (expirado)"**
+- A empresa pode convidar outro freelancer
+
+### Se Aceitar ✅
+
+```
+Você clica "ACEITAR"
+    ↓
+Turno entra na sua agenda ("Agendados")
+    ↓
+Empresa recebe notificação que você aceitou
+    ↓
+Você pode fazer check-in no dia do turno
+    ↓
+Trabalha normalmente (check-in/check-out)
+    ↓
+Ganha o valor combinado
+```
+
+**Dica:** Após aceitar, o turno fica **confirmado** — espera-se que você compareça. Faltar após aceitar pode afetar sua reputação.
+
+### Se Recusar ❌
+
+```
+Você clica "RECUSAR"
+    ↓
+O turno sai do seu convite (status "Recusado")
+    ↓
+Empresa recebe notificação que você recusou
+    ↓
+Ela pode convidar outro freelancer
+    ↓
+Zero punição para você — é uma escolha neutra
+```
+
+**Importante:** Recusar é **NEUTRO** — não afeta sua reputação, não é falta, não te penaliza. Use quando:
+- Já tem outro compromisso
+- Não se encaixa no briefing
+- Quer descansar
+- Qualquer motivo
+
+Apenas **faltar após aceitar** é que penaliza.
+
+---
+
+## Vendo Todos os Convites
+
+Além de receber em tela cheia, você pode acompanhar convites:
+
+### Em "Meus Jobs"
+
+1. Vá para **"Meus Jobs"**
+2. Clique na aba **"Convites"**
+3. Vê todos os convites ativos (com prazo de resposta)
+
+### Status que você Vê
+
+| Status | Significado |
+|---|---|
+| 🟡 **Novo convite** | Chegou agora; você não respondeu ainda |
+| 🟡 **Aguardando** | Passando o prazo; faltam horas para expirar |
+| ✅ **Aceito** | Você aceitou; o turno está confirmado |
+| ❌ **Recusado** | Você recusou; já saiu da lista |
+| ⏰ **Não respondeu (expirado)** | Passou 48h; o convite expirou |
+
+---
+
+## Antes de Aceitar: Verifique o Briefing
+
+O **briefing** é crucial — diz exatamente o que a empresa espera:
+
+**Exemplos de briefing:**
+- "Uniforme: camisa branca, calça preta, sapato social preto"
+- "Serviço de garcom. Trabalho de equipe. Pontos importantes: cumprimentar clientes, apresentar o cardápio"
+- "Funções: corte + finalização. Material será fornecido. Trazer pano pessoal"
+- "Importante: horário rigoroso. Check-in antecipado aos clientes"
+
+Se você **não puder** atender ao briefing, é melhor **recusar** logo.
+
+---
+
+## Cronograma: Antes, Durante, Depois
+
+```
+ANTES DO TURNO
+  - Você aceita convite (até 48h)
+  - Recebe confirmação (app + e-mail)
+  - Estuda o briefing
+  - Prepara uniforme/material
+
+DIA DO TURNO
+  - Você faz check-in (confirma presença)
+  - Trabalha
+  - Você faz check-out (confirma conclusão)
+
+APÓS O TURNO
+  - Empresa confirma conclusão
+  - Você é pago (Modo A = registra pagamento; Modo B/C = transferência)
+  - Você e empresa se avaliam (⭐ estrelas + comentário)
+```
+
+---
+
+## Perguntas Frequentes
+
+### P: Se recuso muito, me penaliza?
+
+R: **Não.** Recusar é uma escolha livre e neutra. A empresa não vê ranking de "aceitações". Você só é avaliado por comparecer aos que **aceita**.
+
+### P: Posso aceitar e depois cancelar?
+
+R: Não é o ideal, mas se for **antes do turno**, fale com a empresa (chat no app). Se for **no dia**, considere como faltar — pode afetar reputação. No turno aceito, você é esperado.
+
+### P: Vejo o briefing antes de aceitar?
+
+R: **Sim!** O briefing aparece logo no convite em destaque. Leia com cuidado antes de clicar "ACEITAR".
+
+### P: E se não entendo o briefing?
+
+R: Clique no **"Chat"** (mensagens) com a empresa e pergunte. Elas adoram esclarecer.
+
+### P: Consigo mudar de horário após aceitar?
+
+R: Fale com a empresa pelo chat. Se conseguirem outro freelancer, tudo bem; se não conseguirem, você segue comprometido.
+
+### P: Qual é a diferença entre "Novo convite" e "Aguardando"?
+
+R: "Novo" = acabou de chegar. "Aguardando" = você viu, mas não respondeu. Ambos têm prazo de 48h.
+
+### P: Se o convite expira, posso aceitar depois?
+
+R: Infelizmente não — expirado é expirado. Mas a empresa pode convidar de novo (você recebe novo convite com novo prazo).
+
+---
+
+## Dicas Importantes
+
+✅ **Faça:**
+- Responda rápido (não deixe pra última hora)
+- Leia o briefing com atenção
+- Se tiver dúvida, converse com a empresa
+- Cumpra o combinado (uniforme, horário, regras)
+- Faça check-in e check-out no app
+
+❌ **Não faça:**
+- Não ignore convites (acaba expirando e eles perdem o freelancer)
+- Não aceite se não puder comparecer
+- Não chegue atrasado no turno aceitado
+- Não ignore o briefing (uniforme errado, por ex., pode rejeitar seu trabalho)
+
+---
+
+## Suporte
+
+Dúvidas sobre um convite específico?
+- **Chat no app** com a empresa
+- **Suporte do Worki:** [suporte@worki.com]
+- **Horário:** Segunda a sexta, 9h–18h (horário de Brasília)

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -19,5 +19,11 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      // Article 5 do projeto: o padrão de dados canônico é useEffect + setState (fetch/reset
+      // on mount/open). A regra set-state-in-effect (recommended do react-hooks) conflita com
+      // esse padrão constitucional; mantida como AVISO (visível), não como erro que quebra o build.
+      'react-hooks/set-state-in-effect': 'warn',
+    },
   },
 ])

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "html5-qrcode": "^2.3.8",
         "lucide-react": "^0.562.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.0",
@@ -3721,6 +3722,12 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html5-qrcode": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/html5-qrcode/-/html5-qrcode-2.3.8.tgz",
+      "integrity": "sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "html5-qrcode": "^2.3.8",
     "lucide-react": "^0.562.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,6 +50,7 @@ const Help = lazy(() => import('./pages/Help'));
 const Notifications = lazy(() => import('./pages/Notifications'));
 const LandingPage = lazy(() => import('./pages/LandingPage'));
 const InviteAccept = lazy(() => import('./pages/InviteAccept'));
+const ReceiptView = lazy(() => import('./pages/ReceiptView'));
 
 // Loading Component - Skeleton placeholder
 const PageLoader = () => (
@@ -143,6 +144,9 @@ function App() {
 
                     {/* Convite de equipe via link (worker-facing, fora do MainLayout para tela dedicada) */}
                     <Route path="/convite/:token" element={<InviteAccept />} />
+
+                    {/* Recibo de pagamento (modo A) — cross-papel (empresa e freela), fora dos layouts para impressão limpa */}
+                    <Route path="/recibo/:jobId" element={<ReceiptView />} />
 
                     {/* Worker Layout Routes */}
                     <Route path="/" element={<MainLayout />}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ const Profile = lazy(() => import('./pages/Profile'));
 const Analytics = lazy(() => import('./pages/Analytics'));
 const MyJobs = lazy(() => import('./pages/MyJobs'));
 const Wallet = lazy(() => import('./pages/Wallet'));
+const CarteiraClientes = lazy(() => import('./pages/CarteiraClientes'));
 
 // Company Pages
 const CompanyCreateJob = lazy(() => import('./pages/company/CompanyCreateJob'));
@@ -155,6 +156,7 @@ function App() {
                       <Route path="my-jobs" element={<MyJobs />} />
                       <Route path="analytics" element={<Analytics />} />
                       <Route path="wallet" element={<Wallet />} />
+                      <Route path="carteira" element={<CarteiraClientes />} />
                       <Route path="profile" element={<Profile />} />
                       <Route path="messages" element={<Messages />} />
                       <Route path="notifications" element={<Notifications />} />

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,4 +1,4 @@
-import { Home, Briefcase, User, MessageSquare, Wallet, PlusCircle, Users } from 'lucide-react';
+import { Home, Briefcase, User, MessageSquare, Wallet, PlusCircle, Users, Contact } from 'lucide-react';
 import { NavLink } from 'react-router-dom';
 
 interface BottomNavProps {
@@ -10,13 +10,14 @@ export default function BottomNav({ type = 'worker' }: BottomNavProps) {
         { icon: Home, label: 'Início', path: '/dashboard' },
         { icon: Briefcase, label: 'Vagas', path: '/jobs' },
         { icon: Wallet, label: 'Carteira', path: '/wallet' },
+        { icon: Contact, label: 'Clientes', path: '/carteira' },
         { icon: MessageSquare, label: 'Msgs', path: '/messages' }, // Shortened label
         { icon: User, label: 'Perfil', path: '/profile' },
     ];
 
     const companyNavItems = [
         { icon: Home, label: 'Início', path: '/company/dashboard' },
-        { icon: Users, label: 'Equipe', path: '/company/team' },
+        { icon: Users, label: 'Elenco', path: '/company/team' },
         { icon: PlusCircle, label: 'Criar', path: '/company/create' },
         { icon: Wallet, label: 'Carteira', path: '/company/wallet' },
         { icon: User, label: 'Perfil', path: '/company/profile' },

--- a/frontend/src/components/InviteTakeover.tsx
+++ b/frontend/src/components/InviteTakeover.tsx
@@ -1,0 +1,202 @@
+/**
+ * InviteTakeover — aviso em tela cheia (dentro do app) quando o freela recebe
+ * um convite de turno (push, Slice 1).
+ *
+ * Reusa `useWorkerInvites` (mesma máquina de estados de `ShiftInviteService.respondToInvite`
+ * já usada em `MyJobs.tsx`) — não duplica lógica de aceite/recusa.
+ *
+ * Disparo: escuta `useNotifications()` (Realtime já existente no `NotificationContext`) e,
+ * ao detectar uma notificação NOVA de convite de turno, chama `refresh()` do hook de convites
+ * pendentes. O overlay some quando não há mais convites pendentes (não-dispensados) — seja
+ * porque o worker respondeu, seja porque ele fechou (X) o aviso.
+ *
+ * Fila: mostra um convite por vez (o mais recente não-dispensado); os demais aparecem em
+ * sequência conforme o atual é respondido/fechado. Escolha simples e documentada — não há
+ * fila persistida entre sessões.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { X, CheckCircle2, XCircle, Loader2, Building2, Clock, DollarSign, MapPin } from 'lucide-react';
+import { useWorkerInvites } from '../hooks/useShiftInvites';
+import { useNotifications } from '../contexts/NotificationContext';
+import type { Notification as AppNotification } from '../contexts/NotificationContext';
+
+// Deve espelhar o título usado em ShiftInviteService.inviteWorkerToShift (notificação in-app).
+const SHIFT_INVITE_NOTIFICATION_TITLE = 'Novo convite de turno';
+
+function isShiftInviteNotification(notification: AppNotification): boolean {
+  return notification.type === 'status_change' && notification.title === SHIFT_INVITE_NOTIFICATION_TITLE;
+}
+
+let hasRequestedBrowserPermission = false;
+
+/**
+ * "Push do app" leve e best-effort via Notification API do browser.
+ * NÃO é push mobile real (não sobrevive à aba fechada) nem WhatsApp/SMS.
+ * TODO: push mobile real (VAPID/service worker) e WhatsApp/SMS = infra gated, Slice 4.
+ */
+function maybeNotifyBrowser(title: string, body: string): void {
+  try {
+    if (typeof window === 'undefined' || !('Notification' in window)) return;
+
+    if (Notification.permission === 'granted') {
+      void new Notification(title, { body });
+      return;
+    }
+
+    if (Notification.permission === 'default' && !hasRequestedBrowserPermission) {
+      hasRequestedBrowserPermission = true;
+      void Notification.requestPermission();
+    }
+  } catch {
+    // Best-effort — nunca deve quebrar a UI do takeover.
+  }
+}
+
+export default function InviteTakeover() {
+  const { pendingInvites, loading, respondingId, respond, refresh } = useWorkerInvites();
+  const { notifications } = useNotifications();
+  const [dismissedIds, setDismissedIds] = useState<Set<string>>(new Set());
+  const seenNotifIdsRef = useRef<Set<string> | null>(null);
+
+  // Detecta notificações NOVAS (chegadas via Realtime após o mount) de convite de turno.
+  // Na primeira execução só registra o snapshot atual como "visto" — não dispara nada,
+  // evitando reabrir o takeover para convites antigos já presentes no histórico.
+  useEffect(() => {
+    if (seenNotifIdsRef.current === null) {
+      seenNotifIdsRef.current = new Set(notifications.map((n) => n.id));
+      return;
+    }
+
+    const seen = seenNotifIdsRef.current;
+    const freshOnes = notifications.filter((n) => !seen.has(n.id));
+    if (freshOnes.length === 0) return;
+    freshOnes.forEach((n) => seen.add(n.id));
+
+    const inviteNotif = freshOnes.find(isShiftInviteNotification);
+    if (inviteNotif) {
+      refresh();
+      maybeNotifyBrowser(
+        SHIFT_INVITE_NOTIFICATION_TITLE,
+        inviteNotif.message || 'Você recebeu um convite para um turno.',
+      );
+    }
+  }, [notifications, refresh]);
+
+  const visibleInvite = pendingInvites.find((invite) => !dismissedIds.has(invite.id));
+
+  if (loading || !visibleInvite) return null;
+
+  const job = visibleInvite.job;
+  const companyName = (job?.company as { name?: string } | undefined)?.name ?? 'Empresa';
+  const companyLogo = (job?.company as { logo_url?: string | null } | undefined)?.logo_url ?? null;
+  const jobTitle = job?.title ?? 'Turno';
+  const budget = job?.budget ?? 0;
+  const startDate = job?.start_date
+    ? new Date(job.start_date).toLocaleDateString('pt-BR')
+    : 'Data a definir';
+  const startTime = job?.work_start_time ?? '';
+  const endTime = job?.work_end_time ?? '';
+  const location = job?.location ?? 'Local a definir';
+  const briefing = job?.briefing || job?.description;
+  const isResponding = respondingId === visibleInvite.id;
+
+  const dismiss = () => {
+    setDismissedIds((prev) => {
+      const next = new Set(prev);
+      next.add(visibleInvite.id);
+      return next;
+    });
+  };
+
+  const handleRespond = async (response: 'accepted' | 'declined') => {
+    await respond(visibleInvite.id, response);
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] bg-black/70 backdrop-blur-sm flex items-center justify-center p-4 animate-in fade-in duration-200"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="invite-takeover-title"
+    >
+      <div className="relative bg-white rounded-2xl border-2 border-black shadow-[8px_8px_0px_0px_rgba(0,166,81,1)] w-full max-w-md p-6 max-h-[90vh] overflow-y-auto">
+        <button
+          type="button"
+          onClick={dismiss}
+          aria-label="Fechar aviso de convite"
+          className="absolute top-4 right-4 w-9 h-9 flex items-center justify-center rounded-xl border-2 border-black bg-white hover:bg-gray-100 transition-colors"
+        >
+          <X size={18} />
+        </button>
+
+        <span className="inline-block bg-primary-light text-primary text-xs font-black uppercase px-3 py-1.5 rounded-pill border border-green-200 mb-4">
+          Convite de turno
+        </span>
+
+        <div className="flex items-center gap-3 mb-4">
+          <div className="w-12 h-12 rounded-xl border-2 border-black overflow-hidden bg-gray-100 flex-shrink-0">
+            {companyLogo ? (
+              <img src={companyLogo} alt={companyName} className="w-full h-full object-cover" />
+            ) : (
+              <div className="w-full h-full flex items-center justify-center">
+                <Building2 size={22} className="text-gray-400" />
+              </div>
+            )}
+          </div>
+          <div>
+            <p className="text-xs font-bold uppercase text-gray-400">Empresa</p>
+            <p className="font-black uppercase">{companyName}</p>
+          </div>
+        </div>
+
+        <h2 id="invite-takeover-title" className="font-black text-2xl uppercase mb-3">
+          {jobTitle}
+        </h2>
+
+        <div className="flex flex-wrap gap-2 mb-4">
+          <span className="flex items-center gap-1.5 text-xs font-bold bg-gray-100 text-gray-600 px-3 py-1.5 rounded-xl">
+            <Clock size={14} /> {startDate}
+            {startTime ? ` · ${startTime}${endTime ? `–${endTime}` : ''}` : ''}
+          </span>
+          <span className="flex items-center gap-1.5 text-xs font-bold bg-primary-light text-primary px-3 py-1.5 rounded-xl">
+            <DollarSign size={14} /> R$ {budget.toFixed(2).replace('.', ',')}
+          </span>
+          {location && (
+            <span className="flex items-center gap-1.5 text-xs font-bold bg-blue-50 text-blue-700 px-3 py-1.5 rounded-xl">
+              <MapPin size={14} /> {location}
+            </span>
+          )}
+        </div>
+
+        {briefing && (
+          <div className="bg-gray-50 border-l-4 border-black rounded-r-xl p-3 mb-6">
+            <p className="text-xs font-bold uppercase text-gray-400 mb-1">Briefing</p>
+            <p className="text-sm font-medium text-gray-700 line-clamp-4">{briefing}</p>
+          </div>
+        )}
+
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={() => void handleRespond('accepted')}
+            disabled={isResponding}
+            className="flex-1 bg-primary hover:bg-black text-white px-6 py-3 rounded-xl font-black uppercase flex items-center justify-center gap-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isResponding ? <Loader2 className="animate-spin" size={18} /> : <CheckCircle2 size={18} />}
+            Aceitar
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleRespond('declined')}
+            disabled={isResponding}
+            className="flex-1 bg-white hover:bg-gray-50 text-gray-700 px-6 py-3 rounded-xl font-black uppercase border-2 border-gray-300 flex items-center justify-center gap-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <XCircle size={18} />
+            Recusar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Home, Briefcase, User, BarChart2, Wallet, FileText, Zap, PlusCircle, Building2, MessageSquare, LogOut, Users, TrendingDown } from 'lucide-react';
+import { Home, Briefcase, User, BarChart2, Wallet, FileText, Zap, PlusCircle, Building2, MessageSquare, LogOut, Users, TrendingDown, Contact } from 'lucide-react';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 import NotificationBell from './NotificationBell';
@@ -60,12 +60,13 @@ export default function Sidebar({ type = 'worker' }: SidebarProps) {
         { icon: MessageSquare, label: 'Mensagens', path: '/messages' },
         { icon: BarChart2, label: 'Analytics', path: '/analytics' },
         { icon: Wallet, label: 'Carteira', path: '/wallet' },
+        { icon: Contact, label: 'Carteira de Clientes', path: '/carteira' },
         { icon: User, label: 'Meu Perfil', path: '/profile' },
     ];
 
     const companyNavItems = [
         { icon: Home, label: 'Dashboard', path: '/company/dashboard' },
-        { icon: Users, label: 'Minha Equipe', path: '/company/team' },
+        { icon: Users, label: 'Meu Elenco', path: '/company/team' },
         { icon: PlusCircle, label: 'Criar Vaga', path: '/company/create' },
         { icon: Briefcase, label: 'Minhas Vagas', path: '/company/jobs' },
         { icon: MessageSquare, label: 'Mensagens', path: '/company/messages' },

--- a/frontend/src/components/__tests__/BottomNav.test.tsx
+++ b/frontend/src/components/__tests__/BottomNav.test.tsx
@@ -18,6 +18,7 @@ describe('BottomNav', () => {
     expect(screen.getByLabelText('Início')).toBeInTheDocument()
     expect(screen.getByLabelText('Vagas')).toBeInTheDocument()
     expect(screen.getByLabelText('Carteira')).toBeInTheDocument()
+    expect(screen.getByLabelText('Clientes')).toBeInTheDocument()
     expect(screen.getByLabelText('Msgs')).toBeInTheDocument()
     expect(screen.getByLabelText('Perfil')).toBeInTheDocument()
   })
@@ -26,18 +27,18 @@ describe('BottomNav', () => {
     renderBottomNav('company', '/company/dashboard')
 
     expect(screen.getByLabelText('Início')).toBeInTheDocument()
-    expect(screen.getByLabelText('Vagas')).toBeInTheDocument()
+    expect(screen.getByLabelText('Elenco')).toBeInTheDocument()
     expect(screen.getByLabelText('Criar')).toBeInTheDocument()
     expect(screen.getByLabelText('Carteira')).toBeInTheDocument()
     expect(screen.getByLabelText('Perfil')).toBeInTheDocument()
   })
 
-  it('worker tem 5 itens de navegacao', () => {
+  it('worker tem 6 itens de navegacao', () => {
     renderBottomNav('worker')
 
     const nav = screen.getByLabelText('Menu de navegacao')
     const links = nav.querySelectorAll('a')
-    expect(links).toHaveLength(5)
+    expect(links).toHaveLength(6)
   })
 
   it('company tem 5 itens de navegacao', () => {
@@ -54,6 +55,7 @@ describe('BottomNav', () => {
     expect(screen.getByLabelText('Início')).toHaveAttribute('href', '/dashboard')
     expect(screen.getByLabelText('Vagas')).toHaveAttribute('href', '/jobs')
     expect(screen.getByLabelText('Carteira')).toHaveAttribute('href', '/wallet')
+    expect(screen.getByLabelText('Clientes')).toHaveAttribute('href', '/carteira')
     expect(screen.getByLabelText('Perfil')).toHaveAttribute('href', '/profile')
   })
 
@@ -61,7 +63,7 @@ describe('BottomNav', () => {
     renderBottomNav('company', '/company/dashboard')
 
     expect(screen.getByLabelText('Início')).toHaveAttribute('href', '/company/dashboard')
-    expect(screen.getByLabelText('Vagas')).toHaveAttribute('href', '/company/jobs')
+    expect(screen.getByLabelText('Elenco')).toHaveAttribute('href', '/company/team')
     expect(screen.getByLabelText('Criar')).toHaveAttribute('href', '/company/create')
     expect(screen.getByLabelText('Carteira')).toHaveAttribute('href', '/company/wallet')
     expect(screen.getByLabelText('Perfil')).toHaveAttribute('href', '/company/profile')
@@ -84,9 +86,9 @@ describe('BottomNav', () => {
   })
 
   it('destaca rota ativa para company', () => {
-    renderBottomNav('company', '/company/jobs')
+    renderBottomNav('company', '/company/team')
 
-    const activeLink = screen.getByLabelText('Vagas')
+    const activeLink = screen.getByLabelText('Elenco')
     expect(activeLink.className).toContain('text-blue-600')
 
     const inactiveLink = screen.getByLabelText('Início')

--- a/frontend/src/components/__tests__/DepositModal.test.tsx
+++ b/frontend/src/components/__tests__/DepositModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import DepositModal from '../DepositModal'
 
 const mockAddToast = vi.fn()
@@ -11,6 +11,15 @@ vi.mock('../../contexts/ToastContext', () => ({
 vi.mock('../../services/walletService', () => ({
   WalletService: {
     createDeposit: vi.fn(),
+  },
+}))
+
+vi.mock('../../lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
+    },
+    from: vi.fn(),
   },
 }))
 
@@ -28,56 +37,44 @@ describe('DepositModal', () => {
   it('renderiza formulario de deposito quando aberto', () => {
     render(<DepositModal {...defaultProps} />)
 
-    expect(screen.getByText('Adicionar Créditos')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('0.00')).toBeInTheDocument()
-    expect(screen.getByText('Gerar Fatura (PIX, Boleto ou Cartão)')).toBeInTheDocument()
+    expect(screen.getByText('Adicionar creditos')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('50,00')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Pagar R\$/ })).toBeInTheDocument()
   })
 
   it('nao renderiza quando isOpen=false', () => {
     render(<DepositModal {...defaultProps} isOpen={false} />)
 
-    expect(screen.queryByText('Adicionar Créditos')).not.toBeInTheDocument()
-    expect(screen.queryByPlaceholderText('0.00')).not.toBeInTheDocument()
+    expect(screen.queryByText('Adicionar creditos')).not.toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('50,00')).not.toBeInTheDocument()
   })
 
-  it('valida valor minimo de deposito (deve ser maior que 0)', async () => {
+  it('exibe aviso e mantem botao desabilitado para valor abaixo do minimo (R$ 50)', () => {
     render(<DepositModal {...defaultProps} />)
 
-    const input = screen.getByPlaceholderText('0.00')
+    const input = screen.getByPlaceholderText('50,00')
     fireEvent.change(input, { target: { value: '2' } })
 
-    const button = screen.getByText('Gerar Fatura (PIX, Boleto ou Cartão)')
-    fireEvent.click(button)
+    expect(screen.getByText('Minimo R$ 50,00')).toBeInTheDocument()
 
-    await waitFor(() => {
-      expect(mockAddToast).toHaveBeenCalledWith(
-        'O valor mínimo para depósito é R$ 5,00',
-        'error'
-      )
-    })
+    const button = screen.getByRole('button', { name: /Pagar R\$/ })
+    expect(button).toBeDisabled()
   })
 
-  it('valida valor maximo de deposito', async () => {
+  it('mantem botao desabilitado para valor acima do maximo (R$ 50.000)', () => {
     render(<DepositModal {...defaultProps} />)
 
-    const input = screen.getByPlaceholderText('0.00')
+    const input = screen.getByPlaceholderText('50,00')
     fireEvent.change(input, { target: { value: '60000' } })
 
-    const button = screen.getByText('Gerar Fatura (PIX, Boleto ou Cartão)')
-    fireEvent.click(button)
-
-    await waitFor(() => {
-      expect(mockAddToast).toHaveBeenCalledWith(
-        'O valor máximo para depósito é R$ 50.000,00',
-        'error'
-      )
-    })
+    const button = screen.getByRole('button', { name: /Pagar R\$/ })
+    expect(button).toBeDisabled()
   })
 
   it('botao desabilitado quando campo valor esta vazio', () => {
     render(<DepositModal {...defaultProps} />)
 
-    const button = screen.getByText('Gerar Fatura (PIX, Boleto ou Cartão)')
+    const button = screen.getByRole('button', { name: /Pagar R\$/ })
     expect(button).toBeDisabled()
   })
 })

--- a/frontend/src/hooks/useTeamConnections.ts
+++ b/frontend/src/hooks/useTeamConnections.ts
@@ -107,7 +107,7 @@ export function useCompanyTeam(): UseCompanyTeamResult {
       const result = await TeamConnectionService.addToTeam(workerId, source);
 
       if (result.alreadyExists) {
-        addToast('Este freela já está na sua equipe.', 'info');
+        addToast('Este freela já está no seu elenco.', 'info');
         return true;
       }
       if (result.error) {
@@ -115,7 +115,7 @@ export function useCompanyTeam(): UseCompanyTeamResult {
         return false;
       }
 
-      addToast('Convite de equipe enviado! Aguardando aceite do freela.', 'success');
+      addToast('Convite de elenco enviado! Aguardando aceite do freela.', 'success');
       load();
       return true;
     },
@@ -204,7 +204,7 @@ export function useWorkerStores(): UseWorkerStoresResult {
         addToast(result.error, 'error');
         return false;
       }
-      addToast('Você agora faz parte da equipe!', 'success');
+      addToast('Você agora faz parte do elenco!', 'success');
       load();
       return true;
     },

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -4,6 +4,7 @@ import { supabase } from '../lib/supabase';
 import Sidebar from '../components/Sidebar';
 import BottomNav from '../components/BottomNav';
 import NotificationBell from '../components/NotificationBell';
+import InviteTakeover from '../components/InviteTakeover';
 
 export default function MainLayout() {
     const navigate = useNavigate();
@@ -67,6 +68,9 @@ export default function MainLayout() {
 
     return (
         <div className="min-h-screen flex flex-col md:flex-row max-w-7xl mx-auto">
+            {/* Aviso em tela cheia de convite de turno (worker only) */}
+            <InviteTakeover />
+
             {/* Desktop Sidebar */}
             <Sidebar />
 

--- a/frontend/src/pages/CarteiraClientes.tsx
+++ b/frontend/src/pages/CarteiraClientes.tsx
@@ -1,0 +1,268 @@
+import { useState } from 'react';
+import { Building2, Star, MapPin, CheckCircle2, XCircle, Loader2, Users, Clock, LogOut } from 'lucide-react';
+import PageMeta from '../components/PageMeta';
+import { useWorkerStores } from '../hooks/useTeamConnections';
+import type { MyStore, TeamConnection } from '../types';
+
+// ---------------------------------------------------------------------------
+// Subcomponent: card de loja/cliente aceito
+// ---------------------------------------------------------------------------
+
+interface StoreCardProps {
+  store: MyStore;
+  onLeave: (connectionId: string) => void;
+  leaving: boolean;
+}
+
+function StoreCard({ store, onLeave, leaving }: StoreCardProps) {
+  const { company, connection } = store;
+  const name = company.name ?? 'Empresa';
+
+  return (
+    <div className="bg-white border-2 border-black rounded-2xl p-5 flex items-start gap-4 hover:shadow-[6px_6px_0px_0px_rgba(0,166,81,1)] hover:-translate-y-1 transition-all">
+      {/* Logo */}
+      <div className="w-14 h-14 rounded-xl border-2 border-black overflow-hidden bg-gray-100 flex-shrink-0">
+        {company.logo_url ? (
+          <img src={company.logo_url} alt={name} className="w-full h-full object-cover" />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center bg-black text-white font-black text-xl">
+            {name[0]?.toUpperCase() ?? '?'}
+          </div>
+        )}
+      </div>
+
+      {/* Info */}
+      <div className="flex-1 min-w-0">
+        <h3 className="font-black uppercase text-base truncate">{name}</h3>
+        {company.industry && (
+          <p className="text-sm font-bold text-gray-500 uppercase truncate">{company.industry}</p>
+        )}
+        <div className="flex flex-wrap gap-2 mt-2">
+          {typeof company.rating_average === 'number' && (
+            <span className="flex items-center gap-1 text-xs font-bold bg-yellow-50 text-yellow-700 px-2 py-1 rounded-xl border border-yellow-200">
+              <Star size={12} fill="currentColor" /> {company.rating_average.toFixed(1)}
+              {typeof company.reviews_count === 'number' && ` (${company.reviews_count})`}
+            </span>
+          )}
+          {company.address && (
+            <span className="flex items-center gap-1 text-xs font-bold bg-blue-50 text-blue-700 px-2 py-1 rounded-xl">
+              <MapPin size={12} /> {company.address}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Ação: sair/bloquear */}
+      <button
+        onClick={() => onLeave(connection.id)}
+        disabled={leaving}
+        aria-label={`Sair do cliente ${name}`}
+        title="Sair / bloquear cliente"
+        className="flex-shrink-0 p-2 rounded-xl text-gray-400 hover:text-red-600 hover:bg-red-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {leaving ? <Loader2 className="animate-spin" size={20} /> : <LogOut size={20} />}
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Subcomponent: card de convite pendente
+// ---------------------------------------------------------------------------
+
+interface PendingCardProps {
+  connection: TeamConnection;
+  onAccept: (connectionId: string) => void;
+  onDecline: (connectionId: string) => void;
+  respondingId: string | null;
+}
+
+function PendingCard({ connection, onAccept, onDecline, respondingId }: PendingCardProps) {
+  const company = connection.company;
+  const name = company?.name ?? 'Empresa';
+  const isResponding = respondingId === connection.id;
+
+  return (
+    <div className="bg-white border-2 border-black rounded-2xl p-5 shadow-[4px_4px_0px_0px_rgba(0,166,81,1)]">
+      <div className="flex items-center gap-3 mb-4">
+        <div className="w-10 h-10 rounded-xl border-2 border-black overflow-hidden bg-gray-100 flex-shrink-0">
+          {company?.logo_url ? (
+            <img src={company.logo_url} alt={name} className="w-full h-full object-cover" />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center">
+              <Building2 size={20} className="text-gray-400" />
+            </div>
+          )}
+        </div>
+        <div className="min-w-0">
+          <p className="text-xs font-bold uppercase text-gray-400">Convite de</p>
+          <p className="font-black uppercase truncate">{name}</p>
+        </div>
+        <span className="ml-auto flex-shrink-0 bg-primary-light text-primary text-xs font-black uppercase px-2 py-1 rounded-xl border border-green-200">
+          Novo
+        </span>
+      </div>
+
+      <div className="flex gap-3">
+        <button
+          onClick={() => onAccept(connection.id)}
+          disabled={isResponding}
+          className="flex-1 bg-primary hover:bg-black text-white px-6 py-3 rounded-xl font-black uppercase flex items-center justify-center gap-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isResponding ? <Loader2 className="animate-spin" size={18} /> : <CheckCircle2 size={18} />}
+          Aceitar
+        </button>
+        <button
+          onClick={() => onDecline(connection.id)}
+          disabled={isResponding}
+          className="flex-1 bg-white hover:bg-gray-50 text-gray-700 px-6 py-3 rounded-xl font-black uppercase border-2 border-gray-300 flex items-center justify-center gap-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isResponding ? <Loader2 className="animate-spin" size={18} /> : <XCircle size={18} />}
+          Recusar
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Página principal: CarteiraClientes
+// ---------------------------------------------------------------------------
+
+export default function CarteiraClientes() {
+  const { myStores, pendingConnections, loading, acceptConnection, blockConnection } = useWorkerStores();
+  const [respondingId, setRespondingId] = useState<string | null>(null);
+  const [confirmLeaveId, setConfirmLeaveId] = useState<string | null>(null);
+
+  const handleAccept = async (connectionId: string) => {
+    setRespondingId(connectionId);
+    await acceptConnection(connectionId);
+    setRespondingId(null);
+  };
+
+  const handleDecline = async (connectionId: string) => {
+    setRespondingId(connectionId);
+    await blockConnection(connectionId);
+    setRespondingId(null);
+  };
+
+  const handleConfirmLeave = async () => {
+    if (!confirmLeaveId) return;
+    const id = confirmLeaveId;
+    setConfirmLeaveId(null);
+    setRespondingId(id);
+    await blockConnection(id);
+    setRespondingId(null);
+  };
+
+  if (loading) {
+    return (
+      <div className="max-w-4xl mx-auto space-y-6 animate-pulse pb-24">
+        <div className="h-10 bg-gray-200 rounded-xl w-64" />
+        <div className="space-y-4">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="h-24 bg-gray-200 rounded-2xl" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const isEmpty = myStores.length === 0 && pendingConnections.length === 0;
+
+  return (
+    <div className="max-w-4xl mx-auto pb-24 font-sans text-accent animate-in fade-in slide-in-from-bottom-4 duration-400">
+      <PageMeta
+        title="Carteira de Clientes"
+        description="Acompanhe os clientes que fazem parte da sua carteira e responda a convites de novas empresas."
+      />
+
+      {/* Header */}
+      <header className="mb-8">
+        <h1 className="text-4xl font-black uppercase tracking-tighter">Carteira de Clientes</h1>
+        <p className="text-gray-500 font-bold mt-1">
+          {myStores.length} cliente{myStores.length !== 1 ? 's' : ''}
+          {pendingConnections.length > 0 && (
+            <span className="ml-2 text-yellow-600">· {pendingConnections.length} convite{pendingConnections.length !== 1 ? 's' : ''} pendente{pendingConnections.length !== 1 ? 's' : ''}</span>
+          )}
+        </p>
+      </header>
+
+      {/* Convites pendentes */}
+      {pendingConnections.length > 0 && (
+        <section className="mb-8">
+          <h2 className="text-xl font-black uppercase mb-4 flex items-center gap-2 text-yellow-700">
+            <Clock size={20} /> Convites Pendentes
+          </h2>
+          <div className="grid grid-cols-1 gap-4">
+            {pendingConnections.map((conn) => (
+              <PendingCard
+                key={conn.id}
+                connection={conn}
+                onAccept={handleAccept}
+                onDecline={handleDecline}
+                respondingId={respondingId}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Clientes aceitos */}
+      {myStores.length > 0 && (
+        <section className="mb-8">
+          <h2 className="text-xl font-black uppercase mb-4 flex items-center gap-2">
+            <Users size={20} /> Meus Clientes
+          </h2>
+          <div className="grid grid-cols-1 gap-4">
+            {myStores.map((store) => (
+              <StoreCard
+                key={store.connection.id}
+                store={store}
+                onLeave={setConfirmLeaveId}
+                leaving={respondingId === store.connection.id}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Empty state */}
+      {isEmpty && (
+        <div className="text-center py-20 border-2 border-dashed border-gray-200 rounded-2xl bg-gray-50">
+          <Users size={48} className="mx-auto mb-4 text-gray-300" />
+          <h3 className="text-xl font-black uppercase mb-2">Você ainda não tem clientes</h3>
+          <p className="text-gray-500 font-bold max-w-sm mx-auto">
+            Aceite um convite de uma empresa ou compartilhe seu link de perfil para começar a construir sua carteira de clientes.
+          </p>
+        </div>
+      )}
+
+      {/* Modal de confirmação: sair/bloquear */}
+      {confirmLeaveId && (
+        <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 animate-in fade-in duration-200">
+          <div className="bg-white rounded-2xl border-2 border-black shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] w-full max-w-sm p-6">
+            <h3 className="text-xl font-black uppercase mb-2">Sair deste cliente?</h3>
+            <p className="text-sm font-bold text-gray-500 mb-6">
+              Você não fará mais parte da carteira dessa empresa. Esta ação não pode ser desfeita.
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setConfirmLeaveId(null)}
+                className="flex-1 px-4 py-3 rounded-xl border-2 border-black font-black uppercase text-sm hover:bg-gray-100 transition-colors"
+              >
+                Voltar
+              </button>
+              <button
+                onClick={handleConfirmLeave}
+                className="flex-1 px-4 py-3 rounded-xl bg-red-600 hover:bg-red-700 text-white font-black uppercase text-sm transition-colors"
+              >
+                Sair
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/CarteiraClientes.tsx
+++ b/frontend/src/pages/CarteiraClientes.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
-import { Building2, Star, MapPin, CheckCircle2, XCircle, Loader2, Users, Clock, LogOut } from 'lucide-react';
+import { Building2, Star, MapPin, CheckCircle2, XCircle, Loader2, Users, Clock, LogOut, Share2, Check } from 'lucide-react';
 import PageMeta from '../components/PageMeta';
 import { useWorkerStores } from '../hooks/useTeamConnections';
+import { useToast } from '../contexts/ToastContext';
+import { TeamConnectionService } from '../services/teamConnectionService';
 import type { MyStore, TeamConnection } from '../types';
 
 // ---------------------------------------------------------------------------
@@ -17,6 +19,24 @@ interface StoreCardProps {
 function StoreCard({ store, onLeave, leaving }: StoreCardProps) {
   const { company, connection } = store;
   const name = company.name ?? 'Empresa';
+  const { addToast } = useToast();
+  const [linkCopied, setLinkCopied] = useState(false);
+
+  // Link transitivo: já sou conectado a essa empresa → posso repassar o link
+  // dela pra outro freela se conectar, sem precisar pedir à empresa.
+  const handleShareLink = async () => {
+    // `connection.company_id` é a FK garantida (não-nula); `company.id` no
+    // embed é opcional no tipo (CompanyProfile.id?), então preferimos a FK.
+    const { url } = TeamConnectionService.generateInviteToken(connection.company_id);
+    try {
+      await navigator.clipboard.writeText(url);
+      setLinkCopied(true);
+      addToast('Link da empresa copiado! Repasse para outro freela.', 'success');
+      setTimeout(() => setLinkCopied(false), 2500);
+    } catch {
+      addToast('Não foi possível copiar o link.', 'error');
+    }
+  };
 
   return (
     <div className="bg-white border-2 border-black rounded-2xl p-5 flex items-start gap-4 hover:shadow-[6px_6px_0px_0px_rgba(0,166,81,1)] hover:-translate-y-1 transition-all">
@@ -52,16 +72,26 @@ function StoreCard({ store, onLeave, leaving }: StoreCardProps) {
         </div>
       </div>
 
-      {/* Ação: sair/bloquear */}
-      <button
-        onClick={() => onLeave(connection.id)}
-        disabled={leaving}
-        aria-label={`Sair do cliente ${name}`}
-        title="Sair / bloquear cliente"
-        className="flex-shrink-0 p-2 rounded-xl text-gray-400 hover:text-red-600 hover:bg-red-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-      >
-        {leaving ? <Loader2 className="animate-spin" size={20} /> : <LogOut size={20} />}
-      </button>
+      {/* Ações: repassar link / sair-bloquear */}
+      <div className="flex flex-col gap-1 flex-shrink-0">
+        <button
+          onClick={handleShareLink}
+          aria-label={`Repassar link da empresa ${name}`}
+          title="Repassar link desta empresa para outro freela"
+          className="p-2 rounded-xl text-gray-400 hover:text-primary hover:bg-primary-light transition-colors"
+        >
+          {linkCopied ? <Check size={20} /> : <Share2 size={20} />}
+        </button>
+        <button
+          onClick={() => onLeave(connection.id)}
+          disabled={leaving}
+          aria-label={`Sair do cliente ${name}`}
+          title="Sair / bloquear cliente"
+          className="p-2 rounded-xl text-gray-400 hover:text-red-600 hover:bg-red-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {leaving ? <Loader2 className="animate-spin" size={20} /> : <LogOut size={20} />}
+        </button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/InviteAccept.tsx
+++ b/frontend/src/pages/InviteAccept.tsx
@@ -1,26 +1,31 @@
 /**
- * InviteAccept — página de aceite de convite de equipe via link (Slice 1, R1-b).
+ * InviteAccept — página de aceite de convite de equipe via link (Slice 1, R1-b)
+ * + link transitivo de contato (R-transitivo).
  *
- * Rota: /convite/:token  (worker-facing, sob ProtectedRoute)
- * Fluxo:
- *   1. Lê :token da URL.
- *   2. Chama TeamConnectionService.addToTeamByToken(token) (deriva workerId da sessão).
- *   3. Exibe loading / sucesso / erro no design neo-brutalista.
- *   4. Em sucesso, navega para /my-jobs (tela de equipes/convites do worker).
+ * Rota: /convite/:token  (sob ProtectedRoute, aberta para worker OU empresa)
+ *
+ * Duas direções, distinguidas pelo prefixo do token (ver teamConnectionService):
+ *   - Token de EMPRESA (sem prefixo): quem abre precisa estar logado como WORKER.
+ *     Chama `addToTeamByToken` (deriva workerId da sessão, empresa vem do token).
+ *   - Token de WORKER (prefixo `w_`): quem abre precisa estar logado como EMPRESA.
+ *     Chama `addWorkerToTeamByToken` (deriva companyId da sessão, worker vem do token).
+ *     Esse é o link "transitivo": uma empresa que já tem o worker no elenco pode
+ *     repassar o MESMO link a outra empresa, sem precisar pedir ao worker de novo.
  *
  * TODO (v1.1): implementar redirect pós-login para retornar a esta URL quando o
- * worker ainda não está autenticado (ProtectedRoute redireciona para / que redireciona
+ * usuário ainda não está autenticado (ProtectedRoute redireciona para / que redireciona
  * para /login; o token é perdido). Sugestão: passar ?redirect=/convite/<token> ao login.
  */
 
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { CheckCircle2, XCircle, Loader2, Building2, ArrowRight } from 'lucide-react';
+import { CheckCircle2, XCircle, Loader2, Building2, User, ArrowRight } from 'lucide-react';
 import { TeamConnectionService } from '../services/teamConnectionService';
 import { logError } from '../lib/logger';
 import PageMeta from '../components/PageMeta';
 
 type PageState = 'loading' | 'success' | 'already_exists' | 'error';
+type InviteDirection = 'company' | 'worker';
 
 interface PageData {
   state: PageState;
@@ -32,6 +37,13 @@ export default function InviteAccept() {
   const navigate = useNavigate();
   const [page, setPage] = useState<PageData>({ state: 'loading' });
 
+  // Direção do convite é conhecida só pelo prefixo do token — não depende de rede.
+  const direction: InviteDirection = token && TeamConnectionService.isWorkerInviteToken(token)
+    ? 'worker'
+    : 'company';
+  const redirectTo = direction === 'worker' ? '/company/team' : '/my-jobs';
+  const redirectLabel = direction === 'worker' ? 'Ver Meu Elenco' : 'Ver Meus Jobs';
+
   useEffect(() => {
     let active = true;
 
@@ -42,7 +54,9 @@ export default function InviteAccept() {
       }
 
       try {
-        const result = await TeamConnectionService.addToTeamByToken(token);
+        const result = TeamConnectionService.isWorkerInviteToken(token)
+          ? await TeamConnectionService.addWorkerToTeamByToken(token)
+          : await TeamConnectionService.addToTeamByToken(token);
 
         if (!active) return;
 
@@ -69,6 +83,15 @@ export default function InviteAccept() {
     return () => { active = false; };
   }, [token]);
 
+  const successTitle = direction === 'worker' ? 'Freela Adicionado!' : 'Convite Aceito!';
+  const successBody = direction === 'worker'
+    ? 'O freela do link entrou (pendente de aceite dele) no seu elenco. Assim que ele confirmar, você poderá convidá-lo para turnos.'
+    : 'Você entrou para o elenco da empresa. Agora pode receber convites de turno diretamente.';
+  const alreadyTitle = direction === 'worker' ? 'Já está no seu elenco' : 'Você já está no elenco';
+  const alreadyBody = direction === 'worker'
+    ? 'Esse freela já tem uma conexão com a sua empresa. Não é necessário repetir.'
+    : 'Você já tem uma conexão com esta empresa. Não é necessário aceitar novamente.';
+
   return (
     <div className="min-h-screen bg-[#F4F4F0] flex items-center justify-center p-4">
       <PageMeta
@@ -81,7 +104,11 @@ export default function InviteAccept() {
         {page.state === 'loading' && (
           <div className="bg-white border-2 border-black rounded-2xl shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] p-8 text-center">
             <div className="w-16 h-16 bg-primary-light border-2 border-black rounded-2xl flex items-center justify-center mx-auto mb-6">
-              <Building2 size={32} className="text-primary" />
+              {direction === 'worker' ? (
+                <User size={32} className="text-primary" />
+              ) : (
+                <Building2 size={32} className="text-primary" />
+              )}
             </div>
             <h1 className="text-2xl font-black uppercase tracking-tighter mb-2">
               Convite de Elenco
@@ -104,16 +131,16 @@ export default function InviteAccept() {
               <CheckCircle2 size={32} className="text-white" />
             </div>
             <h1 className="text-2xl font-black uppercase tracking-tighter mb-2">
-              Convite Aceito!
+              {successTitle}
             </h1>
             <p className="text-gray-600 font-bold mb-8">
-              Você entrou para o elenco da empresa. Agora pode receber convites de turno diretamente.
+              {successBody}
             </p>
             <button
-              onClick={() => navigate('/my-jobs')}
+              onClick={() => navigate(redirectTo)}
               className="w-full bg-primary hover:bg-black text-white px-6 py-3 rounded-xl font-black uppercase transition-colors flex items-center justify-center gap-2"
             >
-              Ver Meus Jobs
+              {redirectLabel}
               <ArrowRight size={18} />
             </button>
           </div>
@@ -126,16 +153,16 @@ export default function InviteAccept() {
               <CheckCircle2 size={32} className="text-primary" />
             </div>
             <h1 className="text-2xl font-black uppercase tracking-tighter mb-2">
-              Você já está no elenco
+              {alreadyTitle}
             </h1>
             <p className="text-gray-600 font-bold mb-8">
-              Você já tem uma conexão com esta empresa. Não é necessário aceitar novamente.
+              {alreadyBody}
             </p>
             <button
-              onClick={() => navigate('/my-jobs')}
+              onClick={() => navigate(redirectTo)}
               className="w-full bg-primary hover:bg-black text-white px-6 py-3 rounded-xl font-black uppercase transition-colors flex items-center justify-center gap-2"
             >
-              Ver Meus Jobs
+              {redirectLabel}
               <ArrowRight size={18} />
             </button>
           </div>
@@ -154,13 +181,15 @@ export default function InviteAccept() {
               {page.errorMsg ?? 'Não foi possível processar este convite.'}
             </p>
             <p className="text-sm text-gray-400 font-medium mb-8">
-              Peça à empresa um novo link de convite.
+              {direction === 'worker'
+                ? 'Este link só pode ser aberto por uma conta de empresa.'
+                : 'Peça à empresa um novo link de convite.'}
             </p>
             <button
-              onClick={() => navigate('/my-jobs')}
+              onClick={() => navigate(redirectTo)}
               className="w-full bg-black hover:bg-primary text-white px-6 py-3 rounded-xl font-black uppercase transition-colors flex items-center justify-center gap-2"
             >
-              Ir para Meus Jobs
+              {redirectLabel}
               <ArrowRight size={18} />
             </button>
           </div>

--- a/frontend/src/pages/InviteAccept.tsx
+++ b/frontend/src/pages/InviteAccept.tsx
@@ -72,8 +72,8 @@ export default function InviteAccept() {
   return (
     <div className="min-h-screen bg-[#F4F4F0] flex items-center justify-center p-4">
       <PageMeta
-        title="Convite de Equipe"
-        description="Aceite o convite para entrar na equipe de uma empresa no Worki."
+        title="Convite de Elenco"
+        description="Aceite o convite para entrar no elenco de uma empresa no Worki."
       />
 
       <div className="w-full max-w-md">
@@ -84,7 +84,7 @@ export default function InviteAccept() {
               <Building2 size={32} className="text-primary" />
             </div>
             <h1 className="text-2xl font-black uppercase tracking-tighter mb-2">
-              Convite de Equipe
+              Convite de Elenco
             </h1>
             <div className="flex items-center justify-center gap-3 text-gray-500 mt-6">
               <Loader2 className="animate-spin text-primary" size={24} />
@@ -107,7 +107,7 @@ export default function InviteAccept() {
               Convite Aceito!
             </h1>
             <p className="text-gray-600 font-bold mb-8">
-              Você entrou para a equipe da empresa. Agora pode receber convites de turno diretamente.
+              Você entrou para o elenco da empresa. Agora pode receber convites de turno diretamente.
             </p>
             <button
               onClick={() => navigate('/my-jobs')}
@@ -126,7 +126,7 @@ export default function InviteAccept() {
               <CheckCircle2 size={32} className="text-primary" />
             </div>
             <h1 className="text-2xl font-black uppercase tracking-tighter mb-2">
-              Você já está na equipe
+              Você já está no elenco
             </h1>
             <p className="text-gray-600 font-bold mb-8">
               Você já tem uma conexão com esta empresa. Não é necessário aceitar novamente.

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,12 +1,13 @@
 
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { supabase } from '../lib/supabase';
-import { User, MapPin, Briefcase, Star, ShieldCheck, Phone, Edit2, Loader2, Award, Save, X, Camera, CreditCard, Lock, QrCode } from 'lucide-react';
+import { User, MapPin, Briefcase, Star, ShieldCheck, Phone, Edit2, Loader2, Award, Save, X, Camera, CreditCard, Lock, QrCode, Copy, Check } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useToast } from '../contexts/ToastContext';
 import { getPasswordStrength } from '../lib/validation';
 import { logError } from '../lib/logger';
 import { QRCodeSVG } from 'qrcode.react';
+import { TeamConnectionService } from '../services/teamConnectionService';
 
 interface WorkerProfile {
     id: string;
@@ -113,9 +114,23 @@ export default function Profile() {
     const [deleteConfirmText, setDeleteConfirmText] = useState('');
     const [deleting, setDeleting] = useState(false);
 
-    // QR de identidade
+    // QR de identidade + "meu link" (link transitivo)
     const [qrModalOpen, setQrModalOpen] = useState(false);
     const [workerId, setWorkerId] = useState<string | null>(null);
+    const [linkCopied, setLinkCopied] = useState(false);
+
+    const handleCopyMyLink = useCallback(async () => {
+        if (!workerId) return;
+        const { url } = TeamConnectionService.generateWorkerInviteToken(workerId);
+        try {
+            await navigator.clipboard.writeText(url);
+            setLinkCopied(true);
+            addToast('Link copiado! Envie para uma empresa te adicionar ao elenco.', 'success');
+            setTimeout(() => setLinkCopied(false), 2500);
+        } catch {
+            addToast('Não foi possível copiar o link.', 'error');
+        }
+    }, [workerId, addToast]);
 
     useEffect(() => {
         const fetchProfile = async () => {
@@ -694,9 +709,15 @@ export default function Profile() {
                         <p className="text-xs font-bold uppercase text-gray-400 mb-1">Worki ID</p>
                         <p className="font-mono text-xs font-bold text-gray-700 break-all">{workerId}</p>
                     </div>
-                    {/* TODO v1.1: scanner de câmera para empresa ler o QR diretamente no app */}
+                    <button
+                        onClick={handleCopyMyLink}
+                        className="w-full bg-black hover:bg-primary text-white px-6 py-3 rounded-xl font-black uppercase text-sm flex items-center justify-center gap-2 transition-colors"
+                    >
+                        {linkCopied ? <Check size={18} /> : <Copy size={18} />}
+                        {linkCopied ? 'Link copiado!' : 'Copiar meu link'}
+                    </button>
                     <p className="text-xs text-gray-400 text-center mt-3 font-bold">
-                        Scanner por câmera (empresa lê aqui) disponível na v1.1.
+                        Envie este link direto (WhatsApp, etc.) para uma empresa te adicionar ao elenco sem precisar do QR.
                     </p>
                 </div>
             </div>

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -678,7 +678,7 @@ export default function Profile() {
                         </button>
                     </div>
                     <p className="text-sm font-bold text-gray-600 mb-5 text-center">
-                        Mostre este QR para uma empresa te adicionar à equipe. Cada scan é único para você.
+                        Mostre este QR para uma empresa te adicionar ao elenco dela. Cada scan é único para você.
                     </p>
                     <div className="flex justify-center mb-5">
                         <div className="p-4 border-2 border-black rounded-2xl bg-white shadow-[4px_4px_0px_0px_rgba(0,166,81,1)]">

--- a/frontend/src/pages/ReceiptView.tsx
+++ b/frontend/src/pages/ReceiptView.tsx
@@ -1,0 +1,224 @@
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { supabase } from '../lib/supabase';
+import { PaymentRecordService } from '../services/paymentRecordService';
+import { logError } from '../lib/logger';
+import { useToast } from '../contexts/ToastContext';
+import PageMeta from '../components/PageMeta';
+import { ArrowLeft, Printer, CheckCircle, Clock, MapPin, AlertTriangle, Loader2 } from 'lucide-react';
+import type { ShiftPaymentReceipt } from '../services/paymentRecordService';
+import type { PaymentSource } from '../types';
+
+const PAYMENT_SOURCE_LABELS: Record<PaymentSource, string> = {
+    external_pix: 'PIX',
+    cash: 'Dinheiro',
+    other: 'Outro',
+};
+
+export default function ReceiptView() {
+    const { jobId } = useParams<{ jobId: string }>();
+    const navigate = useNavigate();
+    const { addToast } = useToast();
+
+    const [loading, setLoading] = useState(true);
+    const [receipt, setReceipt] = useState<ShiftPaymentReceipt | null>(null);
+    const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+    const [confirming, setConfirming] = useState(false);
+
+    useEffect(() => {
+        if (jobId) fetchReceipt();
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- so precisa re-executar quando jobId muda
+    }, [jobId]);
+
+    const fetchReceipt = async () => {
+        setLoading(true);
+        try {
+            const { data: { user } } = await supabase.auth.getUser();
+            if (!user) { navigate('/login'); return; }
+            setCurrentUserId(user.id);
+
+            const data = await PaymentRecordService.getReceipt(jobId as string);
+            setReceipt(data);
+        } catch (error) {
+            logError('ReceiptView: fetchReceipt', error);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleConfirmReceipt = async () => {
+        if (!receipt) return;
+        setConfirming(true);
+        try {
+            const result = await PaymentRecordService.confirmReceiptByWorker(receipt.payment.id);
+            if (!result.success) {
+                addToast(result.error || 'Não foi possível confirmar o recebimento.', 'error');
+                return;
+            }
+            addToast('Recebimento confirmado!', 'success');
+            fetchReceipt();
+        } catch (error) {
+            logError('ReceiptView: handleConfirmReceipt', error);
+            addToast('Erro ao confirmar recebimento.', 'error');
+        } finally {
+            setConfirming(false);
+        }
+    };
+
+    if (loading) {
+        return (
+            <div className="max-w-2xl mx-auto p-4 md:p-8 animate-pulse space-y-4">
+                <div className="h-8 w-40 bg-gray-200 rounded-xl" />
+                <div className="h-96 bg-gray-200 rounded-2xl" />
+            </div>
+        );
+    }
+
+    if (!receipt) {
+        return (
+            <div className="max-w-2xl mx-auto p-4 md:p-8">
+                <PageMeta title="Recibo não encontrado" />
+                <button
+                    onClick={() => navigate(-1)}
+                    className="flex items-center gap-2 text-gray-400 font-bold hover:text-black transition-colors mb-6"
+                >
+                    <ArrowLeft size={16} strokeWidth={3} /> Voltar
+                </button>
+                <div className="bg-white border-2 border-black rounded-2xl p-8 text-center">
+                    <AlertTriangle size={40} className="mx-auto mb-4 text-gray-400" />
+                    <h1 className="text-xl font-black uppercase mb-2">Recibo não encontrado</h1>
+                    <p className="text-gray-500 font-medium">
+                        Não há registro de pagamento visível para este turno, ou você não tem permissão para vê-lo.
+                    </p>
+                </div>
+            </div>
+        );
+    }
+
+    const { payment, job, company, worker } = receipt;
+    const isWorkerViewer = currentUserId === payment.worker_id;
+    const isCompanyViewer = currentUserId === payment.company_id;
+    const shortId = payment.id.slice(0, 8).toUpperCase();
+
+    return (
+        <div className="max-w-2xl mx-auto p-4 md:p-8 pb-20">
+            <PageMeta title="Recibo de Pagamento" />
+
+            {/* Barra de ações — não imprime */}
+            <div className="flex items-center justify-between mb-6 print:hidden">
+                <button
+                    onClick={() => navigate(-1)}
+                    className="flex items-center gap-2 text-gray-400 font-bold hover:text-black transition-colors"
+                >
+                    <ArrowLeft size={16} strokeWidth={3} /> Voltar
+                </button>
+                <button
+                    onClick={() => window.print()}
+                    aria-label="Imprimir recibo"
+                    className="flex items-center gap-2 px-4 py-2 bg-black hover:bg-primary text-white rounded-xl font-black uppercase text-sm transition-colors"
+                >
+                    <Printer size={16} /> Imprimir
+                </button>
+            </div>
+
+            {/* Recibo */}
+            <div className="bg-white border-2 border-black rounded-2xl p-6 md:p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] print:shadow-none print:border-black">
+                <div className="text-center border-b-2 border-black pb-6 mb-6">
+                    <p className="text-xs font-black uppercase tracking-widest text-gray-500 mb-1">Worki</p>
+                    <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">Recibo de Pagamento</h1>
+                    <p className="text-xs font-bold text-gray-400 uppercase mt-1">Registro Worki (declaratório)</p>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+                    <div>
+                        <span className="block text-xs font-black uppercase text-gray-400 mb-1">Empresa</span>
+                        <p className="font-bold text-lg">{company?.name || 'Não informado'}</p>
+                    </div>
+                    <div>
+                        <span className="block text-xs font-black uppercase text-gray-400 mb-1">Freela</span>
+                        <p className="font-bold text-lg">{worker?.full_name || 'Não informado'}</p>
+                    </div>
+                </div>
+
+                <div className="bg-gray-50 border-2 border-gray-100 rounded-xl p-4 mb-6">
+                    <span className="block text-xs font-black uppercase text-gray-400 mb-2">Turno</span>
+                    <p className="font-bold">{job?.title || 'Turno'}</p>
+                    <div className="flex flex-wrap items-center gap-4 text-xs font-bold text-gray-500 mt-2">
+                        {job?.start_date && (
+                            <span className="flex items-center gap-1">
+                                <Clock size={12} />
+                                {format(new Date(job.start_date), "dd/MM/yyyy", { locale: ptBR })}
+                                {job.work_start_time && ` • ${job.work_start_time}`}
+                                {job.work_end_time && ` – ${job.work_end_time}`}
+                            </span>
+                        )}
+                        {job?.location && (
+                            <span className="flex items-center gap-1">
+                                <MapPin size={12} /> {job.location}
+                            </span>
+                        )}
+                    </div>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+                    <div className="border-2 border-black rounded-xl p-4">
+                        <span className="block text-xs font-black uppercase text-gray-400 mb-1">Valor pago</span>
+                        <p className="font-black text-2xl tabular-nums">R$ {payment.amount.toFixed(2).replace('.', ',')}</p>
+                    </div>
+                    <div className="border-2 border-black rounded-xl p-4">
+                        <span className="block text-xs font-black uppercase text-gray-400 mb-1">Forma</span>
+                        <p className="font-bold text-lg">{PAYMENT_SOURCE_LABELS[payment.source]}</p>
+                    </div>
+                    <div className="border-2 border-black rounded-xl p-4">
+                        <span className="block text-xs font-black uppercase text-gray-400 mb-1">Data do pagamento</span>
+                        <p className="font-bold text-lg">{format(new Date(payment.paid_at), 'dd/MM/yyyy', { locale: ptBR })}</p>
+                    </div>
+                </div>
+
+                {payment.note && (
+                    <div className="mb-6">
+                        <span className="block text-xs font-black uppercase text-gray-400 mb-1">Nota</span>
+                        <p className="font-medium text-gray-600 italic">"{payment.note}"</p>
+                    </div>
+                )}
+
+                {/* Confirmação bilateral do freela — não bloqueia ciclo/avaliação */}
+                <div className="border-t-2 border-black pt-6 mb-6">
+                    <span className="block text-xs font-black uppercase text-gray-400 mb-3">Confirmação de recebimento</span>
+                    {payment.worker_confirmed_at ? (
+                        <div className="flex items-center gap-2 bg-primary-light text-primary font-bold px-4 py-3 rounded-xl border-2 border-black w-fit">
+                            <CheckCircle size={18} />
+                            Recebimento confirmado em {format(new Date(payment.worker_confirmed_at), "dd/MM/yyyy 'às' HH:mm", { locale: ptBR })}
+                        </div>
+                    ) : isWorkerViewer ? (
+                        <button
+                            onClick={handleConfirmReceipt}
+                            disabled={confirming}
+                            className="print:hidden bg-primary hover:bg-black text-white px-6 py-3 rounded-xl font-black uppercase transition-colors disabled:opacity-50 flex items-center gap-2"
+                        >
+                            {confirming ? <><Loader2 size={16} className="animate-spin" /> Confirmando...</> : 'Confirmar Recebimento'}
+                        </button>
+                    ) : isCompanyViewer ? (
+                        <p className="text-sm font-bold text-gray-500 bg-gray-100 px-4 py-3 rounded-xl w-fit">
+                            Aguardando confirmação do freela
+                        </p>
+                    ) : null}
+                </div>
+
+                <div className="flex flex-wrap items-center justify-between gap-2 text-xs font-bold text-gray-400 border-t-2 border-black pt-4">
+                    <span>Registro Nº {shortId}</span>
+                    <span>Emitido em {format(new Date(), "dd/MM/yyyy 'às' HH:mm", { locale: ptBR })}</span>
+                </div>
+
+                <div className="mt-6 bg-yellow-50 border-2 border-yellow-200 rounded-xl p-4">
+                    <p className="text-xs font-bold text-yellow-800">
+                        O Worki registra a declaração de pagamento entre as partes; o dinheiro não passou pela
+                        plataforma. Não é documento fiscal.
+                    </p>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/pages/__tests__/MyJobs.test.tsx
+++ b/frontend/src/pages/__tests__/MyJobs.test.tsx
@@ -133,6 +133,7 @@ function buildChain(overrides: Record<string, unknown> = {}) {
   const chain: Record<string, unknown> = {
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
     single: vi.fn().mockResolvedValue({ data: null, error: null }),
     order: vi.fn().mockResolvedValue({ data: [], error: null }),
     update: vi.fn().mockReturnThis(),
@@ -157,11 +158,7 @@ function setupMocks(apps: ApplicationRow[] = []) {
   })
 
   const appsChain = buildChain({
-    select: vi.fn().mockReturnValue({
-      eq: vi.fn().mockReturnValue({
-        order: vi.fn().mockResolvedValue({ data: apps, error: null }),
-      }),
-    }),
+    order: vi.fn().mockResolvedValue({ data: apps, error: null }),
   })
 
   vi.mocked(supabase.from).mockImplementation((table: string) => {
@@ -305,7 +302,9 @@ describe('MyJobs - Estado vazio por tab', () => {
       expect(screen.getByText('Meus Jobs')).toBeInTheDocument()
     })
 
-    // Agendados is the default tab
+    // Convites e a tab padrao; trocar para Agendados
+    fireEvent.click(screen.getByText('Agendados'))
+
     await waitFor(() => {
       expect(screen.getByText('Nenhum job agendado no momento.')).toBeInTheDocument()
     })

--- a/frontend/src/pages/__tests__/Wallet.test.tsx
+++ b/frontend/src/pages/__tests__/Wallet.test.tsx
@@ -199,7 +199,7 @@ describe('Wallet - Calculo de taxa 5%', () => {
 
     // Fee = 200 * 0.05 = 10.00, Fixed = 3.00, Net = 200 - 10 - 3 = 187.00
     await waitFor(() => {
-      expect(screen.getByText('Taxa de servico (5%)')).toBeInTheDocument()
+      expect(screen.getByText('Taxa de servico Worki (5%)')).toBeInTheDocument()
       expect(screen.getByText('- R$ 10.00')).toBeInTheDocument()
       expect(screen.getByText('R$ 187.00')).toBeInTheDocument()
     })

--- a/frontend/src/pages/company/CompanyCreateJob.tsx
+++ b/frontend/src/pages/company/CompanyCreateJob.tsx
@@ -176,7 +176,7 @@ export default function CompanyCreateJob() {
                 const { data: newJob, error } = await supabase.from('jobs').insert(payload).select().single();
                 if (error) throw error;
 
-                addToast('Turno criado! Convide um freela da sua equipe.', 'success');
+                addToast('Turno criado! Convide um freela do seu elenco.', 'success');
                 setCreatedJobId(newJob.id);
                 setShowInvitePanel(true);
             }
@@ -529,7 +529,7 @@ export default function CompanyCreateJob() {
                         </div>
 
                         <p className="text-sm font-bold text-gray-600 mb-5">
-                            Turno criado! Convide um freela da sua equipe para este turno.
+                            Turno criado! Convide um freela do seu elenco para este turno.
                         </p>
 
                         {teamLoading && (
@@ -541,8 +541,8 @@ export default function CompanyCreateJob() {
                         {!teamLoading && teamMembers.length === 0 && (
                             <div className="text-center py-8 border-2 border-dashed border-gray-200 rounded-2xl text-gray-400">
                                 <Users size={32} className="mx-auto mb-2 opacity-30" />
-                                <p className="font-bold text-sm">Sua equipe está vazia.</p>
-                                <p className="text-xs mt-1">Adicione freelas em <strong>Minha Equipe</strong> primeiro.</p>
+                                <p className="font-bold text-sm">Seu elenco está vazio.</p>
+                                <p className="text-xs mt-1">Adicione freelas em <strong>Meu Elenco</strong> primeiro.</p>
                             </div>
                         )}
 

--- a/frontend/src/pages/company/CompanyJobCandidates.test.tsx
+++ b/frontend/src/pages/company/CompanyJobCandidates.test.tsx
@@ -46,6 +46,7 @@ function buildChain(overrides: Record<string, unknown> = {}) {
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
     single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
     order: vi.fn().mockResolvedValue({ data: [], error: null }),
     update: vi.fn().mockReturnThis(),
     insert: vi.fn().mockResolvedValue({ data: null, error: null }),
@@ -109,8 +110,16 @@ function setupMocksWithApps(apps: unknown[]) {
     insert: vi.fn().mockResolvedValue({ data: null, error: null }),
   })
 
+  // Por padrão, simula um turno com escrow prepago reservado (fluxo pull legado) —
+  // é o que faz renderCompletionAction() mostrar "Confirmar Entrega" em vez de cair
+  // no branch modo A ("Registrar Pagamento"). Testes específicos de modo A sobrescrevem.
+  // Nota: o fetch real é `.select(...).eq('job_id', id)` sem `.order()` — o mock
+  // precisa resolver direto no `eq()`, não em `order()`.
   const escrowChain = buildChain({
-    order: vi.fn().mockResolvedValue({ data: [], error: null }),
+    eq: vi.fn().mockResolvedValue({
+      data: [{ application_id: 'app-1', status: 'reserved', kind: 'prepaid' }],
+      error: null,
+    }),
   })
 
   vi.mocked(supabase.from).mockImplementation((table: string) => {

--- a/frontend/src/pages/company/CompanyJobCandidates.tsx
+++ b/frontend/src/pages/company/CompanyJobCandidates.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { supabase } from '../../lib/supabase';
 import { WalletService } from '../../services/walletService';
 import { PaymentRecordService } from '../../services/paymentRecordService';
+import { SpendLimitService } from '../../services/spendLimitService';
 import { logError } from '../../lib/logger';
 import { ArrowLeft, Star, MapPin, Clock, ChevronRight, CheckCircle, XCircle, MessageSquare, Play, Square, Loader2, Receipt } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
@@ -204,6 +205,22 @@ export default function CompanyJobCandidates() {
                 addToast(result.error || 'Não foi possível registrar o pagamento.', 'error');
                 return;
             }
+
+            // Registro OK — avaliar o alerta de teto de gasto (R12) com a MESMA fonte
+            // unificada (escrow ∪ marcador externo) que o dashboard financeiro usa,
+            // senão o alerta fica cego ao modo A (não há releaseEscrow para disparar isso).
+            // Best-effort, fire-and-forget: nunca bloqueia nem falha o registro do pagamento
+            // (espelha walletService.releaseOrCaptureEscrow.spendAlert).
+            void (async () => {
+                try {
+                    const { data: { user: authUser } } = await supabase.auth.getUser();
+                    if (authUser) {
+                        await SpendLimitService.evaluateSpendAlert(authUser.id);
+                    }
+                } catch (alertErr) {
+                    logError('CompanyJobCandidates: handleRecordPayment.spendAlert', alertErr);
+                }
+            })();
 
             // Registro OK — agora sim marcamos o turno como concluído. Falha aqui não
             // desfaz o registro (já é a fonte de verdade do pagamento); só avisamos.

--- a/frontend/src/pages/company/CompanyJobCandidates.tsx
+++ b/frontend/src/pages/company/CompanyJobCandidates.tsx
@@ -2,14 +2,21 @@ import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { supabase } from '../../lib/supabase';
 import { WalletService } from '../../services/walletService';
+import { PaymentRecordService } from '../../services/paymentRecordService';
 import { logError } from '../../lib/logger';
-import { ArrowLeft, Star, MapPin, Clock, ChevronRight, CheckCircle, XCircle, MessageSquare, Play, Square, Loader2 } from 'lucide-react';
+import { ArrowLeft, Star, MapPin, Clock, ChevronRight, CheckCircle, XCircle, MessageSquare, Play, Square, Loader2, Receipt } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { useToast } from '../../contexts/ToastContext';
 import JobLifecycleStepper from '../../components/JobLifecycleStepper';
 import EscrowStatusBadge from '../../components/EscrowStatusBadge';
-import type { Application } from '../../types';
+import type { Application, PaymentSource, ShiftPayment } from '../../types';
+
+const PAYMENT_SOURCE_LABELS: Record<PaymentSource, string> = {
+    external_pix: 'PIX',
+    cash: 'Dinheiro',
+    other: 'Outro',
+};
 
 export default function CompanyJobCandidates() {
     const { id } = useParams();
@@ -28,6 +35,22 @@ export default function CompanyJobCandidates() {
     const [confirmDeliveryApp, setConfirmDeliveryApp] = useState<Application | null>(null);
     const [releasing, setReleasing] = useState(false);
     const [escrowStatusMap, setEscrowStatusMap] = useState<Record<string, 'reserved' | 'released'>>({});
+    // Modo A (pagamento externo declaratório) — ramifica por escrow.kind por application.
+    // Sem entrada no map = turno sem escrow (modo A); 'prepaid'/'postpaid' = caminho de escrow existente.
+    const [escrowKindMap, setEscrowKindMap] = useState<Record<string, 'prepaid' | 'postpaid'>>({});
+    const [jobBudget, setJobBudget] = useState(0);
+    // Registro de pagamento externo (modo A) já feito para ESTE job (UNIQUE por job_id no schema).
+    const [shiftPayment, setShiftPayment] = useState<ShiftPayment | null>(null);
+
+    // Modal "Registrar pagamento" (modo A)
+    const [paymentModalApp, setPaymentModalApp] = useState<Application | null>(null);
+    const [paymentSource, setPaymentSource] = useState<PaymentSource>('external_pix');
+    const [paymentAmount, setPaymentAmount] = useState(0);
+    const [paymentPaidAt, setPaymentPaidAt] = useState(() => new Date().toISOString().slice(0, 10));
+    const [paymentNote, setPaymentNote] = useState('');
+    const [recordingPayment, setRecordingPayment] = useState(false);
+    const [paymentRecorded, setPaymentRecorded] = useState(false);
+
     const { addToast } = useToast();
 
     useEffect(() => {
@@ -41,9 +64,10 @@ export default function CompanyJobCandidates() {
             if (!user) { navigate('/login'); return; }
 
             // Fetch Job Title (only if owned by this company)
-            const { data: job, error: jobError } = await supabase.from('jobs').select('title').eq('id', id).eq('company_id', user.id).single();
+            const { data: job, error: jobError } = await supabase.from('jobs').select('title, budget').eq('id', id).eq('company_id', user.id).single();
             if (jobError || !job) { navigate('/company/jobs'); return; }
             setJobTitle(job.title);
+            setJobBudget(job.budget ?? 0);
 
             // Fetch Applications with Worker Profile (using 'workers' table now)
             const { data, error } = await supabase
@@ -62,22 +86,31 @@ export default function CompanyJobCandidates() {
             if (error) throw error;
             setCandidates(data || []);
 
-            // Fetch escrow status per application for this job
+            // Fetch escrow status + kind per application for this job
             const { data: escrowRows } = await supabase
                 .from('escrow_transactions')
-                .select('application_id, status')
+                .select('application_id, status, kind')
                 .eq('job_id', id);
             const statusMap: Record<string, 'reserved' | 'released'> = {};
+            const kindMap: Record<string, 'prepaid' | 'postpaid'> = {};
             (escrowRows || []).forEach((row) => {
                 if (row.application_id && (row.status === 'reserved' || row.status === 'released')) {
                     statusMap[row.application_id] = row.status;
                 }
+                if (row.application_id && (row.kind === 'prepaid' || row.kind === 'postpaid')) {
+                    kindMap[row.application_id] = row.kind;
+                }
             });
             setEscrowStatusMap(statusMap);
+            setEscrowKindMap(kindMap);
 
             // Fetch company balance to guard the "Contratar" button (AC-7)
             const wallet = await WalletService.getOrCreateWallet(user.id, 'company');
             setCompanyBalance(wallet ? wallet.balance : null);
+
+            // Modo A: existe registro de pagamento externo já feito para este turno?
+            const payment = await PaymentRecordService.getPaymentByJob(id as string);
+            setShiftPayment(payment);
         } catch (error) {
             logError('CompanyJobCandidates', error);
         } finally {
@@ -121,6 +154,77 @@ export default function CompanyJobCandidates() {
         setReleasing(false);
         addToast('Entrega confirmada! Pagamento liberado ao profissional.', 'success');
         fetchCandidates();
+    };
+
+    // Modo A (pagamento externo) — abre o modal "Registrar pagamento" pré-preenchido com o valor do turno.
+    const openPaymentModal = (app: Application) => {
+        setPaymentModalApp(app);
+        setPaymentSource('external_pix');
+        setPaymentAmount(jobBudget);
+        setPaymentPaidAt(new Date().toISOString().slice(0, 10));
+        setPaymentNote('');
+        setPaymentRecorded(false);
+    };
+
+    const closePaymentModal = () => {
+        setPaymentModalApp(null);
+        setPaymentRecorded(false);
+    };
+
+    // O service valida o SINAL REAL de conclusão (chegada + saída confirmadas), não o
+    // status='completed' — por isso registramos o pagamento PRIMEIRO e só marcamos o
+    // turno como concluído DEPOIS que o INSERT tem sucesso. Se o registro falhar (rede/
+    // RLS/timeout), a application permanece como estava e o botão "Registrar Pagamento"
+    // continua disponível — nunca fica em dead-end (status='completed' sem recibo).
+    const handleRecordPayment = async () => {
+        if (!paymentModalApp) return;
+        if (!(paymentAmount > 0)) {
+            addToast('Informe um valor pago maior que zero.', 'error');
+            return;
+        }
+        setRecordingPayment(true);
+        try {
+            const result = await PaymentRecordService.recordExternalPayment({
+                jobId: paymentModalApp.job_id,
+                workerId: paymentModalApp.worker_id,
+                applicationId: paymentModalApp.id,
+                source: paymentSource,
+                amount: paymentAmount,
+                paidAt: paymentPaidAt,
+                note: paymentNote.trim() || undefined,
+            });
+
+            if (!result.success) {
+                if (result.alreadyRecorded) {
+                    addToast('Este turno já tem um pagamento registrado. Veja o recibo.', 'info');
+                    closePaymentModal();
+                    fetchCandidates();
+                    return;
+                }
+                addToast(result.error || 'Não foi possível registrar o pagamento.', 'error');
+                return;
+            }
+
+            // Registro OK — agora sim marcamos o turno como concluído. Falha aqui não
+            // desfaz o registro (já é a fonte de verdade do pagamento); só avisamos.
+            const { error: updateError } = await supabase
+                .from('applications')
+                .update({ status: 'completed' })
+                .eq('id', paymentModalApp.id);
+            if (updateError) {
+                logError('CompanyJobCandidates: handleRecordPayment.updateStatus', updateError);
+                addToast('Pagamento registrado, mas houve erro ao concluir o turno. Contate o suporte.', 'error');
+            } else {
+                addToast('Pagamento registrado com sucesso!', 'success');
+            }
+            setPaymentRecorded(true);
+            fetchCandidates();
+        } catch (error) {
+            logError('CompanyJobCandidates: handleRecordPayment', error);
+            addToast('Erro ao registrar pagamento.', 'error');
+        } finally {
+            setRecordingPayment(false);
+        }
     };
 
     const handleSubmitReview = async () => {
@@ -267,6 +371,40 @@ export default function CompanyJobCandidates() {
                 status: app.status === 'completed' ? 'complete' as const : 'pending' as const
             }
         ];
+    };
+
+    // Ramificação modo A (pagamento externo) vs C (postpago/cartão) vs prepago legado.
+    // Sem entrada em escrowKindMap = nenhum escrow reservado para este turno → modo A (default do piloto).
+    const renderCompletionAction = (app: Application) => {
+        const kind = escrowKindMap[app.id];
+        if (kind === 'prepaid' || kind === 'postpaid') {
+            return (
+                <button
+                    onClick={(e) => { e.stopPropagation(); setConfirmDeliveryApp(app); }}
+                    className="p-1 px-3 bg-black text-white border-2 border-black rounded-lg text-xs font-bold uppercase hover:bg-primary transition-colors flex items-center gap-1"
+                >
+                    Confirmar Entrega
+                </button>
+            );
+        }
+        if (shiftPayment && shiftPayment.job_id === app.job_id && shiftPayment.worker_id === app.worker_id) {
+            return (
+                <button
+                    onClick={(e) => { e.stopPropagation(); navigate(`/recibo/${app.job_id}`); }}
+                    className="p-1 px-3 bg-white text-black border-2 border-black rounded-lg text-xs font-bold uppercase hover:bg-gray-50 transition-colors flex items-center gap-1"
+                >
+                    <Receipt size={14} /> Ver Recibo
+                </button>
+            );
+        }
+        return (
+            <button
+                onClick={(e) => { e.stopPropagation(); openPaymentModal(app); }}
+                className="p-1 px-3 bg-black text-white border-2 border-black rounded-lg text-xs font-bold uppercase hover:bg-primary transition-colors flex items-center gap-1"
+            >
+                Registrar Pagamento
+            </button>
+        );
     };
 
     return (
@@ -440,16 +578,31 @@ export default function CompanyJobCandidates() {
                                                                 </span>
                                                             )}
 
-                                                            {/* Confirmar Entrega button — replaces old "Finalizar Job" */}
-                                                            {app.company_checkin_confirmed_at && app.company_checkout_confirmed_at && (
-                                                                <button
-                                                                    onClick={(e) => { e.stopPropagation(); setConfirmDeliveryApp(app); }}
-                                                                    className="p-1 px-3 bg-black text-white border-2 border-black rounded-lg text-xs font-bold uppercase hover:bg-primary transition-colors flex items-center gap-1"
-                                                                >
-                                                                    Confirmar Entrega
-                                                                </button>
-                                                            )}
+                                                            {/* Confirmar Entrega (escrow) OU Registrar Pagamento (modo A) — ramificado por escrow.kind */}
+                                                            {app.company_checkin_confirmed_at && app.company_checkout_confirmed_at && renderCompletionAction(app)}
                                                         </>
+                                                    )}
+
+                                                    {/* Ver Recibo — turno finalizado via modo A (pagamento externo) */}
+                                                    {app.status === 'completed' && shiftPayment && shiftPayment.job_id === app.job_id && shiftPayment.worker_id === app.worker_id && (
+                                                        <button
+                                                            onClick={(e) => { e.stopPropagation(); navigate(`/recibo/${app.job_id}`); }}
+                                                            className="p-1 px-3 bg-white text-black border-2 border-black rounded-lg text-xs font-bold uppercase hover:bg-gray-50 transition-colors flex items-center gap-1"
+                                                        >
+                                                            <Receipt size={14} /> Ver Recibo
+                                                        </button>
+                                                    )}
+
+                                                    {/* Rede de segurança (defense-in-depth): turno concluído em modo A (sem escrow)
+                                                        mas sem registro de pagamento — caminho de recuperação caso o registro tenha
+                                                        falhado depois da conclusão em algum fluxo legado/edge case. */}
+                                                    {app.status === 'completed' && !escrowKindMap[app.id] && !(shiftPayment && shiftPayment.job_id === app.job_id && shiftPayment.worker_id === app.worker_id) && (
+                                                        <button
+                                                            onClick={(e) => { e.stopPropagation(); openPaymentModal(app); }}
+                                                            className="p-1 px-3 bg-black text-white border-2 border-black rounded-lg text-xs font-bold uppercase hover:bg-primary transition-colors flex items-center gap-1"
+                                                        >
+                                                            Registrar Pagamento
+                                                        </button>
                                                     )}
 
                                                     {/* Botão Avaliar — apenas para candidatos já finalizados */}
@@ -525,6 +678,132 @@ export default function CompanyJobCandidates() {
                                 {releasing ? <><Loader2 size={16} className="animate-spin" /> Processando...</> : 'Confirmar'}
                             </button>
                         </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Modal "Registrar Pagamento" — modo A (pagamento externo declaratório) */}
+            {paymentModalApp && (
+                <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4 backdrop-blur-sm animate-in fade-in duration-200">
+                    <div className="bg-white rounded-2xl w-full max-w-md p-6 border-2 border-black shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+                        {!paymentRecorded ? (
+                            <>
+                                <h2 className="text-xl font-black uppercase tracking-tight mb-1">Registrar Pagamento</h2>
+                                <p className="text-xs font-bold text-gray-500 uppercase mb-5">
+                                    Pagamento feito por fora do Worki — registro declaratório
+                                </p>
+
+                                <div className="mb-4">
+                                    <span className="block text-sm font-bold uppercase mb-2">Forma de pagamento</span>
+                                    <div className="grid grid-cols-3 gap-2">
+                                        {(Object.keys(PAYMENT_SOURCE_LABELS) as PaymentSource[]).map((src) => (
+                                            <button
+                                                key={src}
+                                                type="button"
+                                                onClick={() => setPaymentSource(src)}
+                                                aria-pressed={paymentSource === src}
+                                                className={`py-3 min-h-[44px] rounded-xl border-2 border-black font-black text-xs uppercase transition-colors ${paymentSource === src ? 'bg-black text-white' : 'bg-white text-black hover:bg-gray-50'
+                                                    }`}
+                                            >
+                                                {PAYMENT_SOURCE_LABELS[src]}
+                                            </button>
+                                        ))}
+                                    </div>
+                                </div>
+
+                                <div className="mb-4">
+                                    <label htmlFor="payment-amount" className="block text-sm font-bold uppercase mb-2">
+                                        Valor pago (R$)
+                                    </label>
+                                    <div className="relative">
+                                        <span className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-500 font-bold">R$</span>
+                                        <input
+                                            id="payment-amount"
+                                            type="number"
+                                            min="0.01"
+                                            step="0.01"
+                                            value={paymentAmount}
+                                            onChange={(e) => setPaymentAmount(Number(e.target.value))}
+                                            className="w-full border-2 border-black rounded-xl pl-12 pr-4 py-3 focus:outline-none focus:ring-2 focus:ring-primary font-bold tabular-nums"
+                                        />
+                                    </div>
+                                </div>
+
+                                <div className="mb-4">
+                                    <label htmlFor="payment-paid-at" className="block text-sm font-bold uppercase mb-2">
+                                        Data do pagamento
+                                    </label>
+                                    <input
+                                        id="payment-paid-at"
+                                        type="date"
+                                        value={paymentPaidAt}
+                                        onChange={(e) => setPaymentPaidAt(e.target.value)}
+                                        className="w-full border-2 border-black rounded-xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-primary font-bold"
+                                    />
+                                </div>
+
+                                <div className="mb-6">
+                                    <label htmlFor="payment-note" className="block text-sm font-bold uppercase mb-2">
+                                        Nota (opcional)
+                                    </label>
+                                    <textarea
+                                        id="payment-note"
+                                        value={paymentNote}
+                                        onChange={(e) => setPaymentNote(e.target.value)}
+                                        placeholder="Ex.: pago em 2x, referência do PIX..."
+                                        className="w-full border-2 border-black rounded-xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-primary font-medium h-20 resize-none"
+                                    />
+                                </div>
+
+                                <div className="mb-6 bg-yellow-50 border-2 border-yellow-200 rounded-xl p-4">
+                                    <p className="text-xs font-bold text-yellow-800">
+                                        O dinheiro não passa pelo Worki. Este registro é declaratório, não é
+                                        documento fiscal, e ao confirmar o turno será marcado como concluído.
+                                    </p>
+                                </div>
+
+                                <div className="flex gap-3">
+                                    <button
+                                        onClick={closePaymentModal}
+                                        disabled={recordingPayment}
+                                        className="flex-1 py-3 border-2 border-black font-bold rounded-xl hover:bg-gray-50 transition-colors disabled:opacity-50"
+                                    >
+                                        Cancelar
+                                    </button>
+                                    <button
+                                        onClick={handleRecordPayment}
+                                        disabled={recordingPayment || !(paymentAmount > 0)}
+                                        className="flex-1 py-3 bg-black text-white font-bold rounded-xl border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:bg-primary hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all disabled:opacity-50 flex items-center justify-center gap-2"
+                                    >
+                                        {recordingPayment ? <><Loader2 size={16} className="animate-spin" /> Registrando...</> : 'Confirmar Registro'}
+                                    </button>
+                                </div>
+                            </>
+                        ) : (
+                            <div className="flex flex-col items-center text-center py-4">
+                                <div className="w-16 h-16 rounded-full bg-primary-light border-2 border-black flex items-center justify-center mb-4">
+                                    <CheckCircle size={32} className="text-primary" />
+                                </div>
+                                <h2 className="text-xl font-black uppercase tracking-tight mb-2">Pagamento registrado!</h2>
+                                <p className="text-gray-600 font-medium mb-6">
+                                    O recibo já está disponível para você e para o profissional.
+                                </p>
+                                <div className="flex gap-3 w-full">
+                                    <button
+                                        onClick={closePaymentModal}
+                                        className="flex-1 py-3 border-2 border-black font-bold rounded-xl hover:bg-gray-50 transition-colors"
+                                    >
+                                        Fechar
+                                    </button>
+                                    <button
+                                        onClick={() => navigate(`/recibo/${paymentModalApp.job_id}`)}
+                                        className="flex-1 py-3 bg-black text-white font-bold rounded-xl border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:bg-primary hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all flex items-center justify-center gap-2"
+                                    >
+                                        <Receipt size={16} /> Ver Recibo
+                                    </button>
+                                </div>
+                            </div>
+                        )}
                     </div>
                 </div>
             )}

--- a/frontend/src/pages/company/CompanyJobCandidates.tsx
+++ b/frontend/src/pages/company/CompanyJobCandidates.tsx
@@ -4,14 +4,32 @@ import { supabase } from '../../lib/supabase';
 import { WalletService } from '../../services/walletService';
 import { PaymentRecordService } from '../../services/paymentRecordService';
 import { SpendLimitService } from '../../services/spendLimitService';
+import { TeamConnectionService } from '../../services/teamConnectionService';
+import { useCompanyInvites } from '../../hooks/useShiftInvites';
 import { logError } from '../../lib/logger';
-import { ArrowLeft, Star, MapPin, Clock, ChevronRight, CheckCircle, XCircle, MessageSquare, Play, Square, Loader2, Receipt } from 'lucide-react';
+import { ArrowLeft, Star, MapPin, Clock, ChevronRight, CheckCircle, XCircle, MessageSquare, Play, Square, Loader2, Receipt, Send, Users, X } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { useToast } from '../../contexts/ToastContext';
 import JobLifecycleStepper from '../../components/JobLifecycleStepper';
 import EscrowStatusBadge from '../../components/EscrowStatusBadge';
-import type { Application, PaymentSource, ShiftPayment } from '../../types';
+import type { Application, PaymentSource, ShiftPayment, TeamMember } from '../../types';
+
+/**
+ * Convite expirado sem resposta do freela (R8 — expiração deriva na leitura, sem escrever no
+ * banco). Não depende de migration. Cobre os DOIS estados de forma consistente:
+ *  - antes do cron: ainda `status='invited'` com `invitation_expires_at` no passado;
+ *  - depois do cron `expire-invites`: `status='declined'` com `invitation_response` NULL
+ *    (expiração automática ≠ recusa ativa do worker, que tem `invitation_response='declined'`).
+ */
+function isInviteExpired(app: Application): boolean {
+  const pastDeadline =
+    !!app.invitation_expires_at && new Date(app.invitation_expires_at) < new Date();
+  return (
+    (app.status === 'invited' && pastDeadline) ||
+    (app.status === 'declined' && !app.invitation_response && pastDeadline)
+  );
+}
 
 const PAYMENT_SOURCE_LABELS: Record<PaymentSource, string> = {
     external_pix: 'PIX',
@@ -52,7 +70,15 @@ export default function CompanyJobCandidates() {
     const [recordingPayment, setRecordingPayment] = useState(false);
     const [paymentRecorded, setPaymentRecorded] = useState(false);
 
+    // "Convidar outro" — convite expirado sem resposta; o slot está livre para outro freela (R8).
+    const [reopenApp, setReopenApp] = useState<Application | null>(null);
+    const [reopenTeamMembers, setReopenTeamMembers] = useState<TeamMember[]>([]);
+    const [reopenLoading, setReopenLoading] = useState(false);
+
     const { addToast } = useToast();
+    // Reaproveita o hook do fluxo de convite (mesmo usado em CompanyCreateJob) para disparar
+    // um novo convite a partir desta tela quando o anterior expirou sem resposta.
+    const { invite: sendReopenInvite, invitingWorkerId: reopenInvitingWorkerId } = useCompanyInvites(id ?? '');
 
     useEffect(() => {
         if (id) fetchCandidates();
@@ -170,6 +196,37 @@ export default function CompanyJobCandidates() {
     const closePaymentModal = () => {
         setPaymentModalApp(null);
         setPaymentRecorded(false);
+    };
+
+    // Abre o picker "Convidar outro" para um convite expirado (status='invited' + prazo vencido).
+    // O slot está livre: qualquer outro membro da equipe (que ainda não tenha application para
+    // este job) pode ser convidado. Não escreve nada no convite antigo — é só leitura + novo convite.
+    const openReopenModal = async (app: Application) => {
+        setReopenApp(app);
+        setReopenLoading(true);
+        try {
+            const members = await TeamConnectionService.listTeamMembers();
+            const alreadyOnJob = new Set(candidates.map((c) => c.worker_id));
+            setReopenTeamMembers(members.filter((m) => !alreadyOnJob.has(m.worker.id)));
+        } catch (error) {
+            logError('CompanyJobCandidates: openReopenModal', error);
+            addToast('Erro ao carregar sua equipe.', 'error');
+        } finally {
+            setReopenLoading(false);
+        }
+    };
+
+    const closeReopenModal = () => {
+        setReopenApp(null);
+        setReopenTeamMembers([]);
+    };
+
+    const handlePickReopenWorker = async (workerId: string) => {
+        const ok = await sendReopenInvite(workerId);
+        if (ok) {
+            closeReopenModal();
+            fetchCandidates();
+        }
     };
 
     // O service valida o SINAL REAL de conclusão (chegada + saída confirmadas), não o
@@ -520,14 +577,32 @@ export default function CompanyJobCandidates() {
                                             )}
                                             {app.status !== 'pending' && (
                                                 <div className="flex items-center gap-2 flex-wrap">
-                                                    <span className={`text-xs font-black uppercase px-3 py-1 rounded-lg border-2 ${app.status === 'hired' ? 'bg-green-100 border-green-200 text-green-700' :
-                                                        app.status === 'in_progress' ? 'bg-orange-100 border-orange-200 text-orange-700' :
-                                                        app.status === 'completed' ? 'bg-blue-100 border-blue-200 text-blue-700' :
-                                                            app.status === 'rejected' ? 'bg-red-50 border-red-100 text-red-500' :
-                                                                'bg-blue-50 border-blue-100 text-blue-600'
-                                                        }`}>
-                                                        {app.status === 'interview' ? 'Em Entrevista' : app.status === 'hired' ? 'Contratado' : app.status === 'in_progress' ? 'Em Andamento' : app.status === 'completed' ? 'Finalizado' : 'Descartado'}
-                                                    </span>
+                                                    {isInviteExpired(app) ? (
+                                                            <>
+                                                                <span className="text-xs font-black uppercase px-3 py-1 rounded-lg border-2 bg-gray-100 border-gray-300 text-gray-500">
+                                                                    Não respondeu (expirado)
+                                                                </span>
+                                                                <button
+                                                                    onClick={(e) => { e.stopPropagation(); void openReopenModal(app); }}
+                                                                    className="p-1 px-3 bg-black text-white border-2 border-black rounded-lg text-xs font-bold uppercase hover:bg-primary transition-colors flex items-center gap-1"
+                                                                >
+                                                                    <Send size={14} /> Convidar outro
+                                                                </button>
+                                                            </>
+                                                    ) : app.status === 'invited' ? (
+                                                            <span className="text-xs font-black uppercase px-3 py-1 rounded-lg border-2 bg-blue-50 border-blue-100 text-blue-600">
+                                                                Aguardando resposta
+                                                            </span>
+                                                    ) : (
+                                                        <span className={`text-xs font-black uppercase px-3 py-1 rounded-lg border-2 ${app.status === 'hired' ? 'bg-green-100 border-green-200 text-green-700' :
+                                                            app.status === 'in_progress' ? 'bg-orange-100 border-orange-200 text-orange-700' :
+                                                            app.status === 'completed' ? 'bg-blue-100 border-blue-200 text-blue-700' :
+                                                                app.status === 'rejected' ? 'bg-red-50 border-red-100 text-red-500' :
+                                                                    'bg-blue-50 border-blue-100 text-blue-600'
+                                                            }`}>
+                                                            {app.status === 'interview' ? 'Em Entrevista' : app.status === 'hired' ? 'Contratado' : app.status === 'in_progress' ? 'Em Andamento' : app.status === 'completed' ? 'Finalizado' : 'Descartado'}
+                                                        </span>
+                                                    )}
 
                                                     {app.status === 'interview' && (
                                                         <>
@@ -670,6 +745,84 @@ export default function CompanyJobCandidates() {
                     ))
                 )}
             </div>
+
+            {/* Modal "Convidar outro" — convite anterior expirou sem resposta (R8); slot livre */}
+            {reopenApp && (
+                <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4 backdrop-blur-sm animate-in fade-in duration-200">
+                    <div className="bg-white rounded-2xl w-full max-w-md p-6 border-2 border-black shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+                        <div className="flex items-center justify-between mb-4">
+                            <h2 className="text-xl font-black uppercase tracking-tight">Convidar Outro Freela</h2>
+                            <button
+                                onClick={closeReopenModal}
+                                aria-label="Fechar"
+                                className="p-2 hover:bg-gray-100 rounded-xl transition-colors"
+                            >
+                                <X size={20} />
+                            </button>
+                        </div>
+                        <p className="text-sm font-bold text-gray-600 mb-5">
+                            O convite anterior expirou sem resposta. O slot deste turno está livre — escolha outro freela da sua equipe.
+                        </p>
+
+                        {reopenLoading && (
+                            <div className="space-y-3 animate-pulse">
+                                {[...Array(3)].map((_, i) => <div key={i} className="h-14 bg-gray-200 rounded-xl" />)}
+                            </div>
+                        )}
+
+                        {!reopenLoading && reopenTeamMembers.length === 0 && (
+                            <div className="text-center py-8 border-2 border-dashed border-gray-200 rounded-2xl text-gray-400">
+                                <Users size={32} className="mx-auto mb-2 opacity-30" />
+                                <p className="font-bold text-sm">Nenhum freela disponível para convidar.</p>
+                                <p className="text-xs mt-1">Todos da equipe já têm candidatura neste turno, ou seu elenco está vazio.</p>
+                            </div>
+                        )}
+
+                        {!reopenLoading && reopenTeamMembers.length > 0 && (
+                            <div className="space-y-3 max-h-72 overflow-y-auto">
+                                {reopenTeamMembers.map((member) => {
+                                    const avatarUrl = member.worker.avatar_url ?? member.worker.photo_url ?? null;
+                                    const isInviting = reopenInvitingWorkerId === member.worker.id;
+                                    return (
+                                        <div key={member.connection.id} className="flex items-center gap-3 p-3 rounded-xl border-2 border-gray-100 hover:border-black transition-all">
+                                            <div className="w-10 h-10 rounded-xl border-2 border-black overflow-hidden bg-gray-100 flex-shrink-0">
+                                                {avatarUrl ? (
+                                                    <img src={avatarUrl} alt={member.worker.full_name} className="w-full h-full object-cover" />
+                                                ) : (
+                                                    <div className="w-full h-full flex items-center justify-center bg-black text-white font-black">
+                                                        {member.worker.full_name[0]?.toUpperCase()}
+                                                    </div>
+                                                )}
+                                            </div>
+                                            <div className="flex-1 min-w-0">
+                                                <p className="font-black uppercase text-sm truncate">{member.worker.full_name}</p>
+                                                {member.worker.primary_role && (
+                                                    <p className="text-xs font-bold text-gray-400 uppercase truncate">{member.worker.primary_role}</p>
+                                                )}
+                                            </div>
+                                            <button
+                                                onClick={() => void handlePickReopenWorker(member.worker.id)}
+                                                disabled={isInviting}
+                                                className="bg-black hover:bg-primary text-white px-4 py-2 rounded-xl font-black uppercase text-xs flex items-center gap-1.5 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0"
+                                            >
+                                                {isInviting ? <Loader2 className="animate-spin" size={14} /> : <Send size={14} />}
+                                                {isInviting ? '...' : 'Convidar'}
+                                            </button>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        )}
+
+                        <button
+                            onClick={closeReopenModal}
+                            className="w-full mt-5 bg-gray-100 hover:bg-gray-200 text-gray-700 px-6 py-3 rounded-xl font-black uppercase text-sm transition-colors"
+                        >
+                            Fechar
+                        </button>
+                    </div>
+                </div>
+            )}
 
             {/* Modal de Confirmação de Entrega */}
             {confirmDeliveryApp && (

--- a/frontend/src/pages/company/CompanyTeam.tsx
+++ b/frontend/src/pages/company/CompanyTeam.tsx
@@ -56,7 +56,7 @@ function MemberCard({ member }: MemberCardProps) {
 
       {/* Status badge */}
       <span className="flex-shrink-0 bg-primary-light text-primary text-xs font-black uppercase px-2 py-1 rounded-xl border border-green-200">
-        Equipe
+        Elenco
       </span>
     </div>
   );
@@ -181,7 +181,7 @@ function AddWorkerModal({ companyId, onClose, onAdded, addWorker }: AddWorkerMod
         {method === 'link' && (
           <div className="space-y-4">
             <p className="text-sm font-bold text-gray-600">
-              Compartilhe este link com o freela. Ele abrirá o Worki e aceitará o convite de entrada na sua equipe.
+              Compartilhe este link com o freela. Ele abrirá o Worki e aceitará o convite de entrada no seu elenco.
             </p>
             <div className="bg-gray-50 border-2 border-black rounded-xl p-4 flex items-center gap-3 font-mono text-xs break-all text-gray-700">
               <span className="flex-1">{inviteUrl}</span>
@@ -263,9 +263,9 @@ export default function CompanyTeam() {
       {/* Header */}
       <div className="flex items-start justify-between mb-8 gap-4 flex-wrap">
         <div>
-          <h1 className="text-4xl font-black uppercase tracking-tighter">Minha Equipe</h1>
+          <h1 className="text-4xl font-black uppercase tracking-tighter">Meu Elenco</h1>
           <p className="text-gray-500 font-bold mt-1">
-            {teamMembers.length} freela{teamMembers.length !== 1 ? 's' : ''} na equipe
+            {teamMembers.length} freela{teamMembers.length !== 1 ? 's' : ''} no elenco
             {pendingConnections.length > 0 && (
               <span className="ml-2 text-yellow-600">· {pendingConnections.length} aguardando aceite</span>
             )}
@@ -279,11 +279,11 @@ export default function CompanyTeam() {
         </button>
       </div>
 
-      {/* Equipe aceita */}
+      {/* Elenco aceito */}
       {teamMembers.length > 0 && (
         <section className="mb-8">
           <h2 className="text-xl font-black uppercase mb-4 flex items-center gap-2">
-            <Users size={20} /> Equipe Ativa
+            <Users size={20} /> Elenco Ativo
           </h2>
           <div className="grid grid-cols-1 gap-4">
             {teamMembers.map((member) => (
@@ -311,7 +311,7 @@ export default function CompanyTeam() {
       {teamMembers.length === 0 && pendingConnections.length === 0 && (
         <div className="text-center py-20 border-2 border-dashed border-gray-200 rounded-2xl bg-gray-50">
           <Users size={48} className="mx-auto mb-4 text-gray-300" />
-          <h3 className="text-xl font-black uppercase mb-2">Equipe vazia</h3>
+          <h3 className="text-xl font-black uppercase mb-2">Elenco vazio</h3>
           <p className="text-gray-500 font-bold mb-6 max-w-sm mx-auto">
             Adicione freelas via link de convite, Worki ID ou QR (em breve). Eles aparecerão aqui após aceitarem.
           </p>

--- a/frontend/src/pages/company/CompanyTeam.tsx
+++ b/frontend/src/pages/company/CompanyTeam.tsx
@@ -1,8 +1,15 @@
-import { useState } from 'react';
-import { Users, Link2, Phone, QrCode, Copy, Check, Clock, Star, Briefcase, X, Loader2, UserPlus } from 'lucide-react';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Users, Link2, Phone, QrCode, Copy, Check, Clock, Star, Briefcase, X, Loader2, UserPlus, Share2, CameraOff } from 'lucide-react';
+import { Html5Qrcode, Html5QrcodeSupportedFormats } from 'html5-qrcode';
 import { useCompanyTeam } from '../../hooks/useTeamConnections';
+import { useToast } from '../../contexts/ToastContext';
 import { TeamConnectionService } from '../../services/teamConnectionService';
+import { logError } from '../../lib/logger';
 import type { TeamMember, TeamConnection } from '../../types';
+
+// UUID "solto" — mesmo formato usado como Worki ID (auth.uid()). O QR de
+// identidade (Profile.tsx) codifica o workerId cru, sem prefixo/URL.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 // ---------------------------------------------------------------------------
 // Subcomponent: card de membro da equipe
@@ -15,6 +22,22 @@ interface MemberCardProps {
 function MemberCard({ member }: MemberCardProps) {
   const { worker } = member;
   const avatarUrl = worker.avatar_url ?? worker.photo_url ?? null;
+  const { addToast } = useToast();
+  const [linkCopied, setLinkCopied] = useState(false);
+
+  // Link transitivo: já tenho esse freela no elenco → posso repassar o link
+  // dele pra outra empresa se conectar, sem pedir de novo ao freela.
+  const handleShareLink = async () => {
+    const { url } = TeamConnectionService.generateWorkerInviteToken(worker.id);
+    try {
+      await navigator.clipboard.writeText(url);
+      setLinkCopied(true);
+      addToast('Link do freela copiado! Repasse para outra empresa.', 'success');
+      setTimeout(() => setLinkCopied(false), 2500);
+    } catch {
+      addToast('Não foi possível copiar o link.', 'error');
+    }
+  };
 
   return (
     <div className="bg-white border-2 border-black rounded-2xl p-5 flex items-start gap-4 hover:shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-0.5 transition-all">
@@ -54,10 +77,20 @@ function MemberCard({ member }: MemberCardProps) {
         </div>
       </div>
 
-      {/* Status badge */}
-      <span className="flex-shrink-0 bg-primary-light text-primary text-xs font-black uppercase px-2 py-1 rounded-xl border border-green-200">
-        Elenco
-      </span>
+      {/* Status badge + repassar link */}
+      <div className="flex flex-col items-end gap-2 flex-shrink-0">
+        <span className="bg-primary-light text-primary text-xs font-black uppercase px-2 py-1 rounded-xl border border-green-200">
+          Elenco
+        </span>
+        <button
+          onClick={handleShareLink}
+          aria-label={`Repassar link do freela ${worker.full_name}`}
+          title="Repassar link deste freela para outra empresa"
+          className="p-1.5 rounded-xl text-gray-400 hover:text-black hover:bg-gray-100 transition-colors"
+        >
+          {linkCopied ? <Check size={16} /> : <Share2 size={16} />}
+        </button>
+      </div>
     </div>
   );
 }
@@ -93,10 +126,96 @@ function PendingCard({ connection }: PendingCardProps) {
 }
 
 // ---------------------------------------------------------------------------
+// Subcomponent: scanner de câmera QR (lê o QR de identidade do worker)
+// ---------------------------------------------------------------------------
+
+const QR_READER_ELEMENT_ID = 'add-worker-qr-reader';
+
+interface QrScannerPaneProps {
+  /** Chamado com o texto decodificado do QR (deve ser um Worki ID / UUID). */
+  onDecoded: (decodedText: string) => void;
+  /** true enquanto a última leitura está sendo processada (pausa a câmera). */
+  processing: boolean;
+}
+
+function QrScannerPane({ onDecoded, processing }: QrScannerPaneProps) {
+  const [cameraError, setCameraError] = useState<string | null>(null);
+  const scannerRef = useRef<Html5Qrcode | null>(null);
+  const onDecodedRef = useRef(onDecoded);
+
+  useEffect(() => {
+    onDecodedRef.current = onDecoded;
+  }, [onDecoded]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const scanner = new Html5Qrcode(QR_READER_ELEMENT_ID, {
+      formatsToSupport: [Html5QrcodeSupportedFormats.QR_CODE],
+      verbose: false,
+    });
+    scannerRef.current = scanner;
+
+    scanner
+      .start(
+        { facingMode: 'environment' },
+        { fps: 10, qrbox: { width: 220, height: 220 } },
+        (decodedText) => {
+          if (cancelled) return;
+          onDecodedRef.current(decodedText);
+        },
+        () => {
+          // Frame sem QR detectado — esperado a cada tick, não é erro real.
+        },
+      )
+      .catch((err) => {
+        if (cancelled) return;
+        logError('CompanyTeam.qrScanner.start', err);
+        setCameraError('Não foi possível acessar a câmera. Verifique a permissão do navegador para este site.');
+      });
+
+    return () => {
+      cancelled = true;
+      const instance = scannerRef.current;
+      if (instance) {
+        instance
+          .stop()
+          .then(() => instance.clear())
+          .catch(() => {
+            // câmera pode já ter sido interrompida (unmount rápido) — seguro ignorar
+          });
+      }
+    };
+  }, []);
+
+  if (cameraError) {
+    return (
+      <div className="bg-red-50 border-2 border-red-200 rounded-xl p-6 text-center flex flex-col items-center gap-2">
+        <CameraOff className="text-red-500" size={28} />
+        <p className="text-sm font-bold text-red-600">{cameraError}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <div
+        id={QR_READER_ELEMENT_ID}
+        className="rounded-xl overflow-hidden border-2 border-black bg-black [&_video]:w-full [&_video]:rounded-xl"
+      />
+      {processing && (
+        <div className="absolute inset-0 bg-black/60 rounded-xl flex items-center justify-center">
+          <Loader2 className="animate-spin text-white" size={32} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Subcomponent: modal "Adicionar freela"
 // ---------------------------------------------------------------------------
 
-type AddMethod = 'link' | 'phone';
+type AddMethod = 'link' | 'phone' | 'qr';
 
 interface AddWorkerModalProps {
   companyId: string;
@@ -111,6 +230,9 @@ function AddWorkerModal({ companyId, onClose, onAdded, addWorker }: AddWorkerMod
   const [workerId, setWorkerId] = useState('');
   const [loading, setLoading] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [qrProcessing, setQrProcessing] = useState(false);
+  const qrLockRef = useRef(false);
+  const { addToast } = useToast();
 
   const { url: inviteUrl } = TeamConnectionService.generateInviteToken(companyId);
 
@@ -135,6 +257,33 @@ function AddWorkerModal({ companyId, onClose, onAdded, addWorker }: AddWorkerMod
     }
   };
 
+  // A câmera manda frames continuamente; trava para não disparar 2x a mesma leitura.
+  const handleQrDecoded = useCallback(
+    async (decodedText: string) => {
+      if (qrLockRef.current) return;
+      const candidate = decodedText.trim();
+
+      if (!UUID_RE.test(candidate)) {
+        addToast('QR inválido. Peça ao freela para abrir "Meu QR de Identidade" no perfil dele.', 'error');
+        return;
+      }
+
+      qrLockRef.current = true;
+      setQrProcessing(true);
+      const ok = await addWorker(candidate, 'qr');
+      setQrProcessing(false);
+
+      if (ok) {
+        onAdded();
+        onClose();
+        return;
+      }
+      // erro já foi mostrado via toast pelo addWorker — libera pra tentar de novo
+      qrLockRef.current = false;
+    },
+    [addWorker, addToast, onAdded, onClose],
+  );
+
   return (
     <div
       className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 animate-in fade-in duration-200"
@@ -153,6 +302,7 @@ function AddWorkerModal({ companyId, onClose, onAdded, addWorker }: AddWorkerMod
         <div className="flex gap-2 mb-6 border-b-2 border-gray-200 pb-1">
           {([
             { id: 'link' as AddMethod, icon: Link2, label: 'Link' },
+            { id: 'qr' as AddMethod, icon: QrCode, label: 'QR' },
             { id: 'phone' as AddMethod, icon: Phone, label: 'Telefone' },
           ] as const).map((tab) => (
             <button
@@ -167,14 +317,6 @@ function AddWorkerModal({ companyId, onClose, onAdded, addWorker }: AddWorkerMod
               <tab.icon size={16} /> {tab.label}
             </button>
           ))}
-          {/* QR: destaque como "em breve" */}
-          <button
-            disabled
-            className="flex items-center gap-2 px-4 py-2 rounded-t-xl font-black uppercase text-sm text-gray-300 cursor-not-allowed"
-            title="Scanner QR disponível na v1.1"
-          >
-            <QrCode size={16} /> QR (v1.1)
-          </button>
         </div>
 
         {/* Conteúdo por método */}
@@ -193,6 +335,19 @@ function AddWorkerModal({ companyId, onClose, onAdded, addWorker }: AddWorkerMod
               {copied ? <Check size={18} /> : <Copy size={18} />}
               {copied ? 'Copiado!' : 'Copiar Link'}
             </button>
+            <p className="text-xs text-gray-400 text-center">
+              O freela aparecerá em "Aguardando" até aceitar o convite.
+            </p>
+          </div>
+        )}
+
+        {method === 'qr' && (
+          <div className="space-y-4">
+            <p className="text-sm font-bold text-gray-600">
+              Aponte a câmera para o <span className="font-black">QR de Identidade</span> do freela
+              (ele encontra em Perfil → "Meu QR de Identidade").
+            </p>
+            <QrScannerPane onDecoded={handleQrDecoded} processing={qrProcessing} />
             <p className="text-xs text-gray-400 text-center">
               O freela aparecerá em "Aguardando" até aceitar o convite.
             </p>
@@ -313,7 +468,7 @@ export default function CompanyTeam() {
           <Users size={48} className="mx-auto mb-4 text-gray-300" />
           <h3 className="text-xl font-black uppercase mb-2">Elenco vazio</h3>
           <p className="text-gray-500 font-bold mb-6 max-w-sm mx-auto">
-            Adicione freelas via link de convite, Worki ID ou QR (em breve). Eles aparecerão aqui após aceitarem.
+            Adicione freelas via link de convite, QR de identidade ou Worki ID. Eles aparecerão aqui após aceitarem.
           </p>
           <button
             onClick={() => setShowAddModal(true)}

--- a/frontend/src/services/financialBIService.test.ts
+++ b/frontend/src/services/financialBIService.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mock supabase — chain genérica encadeável (select/eq/in/not) que resolve
+// para `result` em maybeSingle()/single()/await direto (thenable), no padrão
+// de paymentRecordService.test.ts. fromMock roteia por nome de tabela.
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeChain(result: { data: any; error: any }) {
+  const promise = Promise.resolve(result)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = {
+    select: vi.fn(() => chain),
+    eq: vi.fn(() => chain),
+    in: vi.fn(() => chain),
+    not: vi.fn(() => chain),
+    order: vi.fn(() => chain),
+    maybeSingle: vi.fn(() => promise),
+    single: vi.fn(() => promise),
+    then: promise.then.bind(promise),
+    catch: promise.catch.bind(promise),
+  }
+  return chain
+}
+
+const mockFrom = vi.fn()
+
+vi.mock('../lib/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function routeFrom(handlers: Record<string, any>) {
+  mockFrom.mockImplementation((table: string) => {
+    const handler = handlers[table]
+    if (!handler) throw new Error(`Tabela não mockada: ${table}`)
+    return handler
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// Fixtures — ADR-20260630 "Impacto no BI": gasto = escrow (released/captured)
+// ∪ shift_payments (recorded), dedupe por job_id com precedência do escrow.
+// ---------------------------------------------------------------------------
+
+const WALLET_ROW = { id: 'wallet-company-1' }
+
+const PERIOD = { start: '2026-06-01', end: '2026-07-01' }
+
+// job-1 aparece nas DUAS fontes (anomalia) — escrow deve prevalecer (100, não 100+999).
+// job-2 só aparece no marcador externo — deve somar (50).
+const ESCROW_ROWS = [
+  {
+    amount: 100,
+    captured_at: '2026-06-15T10:00:00Z',
+    released_at: null,
+    created_at: '2026-06-01T00:00:00Z',
+    application_id: 'app-1',
+    job_id: 'job-1',
+  },
+]
+
+const SHIFT_PAYMENT_ROWS = [
+  {
+    amount: 999, // deve ser IGNORADO na soma — job-1 já tem escrow (precedência)
+    paid_at: '2026-06-20T10:00:00Z',
+    job_id: 'job-1',
+    application_id: 'app-1',
+    worker_id: 'worker-1',
+  },
+  {
+    amount: 50, // job_id disjunto — soma normalmente
+    paid_at: '2026-06-21T10:00:00Z',
+    job_id: 'job-2',
+    application_id: null,
+    worker_id: 'worker-2',
+  },
+]
+
+const APPLICATIONS_ROWS = [
+  {
+    id: 'app-1',
+    worker_id: 'worker-1',
+    job_id: 'job-1',
+    worker_checkin_at: null,
+    worker_checkout_at: null,
+    status: 'completed',
+  },
+]
+
+const JOBS_ROWS = [
+  { id: 'job-1', estimated_hours: 8 },
+  { id: 'job-2', estimated_hours: 5 },
+]
+
+const WORKERS_ROWS = [
+  { id: 'worker-1', full_name: 'Worker Um', avatar_url: null, photo_url: null },
+  { id: 'worker-2', full_name: 'Worker Dois', avatar_url: null, photo_url: null },
+]
+
+// ---------------------------------------------------------------------------
+// BI-1: getAccumulatedSpend — dedupe por job_id (escrow precede)
+// ---------------------------------------------------------------------------
+
+describe('FinancialBIService.getAccumulatedSpend — fonte unificada (escrow ∪ shift_payments)', () => {
+  it('soma escrow + marcador externo com job_id disjuntos, e IGNORA o marcador quando o job_id já tem escrow (precedência do escrow)', async () => {
+    routeFrom({
+      wallets: makeChain({ data: WALLET_ROW, error: null }),
+      escrow_transactions: makeChain({ data: ESCROW_ROWS, error: null }),
+      shift_payments: makeChain({ data: SHIFT_PAYMENT_ROWS, error: null }),
+    })
+
+    const { FinancialBIService } = await import('./financialBIService')
+    const result = await FinancialBIService.getAccumulatedSpend('company-1', PERIOD)
+
+    // 100 (escrow, job-1) + 50 (external, job-2) — os 999 do marcador de job-1 são descartados.
+    expect(result.totalAmount).toBe(150)
+  })
+
+  it('soma só o marcador externo quando não há wallet/escrow (empresa que só usa o modo A)', async () => {
+    routeFrom({
+      wallets: makeChain({ data: null, error: null }),
+      shift_payments: makeChain({
+        data: [SHIFT_PAYMENT_ROWS[1]], // só o job-2 (50)
+        error: null,
+      }),
+    })
+
+    const { FinancialBIService } = await import('./financialBIService')
+    const result = await FinancialBIService.getAccumulatedSpend('company-1', PERIOD)
+
+    expect(result.totalAmount).toBe(50)
+  })
+
+  it('descarta linhas de shift_payments fora do período (filtro por paid_at)', async () => {
+    routeFrom({
+      wallets: makeChain({ data: WALLET_ROW, error: null }),
+      escrow_transactions: makeChain({ data: [], error: null }),
+      shift_payments: makeChain({
+        data: [{ ...SHIFT_PAYMENT_ROWS[1], paid_at: '2026-05-15T10:00:00Z' }], // mês anterior
+        error: null,
+      }),
+    })
+
+    const { FinancialBIService } = await import('./financialBIService')
+    const result = await FinancialBIService.getAccumulatedSpend('company-1', PERIOD)
+
+    expect(result.totalAmount).toBe(0)
+  })
+
+  it('retorna zero (best-effort) sem lançar exceção em erro de query', async () => {
+    routeFrom({
+      wallets: makeChain({ data: WALLET_ROW, error: null }),
+      escrow_transactions: makeChain({ data: null, error: { message: 'db error' } }),
+      shift_payments: makeChain({ data: null, error: { message: 'db error' } }),
+    })
+
+    const { FinancialBIService } = await import('./financialBIService')
+    const result = await FinancialBIService.getAccumulatedSpend('company-1', PERIOD)
+
+    expect(result.totalAmount).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// BI-2: getSpendByWorker — agrega gasto+horas por freela nas duas fontes
+// ---------------------------------------------------------------------------
+
+describe('FinancialBIService.getSpendByWorker — agrega escrow + marcador externo por freela', () => {
+  it('agrega worker-1 (escrow, via application) e worker-2 (externo, sem application) separadamente', async () => {
+    routeFrom({
+      wallets: makeChain({ data: WALLET_ROW, error: null }),
+      escrow_transactions: makeChain({ data: ESCROW_ROWS, error: null }),
+      shift_payments: makeChain({ data: SHIFT_PAYMENT_ROWS, error: null }),
+      applications: makeChain({ data: APPLICATIONS_ROWS, error: null }),
+      jobs: makeChain({ data: JOBS_ROWS, error: null }),
+      workers: makeChain({ data: WORKERS_ROWS, error: null }),
+    })
+
+    const { FinancialBIService } = await import('./financialBIService')
+    const result = await FinancialBIService.getSpendByWorker('company-1', PERIOD)
+
+    expect(result).toHaveLength(2)
+
+    const worker1 = result.find((w) => w.workerId === 'worker-1')
+    const worker2 = result.find((w) => w.workerId === 'worker-2')
+
+    // worker-1: só a linha de escrow (job-1) conta — o marcador de job-1 foi deduplicado.
+    expect(worker1?.totalAmount).toBe(100)
+    expect(worker1?.totalHours).toBe(8) // fallback estimated_hours (sem checkin/checkout)
+    expect(worker1?.shiftsCount).toBe(1)
+
+    // worker-2: só a linha externa (job-2, sem escrow) conta.
+    expect(worker2?.totalAmount).toBe(50)
+    expect(worker2?.totalHours).toBe(5) // fallback estimated_hours via job-2
+    expect(worker2?.shiftsCount).toBe(1)
+  })
+
+  it('retorna lista vazia quando não há gasto em nenhuma fonte no período', async () => {
+    routeFrom({
+      wallets: makeChain({ data: WALLET_ROW, error: null }),
+      escrow_transactions: makeChain({ data: [], error: null }),
+      shift_payments: makeChain({ data: [], error: null }),
+    })
+
+    const { FinancialBIService } = await import('./financialBIService')
+    const result = await FinancialBIService.getSpendByWorker('company-1', PERIOD)
+
+    expect(result).toEqual([])
+  })
+})

--- a/frontend/src/services/financialBIService.ts
+++ b/frontend/src/services/financialBIService.ts
@@ -1,7 +1,7 @@
 /**
  * FinancialBIService — inteligência financeira da empresa (Slice 3, R13-R16).
  *
- * Implementa 4 queries derivadas de BI sobre escrow_transactions + jobs + applications.
+ * Implementa 4 queries derivadas de BI sobre escrow_transactions + shift_payments + jobs + applications.
  * Nenhuma view criada (decisão do architect: views não propagam RLS com segurança — spec Slice 3).
  *
  * BI-2: Gasto e horas por freela (real: checkout-checkin; fallback: jobs.estimated_hours).
@@ -9,11 +9,18 @@
  * BI-4: Custo de no-show — heurística v1, ROTULADO COMO ESTIMATIVA.
  * BI-5: Flag de concentração de horas/dias por freela (risco de vínculo trabalhista).
  *
- * Contratos de dados (spec Slice 3):
- *  - Gasto = escrow_transactions WHERE status IN ('released','captured').
- *  - Carimbo: COALESCE(captured_at, released_at, created_at) — filtrar o mês por este.
- *  - Empresa da linha: company_wallet_id → wallets.user_id = companyId.
- *  - Freela: worker_wallet_id → wallets.user_id | application_id → applications.worker_id.
+ * Contratos de dados (spec Slice 3 + ADR-20260630-pagamento-opcional-piloto "Impacto no BI"):
+ *  - Gasto = UNIÃO de duas fontes:
+ *      1. Trilho Worki (modos B/C): escrow_transactions WHERE status IN ('released','captured').
+ *         Carimbo: COALESCE(captured_at, released_at, created_at).
+ *      2. Pagamento externo (modo A): shift_payments WHERE status = 'recorded'.
+ *         Carimbo: paid_at.
+ *  - Dedupe por `job_id`: um turno é pago por EXATAMENTE uma fonte. Se o mesmo job_id aparecer
+ *    nas duas (anomalia), o ESCROW TEM PRECEDÊNCIA e a linha externa é descartada da soma —
+ *    ver `fetchUnifiedSpendRows` e ADR-20260630 seção "Impacto no BI".
+ *  - Empresa da linha: escrow via company_wallet_id → wallets.user_id = companyId;
+ *    shift_payments via company_id = companyId diretamente (mesmo UUID — companies.id = owner_id).
+ *  - Freela: escrow via application_id → applications.worker_id; shift_payments já traz worker_id.
  *
  * Padrões do projeto:
  *  - supabase.from direto (Art. 5 — sem React Query).
@@ -109,6 +116,28 @@ interface WorkerProfileRow {
   photo_url: string | null;
 }
 
+/** Linha crua de shift_payments (modo A — pagamento externo). */
+interface ShiftPaymentSpendRow {
+  amount: number;
+  paid_at: string;
+  job_id: string;
+  application_id: string | null;
+  worker_id: string;
+}
+
+/**
+ * Linha de gasto já unificada (uma fonte, pós-dedupe) — ver `fetchUnifiedSpendRows`.
+ * `workerId` só vem preenchido diretamente para 'external' (shift_payments.worker_id);
+ * para 'escrow' é resolvido via applications (application_id → worker_id) por quem consome.
+ */
+interface UnifiedSpendRow {
+  source: 'escrow' | 'external';
+  amount: number;
+  jobId: string | null;
+  applicationId: string | null;
+  workerId: string | null;
+}
+
 // ---------------------------------------------------------------------------
 // Helper: buscar wallet_id da empresa
 // ---------------------------------------------------------------------------
@@ -138,6 +167,93 @@ function isInPeriod(row: EscrowRow, startDate: Date, endDate: Date): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Helper: gasto unificado do período (escrow ∪ marcador externo, dedupe por job_id)
+// Contrato: ADR-20260630-pagamento-opcional-piloto.md, seção "Impacto no BI".
+// ---------------------------------------------------------------------------
+
+/**
+ * Busca e unifica as duas fontes de gasto da empresa no período:
+ *  1. escrow_transactions (status IN released/captured) — trilho Worki (modos B/C).
+ *  2. shift_payments (status = 'recorded') — pagamento externo declarado (modo A).
+ *
+ * Dedupe por `job_id`: um turno é pago por EXATAMENTE uma fonte. Se o mesmo `job_id`
+ * aparecer nas duas (anomalia), a linha do escrow é mantida e a linha externa
+ * correspondente é DESCARTADA da soma (escrow tem precedência — ADR-20260630).
+ *
+ * Reutilizado por getAccumulatedSpend (BI-1), getSpendByWorker (BI-2) e, indiretamente,
+ * por getCostRatio (BI-3, via totalCost) e por SpendLimitService.evaluateSpendAlert (R12).
+ */
+async function fetchUnifiedSpendRows(
+  companyId: string,
+  period: BIPeriod,
+): Promise<UnifiedSpendRow[]> {
+  const startDate = new Date(period.start);
+  const endDate = new Date(period.end);
+  const walletId = await getCompanyWalletId(companyId);
+
+  const [escrowResult, shiftResult] = await Promise.all([
+    walletId
+      ? supabase
+          .from('escrow_transactions')
+          .select('amount, captured_at, released_at, created_at, application_id, job_id')
+          .eq('company_wallet_id', walletId)
+          .in('status', ['released', 'captured'])
+      : Promise.resolve({ data: [] as EscrowRow[], error: null }),
+    supabase
+      .from('shift_payments')
+      .select('amount, paid_at, job_id, application_id, worker_id')
+      .eq('company_id', companyId)
+      .eq('status', 'recorded'),
+  ]);
+
+  if (escrowResult.error) {
+    logError('financialBI.fetchUnifiedSpendRows.escrow', escrowResult.error);
+  }
+  if (shiftResult.error) {
+    logError('financialBI.fetchUnifiedSpendRows.shift', shiftResult.error);
+  }
+
+  const escrowInPeriod = ((escrowResult.data ?? []) as EscrowRow[]).filter((r) =>
+    isInPeriod(r, startDate, endDate),
+  );
+
+  // job_ids já cobertos pelo trilho Worki no período — o marcador externo cede a eles.
+  const escrowJobIds = new Set(
+    escrowInPeriod.map((r) => r.job_id).filter((j): j is string => Boolean(j)),
+  );
+
+  const shiftInPeriod = ((shiftResult.data ?? []) as ShiftPaymentSpendRow[]).filter((r) => {
+    const stamp = new Date(r.paid_at);
+    return stamp >= startDate && stamp < endDate;
+  });
+
+  const rows: UnifiedSpendRow[] = [
+    ...escrowInPeriod.map(
+      (r): UnifiedSpendRow => ({
+        source: 'escrow',
+        amount: Number(r.amount ?? 0),
+        jobId: r.job_id,
+        applicationId: r.application_id,
+        workerId: null,
+      }),
+    ),
+    ...shiftInPeriod
+      .filter((r) => !escrowJobIds.has(r.job_id)) // dedupe: escrow tem precedência
+      .map(
+        (r): UnifiedSpendRow => ({
+          source: 'external',
+          amount: Number(r.amount ?? 0),
+          jobId: r.job_id,
+          applicationId: r.application_id,
+          workerId: r.worker_id,
+        }),
+      ),
+  ];
+
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
 // FinancialBIService (exportado)
 // ---------------------------------------------------------------------------
 
@@ -148,8 +264,9 @@ export const FinancialBIService = {
 
   /**
    * Computa o gasto acumulado da empresa no período (BI-1).
-   * Fonte: escrow_transactions WHERE status IN ('released','captured'),
-   * filtrado pelo carimbo COALESCE(captured_at, released_at, created_at).
+   * Fonte: UNIÃO de escrow_transactions (released/captured) e shift_payments (recorded),
+   * dedupe por job_id com precedência do escrow — ver `fetchUnifiedSpendRows` e
+   * ADR-20260630-pagamento-opcional-piloto.md "Impacto no BI".
    */
   async getAccumulatedSpend(companyId: string, period: BIPeriod): Promise<AccumulatedSpend> {
     const empty: AccumulatedSpend = {
@@ -159,30 +276,8 @@ export const FinancialBIService = {
     };
 
     try {
-      const walletId = await getCompanyWalletId(companyId);
-      if (!walletId) return empty;
-
-      const { data: rows, error } = await supabase
-        .from('escrow_transactions')
-        .select('amount, captured_at, released_at, created_at')
-        .eq('company_wallet_id', walletId)
-        .in('status', ['released', 'captured']);
-
-      if (error) {
-        logError('financialBI.getAccumulatedSpend', error);
-        return empty;
-      }
-
-      const startDate = new Date(period.start);
-      const endDate = new Date(period.end);
-      let totalAmount = 0;
-
-      for (const row of (rows ?? []) as EscrowRow[]) {
-        if (isInPeriod(row, startDate, endDate)) {
-          totalAmount += Number(row.amount ?? 0);
-        }
-      }
-
+      const rows = await fetchUnifiedSpendRows(companyId, period);
+      const totalAmount = rows.reduce((acc, r) => acc + r.amount, 0);
       return { totalAmount, periodStart: period.start, periodEnd: period.end };
     } catch (err) {
       logError('financialBI.getAccumulatedSpend', err);
@@ -198,48 +293,36 @@ export const FinancialBIService = {
    * Gasto e horas por freela no período (BI-2).
    *
    * Horas reais quando houver worker_checkout_at e worker_checkin_at em applications.
-   * Fallback: jobs.estimated_hours do turno concluído.
+   * Fallback: jobs.estimated_hours do turno concluído. O marcador externo (modo A) NÃO
+   * carrega horas — entra só no GASTO; as horas continuam vindo de jobs/applications
+   * via application_id (quando presente), igual ao trilho escrow.
    * hoursSource = 'real' | 'estimated' | 'mixed' (por freela no período).
    *
-   * Agrupa por worker_id (via application_id → applications.worker_id).
+   * Agrupa por worker_id: para linhas 'escrow', resolvido via application_id →
+   * applications.worker_id; para linhas 'external' (shift_payments), já vem direto na linha.
    */
   async getSpendByWorker(companyId: string, period: BIPeriod): Promise<SpendByWorker[]> {
     try {
-      const walletId = await getCompanyWalletId(companyId);
-      if (!walletId) return [];
+      // 1. Gasto unificado do período (escrow ∪ marcador externo, dedupe por job_id)
+      const unified = await fetchUnifiedSpendRows(companyId, period);
+      if (unified.length === 0) return [];
 
-      // 1. Linhas de escrow no período (com application_id para join)
-      const { data: escrowRows, error: escrowErr } = await supabase
-        .from('escrow_transactions')
-        .select('amount, captured_at, released_at, created_at, application_id, job_id')
-        .eq('company_wallet_id', walletId)
-        .in('status', ['released', 'captured'])
-        .not('application_id', 'is', null);
-
-      if (escrowErr) {
-        logError('financialBI.getSpendByWorker.escrow', escrowErr);
-        return [];
-      }
-
-      const startDate = new Date(period.start);
-      const endDate = new Date(period.end);
-
-      // Filtrar pelo período
-      const inPeriod = ((escrowRows ?? []) as EscrowRow[]).filter((r) =>
-        isInPeriod(r, startDate, endDate),
-      );
-
-      if (inPeriod.length === 0) return [];
-
-      // 2. Buscar applications (check-in/out + worker_id) para os application_ids do período
-      const appIds = [...new Set(inPeriod.map((r) => r.application_id as string))];
-      const jobIds = [...new Set(inPeriod.map((r) => r.job_id).filter(Boolean) as string[])];
+      // 2. Buscar applications (check-in/out + worker_id) e jobs (fallback de horas)
+      //    para todos os application_ids/job_ids presentes nas duas fontes.
+      const appIds = [...new Set(
+        unified.map((r) => r.applicationId).filter((a): a is string => Boolean(a)),
+      )];
+      const jobIds = [...new Set(
+        unified.map((r) => r.jobId).filter((j): j is string => Boolean(j)),
+      )];
 
       const [appResult, jobResult] = await Promise.all([
-        supabase
-          .from('applications')
-          .select('id, worker_id, job_id, worker_checkin_at, worker_checkout_at, status')
-          .in('id', appIds),
+        appIds.length > 0
+          ? supabase
+              .from('applications')
+              .select('id, worker_id, job_id, worker_checkin_at, worker_checkout_at, status')
+              .in('id', appIds)
+          : Promise.resolve({ data: [], error: null }),
         jobIds.length > 0
           ? supabase
               .from('jobs')
@@ -263,16 +346,28 @@ export const FinancialBIService = {
         ((jobResult.data ?? []) as JobRow[]).map((j) => [j.id, j]),
       );
 
+      // 3. Resolver worker_id de cada linha unificada. 'escrow' → via appMap (como antes);
+      //    'external' → já vem direto na linha (shift_payments.worker_id). Linhas sem
+      //    worker resolvível (escrow órfão de application) são descartadas, como antes.
+      interface ResolvedRow {
+        workerId: string;
+        amount: number;
+        applicationId: string | null;
+        jobId: string | null;
+      }
+      const resolved: ResolvedRow[] = [];
+      for (const row of unified) {
+        const workerId = row.workerId ?? (row.applicationId ? appMap.get(row.applicationId)?.worker_id : undefined);
+        if (!workerId) continue;
+        resolved.push({ workerId, amount: row.amount, applicationId: row.applicationId, jobId: row.jobId });
+      }
+
+      if (resolved.length === 0) return [];
+
       // Coletar worker_ids únicos
-      const workerIds = [...new Set(
-        appIds
-          .map((aid) => appMap.get(aid)?.worker_id)
-          .filter(Boolean) as string[],
-      )];
+      const workerIds = [...new Set(resolved.map((r) => r.workerId))];
 
-      if (workerIds.length === 0) return [];
-
-      // 3. Buscar perfis dos workers
+      // 4. Buscar perfis dos workers
       const { data: workers, error: workerErr } = await supabase
         .from('workers')
         .select('id, full_name, avatar_url, photo_url')
@@ -286,7 +381,7 @@ export const FinancialBIService = {
         ((workers ?? []) as WorkerProfileRow[]).map((w) => [w.id, w]),
       );
 
-      // 4. Agregar por worker
+      // 5. Agregar por worker
       interface WorkerAgg {
         totalAmount: number;
         totalHours: number;
@@ -297,13 +392,9 @@ export const FinancialBIService = {
 
       const agg = new Map<string, WorkerAgg>();
 
-      for (const row of inPeriod) {
-        const app = appMap.get(row.application_id as string);
-        if (!app) continue;
-
-        const workerId = app.worker_id;
-        if (!agg.has(workerId)) {
-          agg.set(workerId, {
+      for (const row of resolved) {
+        if (!agg.has(row.workerId)) {
+          agg.set(row.workerId, {
             totalAmount: 0,
             totalHours: 0,
             realHoursCount: 0,
@@ -311,12 +402,14 @@ export const FinancialBIService = {
             shiftsCount: 0,
           });
         }
-        const entry = agg.get(workerId)!;
-        entry.totalAmount += Number(row.amount ?? 0);
+        const entry = agg.get(row.workerId)!;
+        entry.totalAmount += row.amount;
         entry.shiftsCount += 1;
 
-        // Horas: real se houver check-in/out; fallback estimated_hours
-        if (app.worker_checkin_at && app.worker_checkout_at) {
+        // Horas: real se houver check-in/out; fallback estimated_hours. Independente da
+        // fonte de gasto (escrow ou externo) — vem sempre de applications/jobs.
+        const app = row.applicationId ? appMap.get(row.applicationId) : undefined;
+        if (app?.worker_checkin_at && app?.worker_checkout_at) {
           const hours =
             (new Date(app.worker_checkout_at).getTime() -
               new Date(app.worker_checkin_at).getTime()) /
@@ -324,7 +417,7 @@ export const FinancialBIService = {
           entry.totalHours += hours;
           entry.realHoursCount += 1;
         } else {
-          const job = row.job_id ? jobMap.get(row.job_id) : undefined;
+          const job = row.jobId ? jobMap.get(row.jobId) : undefined;
           const estimated = job?.estimated_hours ?? 0;
           entry.totalHours += estimated;
           entry.estimatedHoursCount += 1;

--- a/frontend/src/services/paymentRecordService.test.ts
+++ b/frontend/src/services/paymentRecordService.test.ts
@@ -1,0 +1,439 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ShiftPayment, PaymentSource, ShiftPaymentStatus } from '../types'
+
+// ---------------------------------------------------------------------------
+// Mock supabase — chain genérica encadeável (select/insert/update/eq) que
+// resolve para `result` em maybeSingle()/single()/await direto (thenable).
+// fromMock roteia por nome de tabela (um handler por tabela por teste).
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeChain(result: { data: any; error: any }) {
+  const promise = Promise.resolve(result)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = {
+    select: vi.fn(() => chain),
+    insert: vi.fn(() => chain),
+    update: vi.fn(() => chain),
+    eq: vi.fn(() => chain),
+    maybeSingle: vi.fn(() => promise),
+    single: vi.fn(() => promise),
+    then: promise.then.bind(promise),
+    catch: promise.catch.bind(promise),
+  }
+  return chain
+}
+
+const mockGetUser = vi.fn()
+const mockFrom = vi.fn()
+
+vi.mock('../lib/supabase', () => ({
+  supabase: {
+    auth: { getUser: (...args: unknown[]) => mockGetUser(...args) },
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function routeFrom(handlers: Record<string, any>) {
+  mockFrom.mockImplementation((table: string) => {
+    const handler = handlers[table]
+    if (!handler) throw new Error(`Tabela não mockada: ${table}`)
+    return handler
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'user-company-1' } } })
+})
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const APPLICATION_COMPLETED = {
+  id: 'app-1',
+  job_id: 'job-1',
+  worker_id: 'worker-1',
+  company_checkin_confirmed_at: '2026-06-30T09:00:00Z',
+  company_checkout_confirmed_at: '2026-06-30T17:00:00Z',
+}
+
+const COMPANY_ROW = { id: 'company-1' }
+
+const SHIFT_PAYMENT_ROW: ShiftPayment = {
+  id: 'sp-1',
+  job_id: 'job-1',
+  company_id: 'company-1',
+  worker_id: 'worker-1',
+  application_id: 'app-1',
+  source: 'external_pix',
+  amount: 150,
+  paid_at: '2026-06-30T12:00:00Z',
+  recorded_by: 'user-company-1',
+  worker_confirmed_at: null,
+  note: null,
+  status: 'recorded',
+  voided_at: null,
+  void_reason: null,
+  created_at: '2026-06-30T12:00:00Z',
+}
+
+// ---------------------------------------------------------------------------
+// Tipos
+// ---------------------------------------------------------------------------
+
+describe('Tipos ShiftPayment', () => {
+  it('ShiftPayment aceita todos os campos da migration', () => {
+    expect(SHIFT_PAYMENT_ROW.status).toBe('recorded')
+    expect(SHIFT_PAYMENT_ROW.source).toBe('external_pix')
+    expect(SHIFT_PAYMENT_ROW.worker_confirmed_at).toBeNull()
+  })
+
+  it('PaymentSource aceita external_pix | cash | other', () => {
+    const sources: PaymentSource[] = ['external_pix', 'cash', 'other']
+    sources.forEach((s) => expect(['external_pix', 'cash', 'other']).toContain(s))
+  })
+
+  it('ShiftPaymentStatus aceita recorded | voided', () => {
+    const statuses: ShiftPaymentStatus[] = ['recorded', 'voided']
+    statuses.forEach((s) => expect(['recorded', 'voided']).toContain(s))
+  })
+
+  it('ShiftPayment aceita voided com voided_at/void_reason preenchidos', () => {
+    const voided: ShiftPayment = {
+      ...SHIFT_PAYMENT_ROW,
+      status: 'voided',
+      voided_at: '2026-07-01T00:00:00Z',
+      void_reason: 'Valor incorreto',
+    }
+    expect(voided.status).toBe('voided')
+    expect(voided.voided_at).not.toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// recordExternalPayment
+// ---------------------------------------------------------------------------
+
+describe('PaymentRecordService.recordExternalPayment', () => {
+  it('rejeita amount <= 0 sem chamar o supabase', async () => {
+    const { PaymentRecordService } = await import('./paymentRecordService')
+
+    const result = await PaymentRecordService.recordExternalPayment({
+      jobId: 'job-1',
+      workerId: 'worker-1',
+      applicationId: 'app-1',
+      source: 'cash',
+      amount: 0,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/maior que zero/)
+    expect(mockFrom).not.toHaveBeenCalled()
+  })
+
+  it('rejeita quando o turno (application) não está concluído (checkout ainda não confirmado)', async () => {
+    routeFrom({
+      applications: makeChain({
+        data: { ...APPLICATION_COMPLETED, company_checkout_confirmed_at: null },
+        error: null,
+      }),
+    })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.recordExternalPayment({
+      jobId: 'job-1',
+      workerId: 'worker-1',
+      applicationId: 'app-1',
+      source: 'cash',
+      amount: 100,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/concluído/)
+  })
+
+  it('rejeita quando o turno (application) não está concluído (chegada ainda não confirmada)', async () => {
+    routeFrom({
+      applications: makeChain({
+        data: { ...APPLICATION_COMPLETED, company_checkin_confirmed_at: null },
+        error: null,
+      }),
+    })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.recordExternalPayment({
+      jobId: 'job-1',
+      workerId: 'worker-1',
+      applicationId: 'app-1',
+      source: 'cash',
+      amount: 100,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/concluído/)
+  })
+
+  it('registra com sucesso mesmo quando application.status ainda não é "completed" (só depende do sinal real de conclusão)', async () => {
+    routeFrom({
+      applications: makeChain({
+        data: { ...APPLICATION_COMPLETED, status: 'in_progress' },
+        error: null,
+      }),
+      companies: makeChain({ data: COMPANY_ROW, error: null }),
+      shift_payments: makeChain({ data: SHIFT_PAYMENT_ROW, error: null }),
+    })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.recordExternalPayment({
+      jobId: 'job-1',
+      workerId: 'worker-1',
+      applicationId: 'app-1',
+      source: 'cash',
+      amount: 100,
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('rejeita quando a application não corresponde ao job/worker informados', async () => {
+    routeFrom({
+      applications: makeChain({
+        data: { ...APPLICATION_COMPLETED, worker_id: 'worker-OUTRO' },
+        error: null,
+      }),
+    })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.recordExternalPayment({
+      jobId: 'job-1',
+      workerId: 'worker-1',
+      applicationId: 'app-1',
+      source: 'cash',
+      amount: 100,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/não corresponde/)
+  })
+
+  it('rejeita quando a application não existe', async () => {
+    routeFrom({
+      applications: makeChain({ data: null, error: null }),
+    })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.recordExternalPayment({
+      jobId: 'job-1',
+      workerId: 'worker-1',
+      applicationId: 'app-inexistente',
+      source: 'cash',
+      amount: 100,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/não encontrad/)
+  })
+
+  it('registra com sucesso quando o turno está concluído', async () => {
+    routeFrom({
+      applications: makeChain({ data: APPLICATION_COMPLETED, error: null }),
+      companies: makeChain({ data: COMPANY_ROW, error: null }),
+      shift_payments: makeChain({ data: SHIFT_PAYMENT_ROW, error: null }),
+    })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.recordExternalPayment({
+      jobId: 'job-1',
+      workerId: 'worker-1',
+      applicationId: 'app-1',
+      source: 'external_pix',
+      amount: 150,
+      note: 'Pago via PIX',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.payment).toEqual(SHIFT_PAYMENT_ROW)
+    expect(mockFrom).toHaveBeenCalledWith('shift_payments')
+    expect(mockFrom).toHaveBeenCalledWith('companies')
+    expect(mockFrom).toHaveBeenCalledWith('applications')
+  })
+
+  it('trata violação do UNIQUE parcial (23505) como alreadyRecorded, sem crashar', async () => {
+    routeFrom({
+      applications: makeChain({ data: APPLICATION_COMPLETED, error: null }),
+      companies: makeChain({ data: COMPANY_ROW, error: null }),
+      shift_payments: makeChain({
+        data: null,
+        error: { code: '23505', message: 'duplicate key value violates unique constraint' },
+      }),
+    })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.recordExternalPayment({
+      jobId: 'job-1',
+      workerId: 'worker-1',
+      applicationId: 'app-1',
+      source: 'cash',
+      amount: 100,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.alreadyRecorded).toBe(true)
+    expect(result.error).toBeUndefined()
+  })
+
+  it('retorna erro genérico em falha de INSERT não relacionada a duplicidade', async () => {
+    routeFrom({
+      applications: makeChain({ data: APPLICATION_COMPLETED, error: null }),
+      companies: makeChain({ data: COMPANY_ROW, error: null }),
+      shift_payments: makeChain({
+        data: null,
+        error: { code: '42501', message: 'permission denied' },
+      }),
+    })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.recordExternalPayment({
+      jobId: 'job-1',
+      workerId: 'worker-1',
+      applicationId: 'app-1',
+      source: 'cash',
+      amount: 100,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.alreadyRecorded).toBeUndefined()
+    expect(result.error).toBeTruthy()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getPaymentByJob
+// ---------------------------------------------------------------------------
+
+describe('PaymentRecordService.getPaymentByJob', () => {
+  it('retorna o registro recorded do turno', async () => {
+    routeFrom({ shift_payments: makeChain({ data: SHIFT_PAYMENT_ROW, error: null }) })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.getPaymentByJob('job-1')
+
+    expect(result).toEqual(SHIFT_PAYMENT_ROW)
+    expect(mockFrom).toHaveBeenCalledWith('shift_payments')
+  })
+
+  it('retorna null quando não há registro', async () => {
+    routeFrom({ shift_payments: makeChain({ data: null, error: null }) })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.getPaymentByJob('job-sem-registro')
+
+    expect(result).toBeNull()
+  })
+
+  it('retorna null em erro de query (não propaga exceção)', async () => {
+    routeFrom({
+      shift_payments: makeChain({ data: null, error: { message: 'db error' } }),
+    })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.getPaymentByJob('job-1')
+
+    expect(result).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getReceipt
+// ---------------------------------------------------------------------------
+
+describe('PaymentRecordService.getReceipt', () => {
+  it('retorna payment + job + company + worker a partir do join', async () => {
+    const joined = {
+      ...SHIFT_PAYMENT_ROW,
+      job: { id: 'job-1', title: 'Garçom', location: 'SP', start_date: '2026-06-29' },
+      company: { id: 'company-1', name: 'Empresa X', logo_url: null },
+      worker: { id: 'worker-1', full_name: 'Fulano', avatar_url: null, photo_url: null },
+    }
+    routeFrom({ shift_payments: makeChain({ data: joined, error: null }) })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.getReceipt('job-1')
+
+    expect(result).not.toBeNull()
+    expect(result?.job?.title).toBe('Garçom')
+    expect(result?.company?.name).toBe('Empresa X')
+    expect(result?.worker?.full_name).toBe('Fulano')
+    expect(result?.payment.id).toBe('sp-1')
+  })
+
+  it('retorna null quando não há registro (RLS ou inexistente)', async () => {
+    routeFrom({ shift_payments: makeChain({ data: null, error: null }) })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.getReceipt('job-x')
+
+    expect(result).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// confirmReceiptByWorker
+// ---------------------------------------------------------------------------
+
+describe('PaymentRecordService.confirmReceiptByWorker', () => {
+  it('confirma com sucesso (worker_confirmed_at)', async () => {
+    routeFrom({ shift_payments: makeChain({ data: null, error: null }) })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.confirmReceiptByWorker('sp-1')
+
+    expect(result.success).toBe(true)
+    expect(mockFrom).toHaveBeenCalledWith('shift_payments')
+  })
+
+  it('retorna erro quando o UPDATE falha (ex.: trigger de imutabilidade)', async () => {
+    routeFrom({
+      shift_payments: makeChain({
+        data: null,
+        error: { message: 'worker_confirmed_at nao pode ser alterado apos a confirmacao' },
+      }),
+    })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.confirmReceiptByWorker('sp-1')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBeTruthy()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// voidPayment
+// ---------------------------------------------------------------------------
+
+describe('PaymentRecordService.voidPayment', () => {
+  it('estorna com sucesso (status=voided)', async () => {
+    routeFrom({ shift_payments: makeChain({ data: null, error: null }) })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.voidPayment('sp-1', 'Valor informado errado')
+
+    expect(result.success).toBe(true)
+  })
+
+  it('retorna erro quando o UPDATE falha', async () => {
+    routeFrom({
+      shift_payments: makeChain({ data: null, error: { message: 'permission denied' } }),
+    })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.voidPayment('sp-1', 'motivo')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBeTruthy()
+  })
+})

--- a/frontend/src/services/paymentRecordService.ts
+++ b/frontend/src/services/paymentRecordService.ts
@@ -1,0 +1,341 @@
+/**
+ * PaymentRecordService — marcador de pagamento externo por turno (modo A do ADR).
+ *
+ * ADR: .harness/memory-bank/decisions/ADR-20260630-pagamento-opcional-piloto.md
+ * Migration: supabase/migrations/20260630000000_shift_payments.sql
+ * Plano: .harness/spec/v1-operacao-freelancer/plan-modo-a.md (§HALT RESOLVIDO)
+ *
+ * FRONTEIRA CRÍTICA (Article 8/9/10) — este service é REGISTRO/AUDITORIA, NÃO liquidação:
+ *  - NÃO chama nenhuma RPC de saldo (reserve/release/refund/authorize/capture).
+ *  - NÃO toca `wallets` nem `escrow_transactions`.
+ *  - NÃO usa service_role — todo INSERT/UPDATE é do papel `authenticated` sob RLS.
+ *
+ * Decisões do HALT (2026-06-30, owner) refletidas aqui:
+ *  1. Empresa registra + freela confirma (bilateral ATIVO) → confirmReceiptByWorker.
+ *  2. Registrar EXIGE turno concluído — guarda dura fica na UI; este service valida
+ *     defensivamente o SINAL REAL de conclusão (company_checkin_confirmed_at E
+ *     company_checkout_confirmed_at preenchidos) antes do INSERT — não o `status`
+ *     de `applications`, que só é setado 'completed' DEPOIS que este INSERT tem
+ *     sucesso (evita dead-end: status='completed' sem registro se o INSERT falhar).
+ *  3. 1 registro 'recorded' por turno — violação do UNIQUE parcial (Postgres 23505)
+ *     é tratada como `alreadyRecorded: true`, nunca propagada como crash.
+ *  4. Fontes: external_pix | cash | other.
+ *
+ * Padrões do projeto:
+ *  - Fetch/mutate: supabase.from direto (Art. 5 — sem React Query).
+ *  - Tipos à mão em types/index.ts (Art. 2).
+ *  - Imports relativos (sem alias @/).
+ *  - logError (nunca console.log).
+ */
+
+import { supabase } from '../lib/supabase';
+import { logError } from '../lib/logger';
+import type { ShiftPayment, PaymentSource } from '../types';
+
+// ---------------------------------------------------------------------------
+// Tipos de parâmetros e resultado
+// ---------------------------------------------------------------------------
+
+export interface RecordExternalPaymentParams {
+  jobId: string;
+  workerId: string;
+  /**
+   * Link ao ciclo específico (evidência de que o turno é o mesmo confirmado).
+   * A coluna é nullable no schema (ON DELETE SET NULL — preserva o recibo se a
+   * application for removida), mas o INSERT sempre parte de uma application
+   * concreta neste fluxo (confirmação de conclusão), então é exigido aqui para
+   * viabilizar a validação defensiva de "turno concluído".
+   */
+  applicationId: string;
+  source: PaymentSource;
+  /** Valor declarado pago (BRL). Deve ser > 0 (também reforçado por CHECK no DB). */
+  amount: number;
+  /** Quando o pagamento aconteceu (declarado). Default: agora. */
+  paidAt?: string | Date;
+  note?: string;
+}
+
+export interface RecordExternalPaymentResult {
+  success: boolean;
+  payment?: ShiftPayment;
+  /** true quando já existe um registro 'recorded' ativo para este job_id (UNIQUE parcial, 23505). */
+  alreadyRecorded?: boolean;
+  error?: string;
+}
+
+export interface ConfirmReceiptResult {
+  success: boolean;
+  error?: string;
+}
+
+export interface VoidPaymentResult {
+  success: boolean;
+  error?: string;
+}
+
+export interface ShiftPaymentReceipt {
+  payment: ShiftPayment;
+  job: {
+    id: string;
+    title: string;
+    location: string;
+    start_date: string;
+    work_start_time?: string | null;
+    work_end_time?: string | null;
+  } | null;
+  company: {
+    id: string;
+    name: string;
+    logo_url?: string | null;
+  } | null;
+  worker: {
+    id: string;
+    full_name: string;
+    avatar_url?: string | null;
+    photo_url?: string | null;
+  } | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers internos
+// ---------------------------------------------------------------------------
+
+/** Obtém o company_id da sessão autenticada (empresa). Espelha shiftInviteService. */
+async function getAuthCompanyId(): Promise<string> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('Sessão expirada. Faça login novamente.');
+
+  const { data: company, error } = await supabase
+    .from('companies')
+    .select('id')
+    .eq('owner_id', user.id)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!company) throw new Error('Perfil de empresa não encontrado.');
+
+  return company.id as string;
+}
+
+/** Normaliza paidAt (string | Date | undefined) para ISO string. Default: agora. */
+function normalizePaidAt(paidAt?: string | Date): string {
+  if (!paidAt) return new Date().toISOString();
+  return typeof paidAt === 'string' ? paidAt : paidAt.toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// PaymentRecordService (exportado)
+// ---------------------------------------------------------------------------
+
+export const PaymentRecordService = {
+  /**
+   * Registra que o pagamento de um turno foi feito FORA do Worki (PIX/dinheiro/outro).
+   * NÃO move saldo, NÃO chama RPC, NÃO toca wallets/escrow_transactions.
+   *
+   * Validação defensiva (decisão do HALT #4 — "exige turno concluído"): a guarda dura
+   * de habilitar/desabilitar o botão é responsabilidade da UI, mas este service confere
+   * novamente antes do INSERT que a application referenciada pertence ao job/worker
+   * informados e tem `company_checkin_confirmed_at` E `company_checkout_confirmed_at`
+   * preenchidos (o sinal real de "turno concluído") — evita registro sem lastro de
+   * trabalho mesmo se a UI for contornada. Deliberadamente NÃO depende de
+   * `application.status === 'completed'`: esse status só é setado pela UI DEPOIS que
+   * este método retorna sucesso, para nunca deixar uma application 'completed' sem
+   * registro correspondente caso o INSERT falhe.
+   *
+   * Idempotência (decisão do HALT #5 — "1 registro por turno"): o UNIQUE parcial
+   * `(job_id) WHERE status='recorded'` no DB rejeita um segundo registro ativo para o
+   * mesmo turno com erro Postgres 23505 — tratado aqui como `alreadyRecorded: true`,
+   * nunca propagado como exceção.
+   */
+  async recordExternalPayment(
+    params: RecordExternalPaymentParams,
+  ): Promise<RecordExternalPaymentResult> {
+    try {
+      const { jobId, workerId, applicationId, source, amount, paidAt, note } = params;
+
+      if (!(amount > 0)) {
+        return { success: false, error: 'O valor pago deve ser maior que zero.' };
+      }
+
+      // 1. Validação defensiva: turno concluído (HALT #4) — sinal REAL, não o status.
+      const { data: application, error: appErr } = await supabase
+        .from('applications')
+        .select('id, job_id, worker_id, company_checkin_confirmed_at, company_checkout_confirmed_at')
+        .eq('id', applicationId)
+        .maybeSingle();
+
+      if (appErr) {
+        logError('paymentRecord.recordExternalPayment.checkApplication', appErr);
+        return { success: false, error: 'Erro ao verificar o turno.' };
+      }
+      if (!application) {
+        return { success: false, error: 'Candidatura/turno não encontrado.' };
+      }
+      if (application.job_id !== jobId || application.worker_id !== workerId) {
+        return {
+          success: false,
+          error: 'A candidatura informada não corresponde ao turno/freela informado.',
+        };
+      }
+      if (!application.company_checkin_confirmed_at || !application.company_checkout_confirmed_at) {
+        return {
+          success: false,
+          error: 'O turno precisa estar concluído (chegada e saída confirmadas) antes de registrar o pagamento.',
+        };
+      }
+
+      // 2. Resolver a empresa dona (RLS exige company_id = empresa do auth.uid()).
+      const companyId = await getAuthCompanyId();
+
+      // 3. INSERT — recorded_by é preenchido pelo DEFAULT auth.uid() no schema.
+      const { data: payment, error: insertErr } = await supabase
+        .from('shift_payments')
+        .insert({
+          job_id: jobId,
+          company_id: companyId,
+          worker_id: workerId,
+          application_id: applicationId,
+          source,
+          amount,
+          paid_at: normalizePaidAt(paidAt),
+          note: note ?? null,
+        })
+        .select()
+        .single();
+
+      if (insertErr) {
+        if (insertErr.code === '23505') {
+          return { success: false, alreadyRecorded: true };
+        }
+        logError('paymentRecord.recordExternalPayment.insert', insertErr);
+        return { success: false, error: 'Não foi possível registrar o pagamento.' };
+      }
+
+      return { success: true, payment: payment as ShiftPayment };
+    } catch (err) {
+      logError('paymentRecord.recordExternalPayment', err);
+      return { success: false, error: err instanceof Error ? err.message : 'Erro inesperado.' };
+    }
+  },
+
+  /**
+   * Busca o registro 'recorded' (ativo) de um turno, se existir.
+   * Usado pela UI para decidir entre mostrar "Registrar pagamento" ou "Ver recibo".
+   */
+  async getPaymentByJob(jobId: string): Promise<ShiftPayment | null> {
+    try {
+      const { data, error } = await supabase
+        .from('shift_payments')
+        .select('*')
+        .eq('job_id', jobId)
+        .eq('status', 'recorded')
+        .maybeSingle();
+
+      if (error) {
+        logError('paymentRecord.getPaymentByJob', error);
+        return null;
+      }
+      return (data as ShiftPayment) ?? null;
+    } catch (err) {
+      logError('paymentRecord.getPaymentByJob', err);
+      return null;
+    }
+  },
+
+  /**
+   * Busca o marcador ativo do turno + dados leves para renderizar o recibo
+   * (empresa, freela, turno). Só-leitura sob RLS — quem não é parte (nem empresa
+   * dona nem freela pago) recebe null.
+   */
+  async getReceipt(jobId: string): Promise<ShiftPaymentReceipt | null> {
+    try {
+      const { data, error } = await supabase
+        .from('shift_payments')
+        .select(
+          `
+          *,
+          job:jobs ( id, title, location, start_date, work_start_time, work_end_time ),
+          company:companies ( id, name, logo_url ),
+          worker:workers ( id, full_name, avatar_url, photo_url )
+        `,
+        )
+        .eq('job_id', jobId)
+        .eq('status', 'recorded')
+        .maybeSingle();
+
+      if (error) {
+        logError('paymentRecord.getReceipt', error);
+        return null;
+      }
+      if (!data) return null;
+
+      const { job, company, worker, ...paymentFields } = data as ShiftPayment & {
+        job: ShiftPaymentReceipt['job'];
+        company: ShiftPaymentReceipt['company'];
+        worker: ShiftPaymentReceipt['worker'];
+      };
+
+      return {
+        payment: paymentFields as ShiftPayment,
+        job: job ?? null,
+        company: company ?? null,
+        worker: worker ?? null,
+      };
+    } catch (err) {
+      logError('paymentRecord.getReceipt', err);
+      return null;
+    }
+  },
+
+  /**
+   * Freela confirma o recebimento do pagamento declarado (bilateral ATIVO — HALT #2).
+   * One-way: só permite NULL → timestamp (o trigger `enforce_shift_payment_immutability`
+   * rejeita qualquer tentativa de alterar depois de confirmado). NÃO bloqueia ciclo/avaliação.
+   */
+  async confirmReceiptByWorker(paymentId: string): Promise<ConfirmReceiptResult> {
+    try {
+      const { error } = await supabase
+        .from('shift_payments')
+        .update({ worker_confirmed_at: new Date().toISOString() })
+        .eq('id', paymentId);
+
+      if (error) {
+        logError('paymentRecord.confirmReceiptByWorker', error);
+        return { success: false, error: 'Não foi possível confirmar o recebimento.' };
+      }
+      return { success: true };
+    } catch (err) {
+      logError('paymentRecord.confirmReceiptByWorker', err);
+      return { success: false, error: err instanceof Error ? err.message : 'Erro inesperado.' };
+    }
+  },
+
+  /**
+   * Estorno lógico de um registro ativo (só a empresa dona — RLS `sp_update_company`).
+   * NUNCA faz UPDATE destrutivo do valor/fonte/data — só marca status='voided'.
+   * Libera o `job_id` para um novo registro 'recorded' (UNIQUE é parcial).
+   */
+  async voidPayment(paymentId: string, reason: string): Promise<VoidPaymentResult> {
+    try {
+      const { error } = await supabase
+        .from('shift_payments')
+        .update({
+          status: 'voided',
+          voided_at: new Date().toISOString(),
+          void_reason: reason,
+        })
+        .eq('id', paymentId);
+
+      if (error) {
+        logError('paymentRecord.voidPayment', error);
+        return { success: false, error: 'Não foi possível estornar o registro.' };
+      }
+      return { success: true };
+    } catch (err) {
+      logError('paymentRecord.voidPayment', err);
+      return { success: false, error: err instanceof Error ? err.message : 'Erro inesperado.' };
+    }
+  },
+};

--- a/frontend/src/services/spendLimitService.test.ts
+++ b/frontend/src/services/spendLimitService.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mock supabase — chain genérica encadeável (select/eq/in/insert/limit) que
+// resolve para `result` em maybeSingle()/await direto (thenable), no padrão
+// de financialBIService.test.ts / paymentRecordService.test.ts.
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeChain(result: { data: any; error: any }) {
+  const promise = Promise.resolve(result)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = {
+    select: vi.fn(() => chain),
+    eq: vi.fn(() => chain),
+    in: vi.fn(() => chain),
+    limit: vi.fn(() => chain),
+    insert: vi.fn(() => chain),
+    upsert: vi.fn(() => chain),
+    maybeSingle: vi.fn(() => promise),
+    single: vi.fn(() => promise),
+    then: promise.then.bind(promise),
+    catch: promise.catch.bind(promise),
+  }
+  return chain
+}
+
+const mockFrom = vi.fn()
+
+vi.mock('../lib/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}))
+
+// FinancialBIService.getAccumulatedSpend é a fonte ÚNICA de gasto acumulado (dedupe
+// escrow ∪ shift_payments) — spendLimitService NÃO deve duplicar essa query.
+const mockGetAccumulatedSpend = vi.fn()
+vi.mock('./financialBIService', () => ({
+  FinancialBIService: {
+    getAccumulatedSpend: (...args: unknown[]) => mockGetAccumulatedSpend(...args),
+  },
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function routeFrom(handlers: Record<string, any>) {
+  mockFrom.mockImplementation((table: string) => {
+    const handler = handlers[table]
+    if (!handler) throw new Error(`Tabela não mockada: ${table}`)
+    return handler
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// Data fixa, construída localmente (evita ambiguidade de timezone com strings ISO 'Z').
+const NOW = new Date(2026, 5, 15, 12, 0, 0) // 2026-06-15 local
+
+const SPEND_LIMIT_ROW = {
+  company_id: 'company-1',
+  period: 'month',
+  scope: '',
+  amount: 1000,
+  alert_thresholds: [80, 90, 100],
+  financial_contact_email: null,
+  financial_contact_phone: null,
+}
+
+describe('SpendLimitService.evaluateSpendAlert — gasto acumulado via fonte unificada (ADR-20260630)', () => {
+  it('delega o cômputo do gasto ao FinancialBIService.getAccumulatedSpend (BI-1 unificado) em vez de consultar escrow_transactions/shift_payments diretamente', async () => {
+    mockGetAccumulatedSpend.mockResolvedValue({
+      totalAmount: 850, // 85% do teto de 1000 — cruza o threshold de 80
+      periodStart: '2026-06-01',
+      periodEnd: '2026-07-01',
+    })
+
+    routeFrom({
+      company_spend_limits: makeChain({ data: SPEND_LIMIT_ROW, error: null }),
+      companies: makeChain({ data: { owner_id: 'owner-1' }, error: null }),
+      // Mesma tabela serve o SELECT de idempotência (maybeSingle → null = sem alerta prévio)
+      // e o INSERT do alerta (ambos resolvem no mesmo `result` do chain — ok para este teste).
+      notifications: makeChain({ data: null, error: null }),
+    })
+
+    const { SpendLimitService } = await import('./spendLimitService')
+    await SpendLimitService.evaluateSpendAlert('company-1', NOW)
+
+    // Chamou o BI unificado com o período do mês corrente — não recomputa a query aqui.
+    expect(mockGetAccumulatedSpend).toHaveBeenCalledWith('company-1', {
+      start: '2026-06-01',
+      end: '2026-07-01',
+    })
+
+    // Contrato de não-duplicação: spendLimitService não deve ler escrow/shift_payments
+    // diretamente — isso é responsabilidade exclusiva do FinancialBIService.
+    expect(mockFrom).not.toHaveBeenCalledWith('escrow_transactions')
+    expect(mockFrom).not.toHaveBeenCalledWith('shift_payments')
+
+    // E ainda assim dispara o alerta (85% cruza o threshold de 80%) usando o valor delegado.
+    expect(mockFrom).toHaveBeenCalledWith('notifications')
+  })
+
+  it('não dispara alerta quando o gasto delegado não cruza nenhum threshold', async () => {
+    mockGetAccumulatedSpend.mockResolvedValue({
+      totalAmount: 100, // 10% do teto — não cruza 80/90/100
+      periodStart: '2026-06-01',
+      periodEnd: '2026-07-01',
+    })
+
+    const notificationsHandler = makeChain({ data: null, error: null })
+    routeFrom({
+      company_spend_limits: makeChain({ data: SPEND_LIMIT_ROW, error: null }),
+      companies: makeChain({ data: { owner_id: 'owner-1' }, error: null }),
+      notifications: notificationsHandler,
+    })
+
+    const { SpendLimitService } = await import('./spendLimitService')
+    await SpendLimitService.evaluateSpendAlert('company-1', NOW)
+
+    expect(mockGetAccumulatedSpend).toHaveBeenCalled()
+    // Sem threshold cruzado, a função retorna antes de tocar em `notifications`.
+    expect(mockFrom).not.toHaveBeenCalledWith('notifications')
+  })
+
+  it('não bloqueia (retorna silenciosamente) quando não há teto configurado — nunca falha o fluxo que o chama', async () => {
+    routeFrom({
+      company_spend_limits: makeChain({ data: null, error: null }),
+    })
+
+    const { SpendLimitService } = await import('./spendLimitService')
+    await expect(SpendLimitService.evaluateSpendAlert('company-1', NOW)).resolves.toBeUndefined()
+
+    // Sem teto configurado, nem chega a calcular o gasto.
+    expect(mockGetAccumulatedSpend).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/services/spendLimitService.ts
+++ b/frontend/src/services/spendLimitService.ts
@@ -4,14 +4,18 @@
  * Responsabilidades:
  *  1. CRUD do teto de gasto (company_spend_limits).
  *  2. CRUD do faturamento mensal declarado (company_monthly_revenue).
- *  3. evaluateSpendAlert — computa BI-1, compara com o teto, e insere alerta idempotente
- *     em `notifications` para o maior threshold cruzado ainda não alertado.
+ *  3. evaluateSpendAlert — computa o gasto acumulado (BI-1 unificado), compara com o teto,
+ *     e insere alerta idempotente em `notifications` para o maior threshold cruzado ainda
+ *     não alertado.
  *
- * Contratos do architect (spec Slice 3):
- *  - Gasto = escrow_transactions WHERE status IN ('released','captured').
- *  - Período: COALESCE(captured_at, released_at, created_at).
- *  - Empresa da linha: company_wallet_id → wallets.user_id = companyId.
- *  - Alerta NUNCA bloqueia contratação.
+ * Contratos do architect (spec Slice 3) + ADR-20260630-pagamento-opcional-piloto ("Impacto no BI"):
+ *  - Gasto = MESMA fonte unificada do FinancialBIService (BI-1): escrow_transactions
+ *    (status IN 'released'/'captured') ∪ shift_payments (status='recorded', modo A pagamento
+ *    externo), dedupe por job_id com precedência do escrow. Delega para
+ *    `FinancialBIService.getAccumulatedSpend` — NÃO duplica a query aqui (evita a fonte de
+ *    gasto divergir entre o dashboard e o alerta de teto).
+ *  - Período: mês corrente, mesma janela [monthStart, nextMonthStart).
+ *  - Alerta NUNCA bloqueia contratação nem o registro de pagamento externo.
  *  - Idempotência via link='/company/financeiro?alert=<companyId>:<YYYYMM>:<threshold>'
  *    + SELECT LIMIT 1 antes do INSERT.
  *  - Dispara APENAS o maior threshold cruzado ainda não alertado no período.
@@ -26,6 +30,7 @@
 
 import { supabase } from '../lib/supabase';
 import { logError } from '../lib/logger';
+import { FinancialBIService } from './financialBIService';
 import type { SpendLimit, MonthlyRevenue } from '../types';
 
 // ---------------------------------------------------------------------------
@@ -53,13 +58,15 @@ function yyyymm(d: Date): string {
 // ---------------------------------------------------------------------------
 
 /**
- * Calcula o gasto acumulado de uma empresa no mês corrente (BI-1).
- * Gasto = SUM(amount) de escrow_transactions com status IN ('released','captured')
- * filtrado pelo carimbo COALESCE(captured_at, released_at, created_at) dentro do mês.
+ * Calcula o gasto acumulado de uma empresa no mês corrente (BI-1 unificado).
+ * Delega para `FinancialBIService.getAccumulatedSpend` — MESMA fonte do dashboard
+ * financeiro (escrow released/captured ∪ shift_payments recorded, dedupe por job_id
+ * com precedência do escrow). Ver ADR-20260630-pagamento-opcional-piloto.md.
  *
- * A empresa é identificada via company_wallet_id → wallets.user_id = companyId.
- *
- * @returns { totalAmount, periodStart, periodEnd } ou null em caso de erro.
+ * Nota: `FinancialBIService.getAccumulatedSpend` já trata erros internamente (loga e
+ * retorna totalAmount=0) em vez de propagar — aqui isso é tratado como "gasto zero" para
+ * fins de alerta, nunca como bloqueio (o alerta é best-effort por natureza: um erro
+ * transiente na leitura, na pior hipótese, apenas deixa de disparar um alerta).
  */
 async function computeAccumulatedSpend(
   companyId: string,
@@ -68,51 +75,8 @@ async function computeAccumulatedSpend(
   try {
     const ps = monthStart(now);
     const pe = nextMonthStart(now);
-
-    // Buscar o wallet_id da empresa
-    const { data: wallet, error: walletErr } = await supabase
-      .from('wallets')
-      .select('id')
-      .eq('user_id', companyId)
-      .maybeSingle();
-
-    if (walletErr) {
-      logError('spendLimit.computeAccumulatedSpend.wallet', walletErr);
-      return null;
-    }
-    if (!wallet) return { totalAmount: 0, periodStart: ps, periodEnd: pe };
-
-    // Soma do gasto efetivo (released + captured) no período
-    // Filtra pelo carimbo: COALESCE(captured_at, released_at, created_at)
-    // PostgREST não suporta COALESCE em filtros → buscar as linhas e filtrar em JS.
-    // Volume esperado: dezenas/centenas por empresa por mês → ok.
-    const { data: rows, error: escrowErr } = await supabase
-      .from('escrow_transactions')
-      .select('amount, captured_at, released_at, created_at')
-      .eq('company_wallet_id', wallet.id)
-      .in('status', ['released', 'captured']);
-
-    if (escrowErr) {
-      logError('spendLimit.computeAccumulatedSpend.escrow', escrowErr);
-      return null;
-    }
-
-    const psDate = new Date(ps);
-    const peDate = new Date(pe);
-    let totalAmount = 0;
-
-    for (const row of rows ?? []) {
-      const stamp = new Date(
-        (row.captured_at as string | null) ??
-        (row.released_at as string | null) ??
-        (row.created_at as string),
-      );
-      if (stamp >= psDate && stamp < peDate) {
-        totalAmount += Number(row.amount ?? 0);
-      }
-    }
-
-    return { totalAmount, periodStart: ps, periodEnd: pe };
+    const result = await FinancialBIService.getAccumulatedSpend(companyId, { start: ps, end: pe });
+    return { totalAmount: result.totalAmount, periodStart: ps, periodEnd: pe };
   } catch (err) {
     logError('spendLimit.computeAccumulatedSpend', err);
     return null;

--- a/frontend/src/services/teamConnectionService.ts
+++ b/frontend/src/services/teamConnectionService.ts
@@ -51,6 +51,9 @@ export interface ConnectionInviteToken {
   url: string;
 }
 
+/** Prefixo que identifica um token de convite gerado por um WORKER (link transitivo). */
+const WORKER_TOKEN_PREFIX = 'w_';
+
 // ---------------------------------------------------------------------------
 // Helpers de query de empresa (session)
 // ---------------------------------------------------------------------------
@@ -173,9 +176,11 @@ export const TeamConnectionService = {
 
   /**
    * Resolve um token de link de convite → retorna o `company_id`.
-   * Retorna null se o token for inválido ou malformado.
+   * Retorna null se o token for inválido, malformado, ou for um token de worker
+   * (prefixo `w_` — ver `generateWorkerInviteToken`).
    */
   resolveInviteToken(token: string): string | null {
+    if (this.isWorkerInviteToken(token)) return null;
     try {
       // Reverter base64url → base64 padrão antes de decodificar
       const padded = token.replace(/-/g, '+').replace(/_/g, '/');
@@ -185,6 +190,89 @@ export const TeamConnectionService = {
     } catch {
       return null;
     }
+  },
+
+  // -------------------------------------------------------------------------
+  // Link transitivo — "meu link" (worker) + repasse de contato já conectado
+  // -------------------------------------------------------------------------
+
+  /**
+   * Gera um token de convite de link ESTÁVEL para um WORKER (direção inversa do
+   * `generateInviteToken`, que é empresa→worker).
+   *
+   * Uso (R-transitivo):
+   * - Worker gera o próprio link ("Meu link") e compartilha com uma empresa.
+   * - Empresa que JÁ tem esse worker no elenco pode repassar o MESMO link a
+   *   outra empresa (ex.: "tenho o Adriano no elenco → repasso o link dele
+   *   pro Gabriel"). Não é preciso pedir ao worker — a empresa já conhece o
+   *   `worker_id` via `team_connections`.
+   *
+   * Prefixo `w_` distingue de um token de empresa (`generateInviteToken`),
+   * que não tem prefixo. Resolução acontece em `resolveWorkerInviteToken`.
+   * A URL usa a MESMA rota `/convite/:token` — `InviteAccept` decide o fluxo
+   * pelo prefixo.
+   */
+  generateWorkerInviteToken(workerId: string): ConnectionInviteToken {
+    const encoded = btoa(workerId).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+    const token = `${WORKER_TOKEN_PREFIX}${encoded}`;
+    const url = `${window.location.origin}/convite/${token}`;
+    return { token, url };
+  },
+
+  /** true se o token for um link de worker (prefixo `w_`). */
+  isWorkerInviteToken(token: string): boolean {
+    return token.startsWith(WORKER_TOKEN_PREFIX);
+  },
+
+  /**
+   * Resolve um token de link de worker → retorna o `worker_id`.
+   * Retorna null se o token não tiver o prefixo `w_` ou for malformado.
+   */
+  resolveWorkerInviteToken(token: string): string | null {
+    if (!this.isWorkerInviteToken(token)) return null;
+    try {
+      const raw = token.slice(WORKER_TOKEN_PREFIX.length);
+      const padded = raw.replace(/-/g, '+').replace(/_/g, '/');
+      const workerId = atob(padded);
+      if (!workerId || workerId.length < 30) return null;
+      return workerId;
+    } catch {
+      return null;
+    }
+  },
+
+  /**
+   * Adiciona o worker do link (`w_...`) à equipe da EMPRESA autenticada.
+   *
+   * Direção inversa de `addToTeamByToken`: aqui quem abre o link precisa estar
+   * autenticado como EMPRESA (o worker é identificado pelo token, não pela
+   * sessão). Reusa `addToTeam` (mesma idempotência/RLS já usada pelo canal
+   * 'phone' — a empresa já pode adicionar qualquer `worker_id` que conheça).
+   *
+   * Se a sessão ativa não for de uma empresa, `addToTeam` retorna o erro de
+   * `getAuthenticatedCompanyId()` (ex.: "Perfil de empresa não encontrado.").
+   */
+  async addWorkerToTeamByToken(token: string): Promise<CreateConnectionResult> {
+    const workerId = this.resolveWorkerInviteToken(token);
+    if (!workerId) {
+      return { connection: null, error: 'Link de contato inválido ou expirado.' };
+    }
+
+    const { data: worker, error: workerErr } = await supabase
+      .from('workers')
+      .select('id')
+      .eq('id', workerId)
+      .maybeSingle();
+
+    if (workerErr) {
+      logError('teamConnection.addWorkerToTeamByToken.check', workerErr);
+      return { connection: null, error: 'Erro ao verificar o freela do link.' };
+    }
+    if (!worker) {
+      return { connection: null, error: 'Freela do link não encontrado.' };
+    }
+
+    return this.addToTeam(workerId, 'link');
   },
 
   /**

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -463,3 +463,56 @@ export interface FinancialBIData {
   noShowCost: NoShowCost;
   concentrationFlags: ConcentrationFlag[];
 }
+
+// =============================================
+// PAGAMENTO EXTERNO — modo A (ADR-20260630-pagamento-opcional-piloto)
+// migration: supabase/migrations/20260630000000_shift_payments.sql
+// =============================================
+
+/**
+ * Método declarado do pagamento (NÃO é prova bancária — é uma declaração).
+ */
+export type PaymentSource = 'external_pix' | 'cash' | 'other';
+
+/**
+ * Estado do registro. 'voided' é totalmente imutável (correção = novo registro).
+ */
+export type ShiftPaymentStatus = 'recorded' | 'voided';
+
+/**
+ * Espelha a tabela `shift_payments` (marcador de pagamento externo por turno).
+ * Registro/auditoria declaratório — NÃO move saldo, NÃO toca wallets/escrow_transactions,
+ * sem RPC (Article 8 intacto). Gerado à mão conforme migration
+ * `20260630000000_shift_payments.sql`.
+ *
+ * Imutabilidade (trigger `enforce_shift_payment_immutability`):
+ *  - Colunas materiais (job_id, company_id, worker_id, application_id, source, amount,
+ *    paid_at, recorded_by, note, created_at) são imutáveis após o INSERT.
+ *  - `worker_confirmed_at` é one-way (NULL → timestamp).
+ *  - Correção = estorno lógico (status='voided' + voided_at + void_reason).
+ */
+export interface ShiftPayment {
+  id: string;
+  job_id: string;
+  company_id: string;
+  worker_id: string;
+  /** Link opcional ao ciclo específico; ON DELETE SET NULL preserva o recibo. */
+  application_id: string | null;
+  /** Método DECLARADO (não prova bancária). */
+  source: PaymentSource;
+  /** Valor declarado pago (BRL). Sempre > 0. */
+  amount: number;
+  /** Quando o pagamento aconteceu (declarado). */
+  paid_at: string;
+  /** auth.uid() de quem registrou (empresa no v1). */
+  recorded_by: string;
+  /** Confirmação de recebimento pelo freela (bilateral ativo). One-way NULL→ts. Não bloqueia ciclo. */
+  worker_confirmed_at: string | null;
+  /** Observação livre (ex.: "pago em 2x", referência PIX). Imutável. */
+  note: string | null;
+  /** recorded (ativo) | voided (estornado, imutável). */
+  status: ShiftPaymentStatus;
+  voided_at: string | null;
+  void_reason: string | null;
+  created_at: string;
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -9,5 +9,12 @@ export default defineConfig({
     setupFiles: ['./src/test/setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     css: false,
+    // Unit tests mockam o Supabase — não acessam DB real. Credenciais dummy evitam que
+    // lib/supabase.ts lance "Missing VITE_SUPABASE_URL" na coleção (o repo/CI não expõe secrets
+    // p/ o step de testes). Fonte única p/ CI e local, sem depender de env externo.
+    env: {
+      VITE_SUPABASE_URL: 'https://dummy.supabase.co',
+      VITE_SUPABASE_ANON_KEY: 'dummy-anon-key-for-tests',
+    },
   },
 })

--- a/supabase/functions/expire-invites/index.ts
+++ b/supabase/functions/expire-invites/index.ts
@@ -1,0 +1,125 @@
+/**
+ * expire-invites — auto-expiração de convites de turno vencidos (item #6 do piloto).
+ *
+ * CONTEXTO (sem migration — restrição dura desta tarefa):
+ *   `applications.status` tem CHECK (herdado do schema legado — não localizado como migration
+ *   isolada neste repo, mas confirmado via `frontend/src/types/index.ts` `ApplicationStatus`)
+ *   que permite: 'pending' | 'reviewing' | 'interview' | 'hired' | 'in_progress' | 'completed' |
+ *   'rejected' | 'invited' | 'declined'. Não existe valor 'expired'.
+ *
+ *   `applications.invitation_response` tem CHECK explícito (migration
+ *   20260622000100_invite_columns_applications.sql, linha 35):
+ *     CHECK (invitation_response IS NULL OR invitation_response IN ('accepted', 'declined'))
+ *   ou seja, 'expired' TAMBÉM violaria esse CHECK — não dá para usar
+ *   invitation_response='expired' sem migration.
+ *
+ * DECISÃO (sem migration): usamos o valor 'declined' já permitido em `status` (semântica R7:
+ * recusa é NEUTRA — zero punição — o mesmo vale para expiração, que também não deve punir o
+ * freela). Para DISTINGUIR "expirado sem resposta" de "recusado ativamente pelo worker":
+ *   - Expiração automática (esta função): status='declined', invitation_responded_at=now(),
+ *     invitation_response permanece NULL (nunca setamos 'expired' ali — violaria o CHECK).
+ *   - Recusa ativa (shiftInviteService.respondToInvite): status='declined',
+ *     invitation_response='declined' (setado).
+ *   Consumidores que precisarem diferenciar os dois casos podem checar
+ *   `invitation_response IS NULL` (auto-expirado) vs `= 'declined'` (recusa ativa do worker).
+ *
+ * TODO (exigiria migration — gate architect, NÃO implementado aqui):
+ *   Um valor de status dedicado (ex.: 'expired') tornaria essa distinção explícita no próprio
+ *   `status` em vez de depender da combinação status+invitation_response. Deixado como TODO
+ *   proposital — fora do escopo desta tarefa (regra dura: nenhuma migration nova).
+ *
+ * IDEMPOTÊNCIA: o UPDATE só afeta linhas com status='invited' AND invitation_expires_at < now().
+ * Após a primeira execução, essas linhas passam a status='declined' e saem do filtro — rodar de
+ * novo é seguro (não há duplo efeito, não mexe em saldo/escrow).
+ *
+ * OPS (fora do escopo desta tarefa):
+ *   - Agendamento: pg_cron (`SELECT cron.schedule(...)`) ou Supabase Scheduled Functions,
+ *     chamando este endpoint periodicamente (ex.: a cada 15-60 min).
+ *   - Deploy: `supabase functions deploy expire-invites --no-verify-jwt` (chamada por scheduler,
+ *     sem JWT de usuário — mesmo padrão de asaas-webhook/admin-data, Article 11). Alternativamente,
+ *     se o scheduler suportar enviar o service_role key como Bearer, pode manter verify-jwt e
+ *     autenticar como esta função já faz (compara Authorization com SUPABASE_SERVICE_ROLE_KEY).
+ *   - Notificação ao worker/empresa sobre a expiração: não implementado aqui (best-effort futuro,
+ *     mesmo padrão de `send-notification`).
+ *
+ * NÃO toca saldo/escrow/pagamento (Article 8). NÃO expõe service_role no frontend (Article 10) —
+ * a key só existe aqui, dentro da Edge Function, via Deno.env.
+ */
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+import { getCorsHeaders } from '../_shared/asaas.ts';
+
+serve(async (req) => {
+  const cors = getCorsHeaders(req);
+
+  // CORS preflight (Article 11)
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: cors });
+  }
+
+  // Auth: só service_role pode chamar (chamada por scheduler/ops, não pelo frontend).
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) {
+    return new Response(
+      JSON.stringify({ error: 'Authorization header required' }),
+      { status: 401, headers: { ...cors, 'Content-Type': 'application/json' } },
+    );
+  }
+
+  const token = authHeader.replace('Bearer ', '');
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+  if (!serviceRoleKey || token !== serviceRoleKey) {
+    return new Response(
+      JSON.stringify({ error: 'Service role required' }),
+      { status: 403, headers: { ...cors, 'Content-Type': 'application/json' } },
+    );
+  }
+
+  try {
+    const supabaseAdmin = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      serviceRoleKey,
+    );
+
+    const nowIso = new Date().toISOString();
+
+    // Marca como 'declined' (neutro — R7) os convites vencidos que ainda estão 'invited'.
+    // invitation_response permanece NULL de propósito — distingue expiração automática de
+    // recusa ativa do worker (ver cabeçalho do arquivo).
+    const { data: expired, error } = await supabaseAdmin
+      .from('applications')
+      .update({
+        status: 'declined',
+        invitation_responded_at: nowIso,
+      })
+      .eq('status', 'invited')
+      .not('invitation_expires_at', 'is', null)
+      .lt('invitation_expires_at', nowIso)
+      .select('id, job_id, worker_id');
+
+    if (error) {
+      console.error('expire-invites: update failed', error);
+      return new Response(JSON.stringify({ error: error.message }), {
+        status: 500,
+        headers: { ...cors, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const expiredCount = expired?.length ?? 0;
+    console.log(`expire-invites: ${expiredCount} convite(s) expirado(s) marcados como 'declined'.`);
+
+    return new Response(
+      JSON.stringify({ success: true, expiredCount, expired: expired ?? [] }),
+      { status: 200, headers: { ...cors, 'Content-Type': 'application/json' } },
+    );
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Unknown error';
+    console.error('expire-invites: unexpected error', msg);
+    return new Response(JSON.stringify({ error: msg }), {
+      status: 500,
+      headers: { ...cors, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/migrations/20260630000000_shift_payments.sql
+++ b/supabase/migrations/20260630000000_shift_payments.sql
@@ -1,0 +1,293 @@
+-- Migration: Marcador de pagamento externo por turno (modo A) + recibo — Piloto #1
+-- File: supabase/migrations/20260630000000_shift_payments.sql
+-- ADR: .harness/memory-bank/decisions/ADR-20260630-pagamento-opcional-piloto.md (decisão-mãe: modo A = registro ≠ saldo)
+-- Plano: .harness/spec/v1-operacao-freelancer/plan-modo-a.md (§2 schema; §4 HALT RESOLVIDO)
+-- Gate: harness-architect (auditoria financeira, mesmo SEM mover saldo).
+--
+-- ============================================================================
+-- FRONTEIRA CRÍTICA (Article 8/9/10) — LER ANTES DE MEXER
+-- ----------------------------------------------------------------------------
+--   Esta tabela é REGISTRO/AUDITORIA, NÃO liquidação. O modo A grava a DECLARAÇÃO
+--   de que o pagamento aconteceu FORA do Worki (PIX/dinheiro) e emite recibo.
+--
+--   NÃO move saldo:      nenhum UPDATE em wallets, nenhuma linha em escrow_transactions.
+--   NÃO chama RPC:       sem reserve/release/refund/authorize/capture — Article 8 intacto.
+--   NÃO referencia nem   é referenciada por wallets/escrow_transactions. As FKs saem
+--                        de shift_payments → jobs/companies/workers/applications (nunca o inverso).
+--   NÃO precisa de       service_role para ESCREVER: o INSERT é do papel `authenticated`
+--                        sob RLS (a empresa dona registra). O GRANT a service_role é só
+--                        p/ LEITURA futura do BI (BI-1 unifica escrow ∪ marcador por job_id).
+--   Idempotência (Article 9, adaptado — NÃO é wallet_transactions): a chave de dedupe
+--                        é `job_id` — UM turno é pago por EXATAMENTE uma fonte no modo A.
+--                        Aqui o UNIQUE é PARCIAL (WHERE status='recorded') — ver DECISÃO abaixo.
+--
+-- ============================================================================
+-- DECISÃO DO ARCHITECT — UNIQUE PARCIAL (WHERE status = 'recorded')
+-- ----------------------------------------------------------------------------
+--   HALT resolveu "1 registro por turno, índice parcial p/ re-registro após void".
+--   Adotado: UNIQUE (job_id) WHERE status = 'recorded'  (índice parcial).
+--   Justificativa: um UNIQUE(job_id) simples impediria corrigir um registro errado —
+--   como correção = ESTORNO LÓGICO (status='voided', nunca UPDATE destrutivo do valor),
+--   após o void o mesmo turno precisa aceitar um NOVO registro 'recorded'. O parcial
+--   permite N linhas 'voided' + no máximo UMA 'recorded' por job_id. Casa com o contrato
+--   de dedupe do BI (job_id disjunto entre escrow e marcador; escrow tem precedência em
+--   anomalia). Não é wallet_transactions → não usa (wallet_id, reference_id).
+--
+-- ============================================================================
+-- MODELO DE IDENTIDADE (confirmado por team_connections / payment_methods / applications)
+-- ----------------------------------------------------------------------------
+--   companies.id = companies.owner_id = auth.uid() = jobs.company_id = wallets.user_id  → UUID
+--   workers.id   = auth.uid() (usuário 'work')  = applications.worker_id                → UUID
+--   → company_id ancora o RLS da empresa (owner_id = auth.uid()); worker_id = auth.uid() ancora o freela.
+--
+-- ============================================================================
+-- IMUTABILIDADE / AUDITORIA (ADR §2; HALT bilateral ativo)
+-- ----------------------------------------------------------------------------
+--   Colunas MATERIAIS (job_id, company_id, worker_id, application_id, source, amount,
+--   paid_at, recorded_by, note, created_at) são IMUTÁVEIS após o INSERT — trigger
+--   BEFORE UPDATE compara OLD/NEW (padrão validate_application_update). Correção só via
+--   estorno lógico (status='voided' + voided_at + void_reason) — NUNCA UPDATE do valor.
+--   Registro 'voided' é totalmente imutável (não re-abre, não re-confirma).
+--   UPDATE PARTICIONADO por papel:
+--     - EMPRESA dona → estorno lógico (status recorded→voided, voided_at, void_reason).
+--                      NÃO pode tocar worker_confirmed_at (é do freela).
+--     - FREELA (worker_id=auth.uid()) → só seta worker_confirmed_at (one-way NULL→ts).
+--                      NÃO pode tocar status/void/nada mais. Bilateral ATIVO (HALT #2).
+--   SEM policy de DELETE — auditoria não se apaga (correção = voided).
+--   FKs com ON DELETE RESTRICT (jobs/companies/workers): o registro de auditoria NÃO
+--   pode ser destruído em cascata por deleção de turno/empresa/freela. application_id
+--   (link opcional) usa SET NULL: se a candidatura sumir, o recibo permanece.
+--
+-- Turno concluído é PRÉ-REQUISITO de PRODUTO (guarda de UI/service — habilitar o botão só
+-- pós-checkout/confirmação). NÃO é enforced aqui: o schema não conhece o estado do ciclo
+-- sem acoplar shift_payments a applications.status (acoplamento indesejado). Fica no service.
+--
+-- DOWN (rollback): ver rodapé.
+-- ============================================================================
+
+-- =============================================
+-- 1. TABELA
+-- =============================================
+CREATE TABLE IF NOT EXISTS public.shift_payments (
+    id             uuid          DEFAULT gen_random_uuid() PRIMARY KEY,
+    -- turno pago. Base do dedupe (UNIQUE parcial abaixo). RESTRICT: audit não some com o job.
+    job_id         uuid          NOT NULL REFERENCES public.jobs(id)         ON DELETE RESTRICT,
+    -- dono do registro (empresa). Âncora do RLS empresa. RESTRICT: audit não some com a empresa.
+    company_id     uuid          NOT NULL REFERENCES public.companies(id)    ON DELETE RESTRICT,
+    -- freela pago. Âncora do RLS worker (= auth.uid()). RESTRICT: audit não some com o freela.
+    -- [architect ajustou §2: worker_id ganha FK → workers(id) ON DELETE RESTRICT (integridade
+    --  referencial + proteção de auditoria; o plano listava só jobs/applications/companies).]
+    worker_id      uuid          NOT NULL REFERENCES public.workers(id)      ON DELETE RESTRICT,
+    -- liga ao ciclo/turno específico (evidência). Opcional; SET NULL preserva o recibo se a
+    -- candidatura for removida.
+    application_id uuid          REFERENCES public.applications(id)          ON DELETE SET NULL,
+    -- método DECLARADO (não prova bancária). HALT #3.
+    source         text          NOT NULL CHECK (source IN ('external_pix', 'cash', 'other')),
+    -- valor declarado pago (BRL). Sempre > 0.
+    amount         numeric(12,2) NOT NULL CHECK (amount > 0),
+    -- quando o pagamento aconteceu (declarado). Carimbo de período do BI (fallback = conclusão).
+    paid_at        timestamptz   NOT NULL DEFAULT now(),
+    -- quem registrou (empresa no v1). DEFAULT auth.uid(); RLS INSERT força = auth.uid().
+    recorded_by    uuid          NOT NULL DEFAULT auth.uid(),
+    -- confirmação de recebimento pelo freela (bilateral ATIVO — HALT #2). One-way NULL→ts.
+    -- NÃO bloqueia ciclo/avaliação (HALT #7); é sinal de confiança.
+    worker_confirmed_at timestamptz,
+    -- observação livre (ex.: "pago em 2x", referência PIX). Imutável (parte da declaração).
+    note           text,
+    -- estado. Correção = estorno lógico ('voided'), NUNCA UPDATE destrutivo do valor.
+    status         text          NOT NULL DEFAULT 'recorded'
+                                 CHECK (status IN ('recorded', 'voided')),
+    -- trilha do estorno lógico.
+    voided_at      timestamptz,
+    void_reason    text,
+    created_at     timestamptz   NOT NULL DEFAULT now(),
+    -- coerência do estorno: 'recorded' é limpo; 'voided' exige carimbo (motivo opcional).
+    CONSTRAINT shift_payments_void_consistency CHECK (
+        (status = 'recorded' AND voided_at IS NULL AND void_reason IS NULL)
+        OR
+        (status = 'voided'   AND voided_at IS NOT NULL)
+    )
+);
+
+COMMENT ON TABLE  public.shift_payments IS 'Marcador de pagamento EXTERNO por turno (modo A do ADR-20260630). Registro/auditoria declaratório — NÃO move saldo, NÃO toca wallets/escrow_transactions, sem RPC. Fonte da verdade do gasto quando o dinheiro não passa pelo Worki (insumo do BI).';
+COMMENT ON COLUMN public.shift_payments.job_id              IS 'Turno pago. Chave de dedupe (UNIQUE parcial WHERE status=recorded). RESTRICT.';
+COMMENT ON COLUMN public.shift_payments.source              IS 'Método DECLARADO (não prova bancária): external_pix | cash | other.';
+COMMENT ON COLUMN public.shift_payments.amount              IS 'Valor declarado pago em BRL (> 0). NÃO é saldo — nenhuma RPC.';
+COMMENT ON COLUMN public.shift_payments.paid_at             IS 'Data declarada do pagamento. Carimbo de período do BI (fallback = conclusão do turno).';
+COMMENT ON COLUMN public.shift_payments.recorded_by         IS 'auth.uid() de quem registrou (empresa no v1). RLS força = auth.uid() no INSERT.';
+COMMENT ON COLUMN public.shift_payments.worker_confirmed_at IS 'Confirmação de recebimento pelo freela (bilateral ativo). One-way NULL→ts. Não bloqueia ciclo.';
+COMMENT ON COLUMN public.shift_payments.status              IS 'recorded (ativo) | voided (estornado, imutável). Correção = void + novo registro, nunca UPDATE do valor.';
+
+-- =============================================
+-- 2. ÍNDICES (tabela nova/vazia → CREATE INDEX simples é seguro; sem CONCURRENTLY)
+-- =============================================
+-- Dedupe + idempotência: no máximo UMA linha 'recorded' por turno; N 'voided' permitidos.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_shift_payments_job_recorded
+    ON public.shift_payments (job_id)
+    WHERE status = 'recorded';
+
+-- Lookup do recibo por turno (qualquer status) — getPaymentByJob.
+CREATE INDEX IF NOT EXISTS idx_shift_payments_job
+    ON public.shift_payments (job_id);
+
+-- BI de gasto externo por empresa/período (só linhas ativas somam) — parcial p/ enxugar.
+CREATE INDEX IF NOT EXISTS idx_shift_payments_company_paid
+    ON public.shift_payments (company_id, paid_at)
+    WHERE status = 'recorded';
+
+-- Recibos/gasto do lado do freela.
+CREATE INDEX IF NOT EXISTS idx_shift_payments_worker
+    ON public.shift_payments (worker_id);
+
+-- =============================================
+-- 3. IMUTABILIDADE — trigger BEFORE UPDATE (padrão validate_application_update)
+--    Enforça: colunas materiais congeladas (todos os papéis, inclusive service_role);
+--    'voided' totalmente imutável; worker_confirmed_at one-way; UPDATE particionado por papel.
+-- =============================================
+CREATE OR REPLACE FUNCTION public.enforce_shift_payment_immutability()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_is_company BOOLEAN;
+    v_is_worker  BOOLEAN;
+BEGIN
+    -- === COLUNAS MATERIAIS: imutáveis para TODOS (inclusive service_role) ===
+    -- Não há caso legítimo de mutar valor/fonte/data/vínculo de um registro de auditoria.
+    IF NEW.id             IS DISTINCT FROM OLD.id
+       OR NEW.job_id         IS DISTINCT FROM OLD.job_id
+       OR NEW.company_id     IS DISTINCT FROM OLD.company_id
+       OR NEW.worker_id      IS DISTINCT FROM OLD.worker_id
+       OR NEW.application_id IS DISTINCT FROM OLD.application_id
+       OR NEW.source         IS DISTINCT FROM OLD.source
+       OR NEW.amount         IS DISTINCT FROM OLD.amount
+       OR NEW.paid_at        IS DISTINCT FROM OLD.paid_at
+       OR NEW.recorded_by    IS DISTINCT FROM OLD.recorded_by
+       OR NEW.note           IS DISTINCT FROM OLD.note
+       OR NEW.created_at     IS DISTINCT FROM OLD.created_at
+    THEN
+        RAISE EXCEPTION 'shift_payments: colunas materiais sao imutaveis (job_id, company_id, worker_id, application_id, source, amount, paid_at, recorded_by, note, created_at). Correcao = estorno logico (voided).';
+    END IF;
+
+    -- === Registro estornado é IMUTÁVEL (não re-abre, não re-confirma) ===
+    IF OLD.status = 'voided' THEN
+        RAISE EXCEPTION 'shift_payments: registro estornado (voided) e imutavel.';
+    END IF;
+
+    -- === worker_confirmed_at é ONE-WAY (NULL → timestamp; nunca altera/limpa) ===
+    IF OLD.worker_confirmed_at IS NOT NULL
+       AND NEW.worker_confirmed_at IS DISTINCT FROM OLD.worker_confirmed_at
+    THEN
+        RAISE EXCEPTION 'shift_payments: worker_confirmed_at nao pode ser alterado apos a confirmacao.';
+    END IF;
+
+    -- === PARTIÇÃO POR PAPEL (só para chamadas autenticadas; service_role/trigger tem auth.uid() NULL) ===
+    IF auth.uid() IS NOT NULL THEN
+        v_is_company := EXISTS (
+            SELECT 1 FROM public.companies WHERE id = NEW.company_id AND owner_id = auth.uid()
+        );
+        v_is_worker := (NEW.worker_id = auth.uid());
+
+        IF v_is_worker AND NOT v_is_company THEN
+            -- Freela: SÓ pode setar worker_confirmed_at. Nada mais muda.
+            IF NEW.status      IS DISTINCT FROM OLD.status
+               OR NEW.voided_at   IS DISTINCT FROM OLD.voided_at
+               OR NEW.void_reason IS DISTINCT FROM OLD.void_reason
+            THEN
+                RAISE EXCEPTION 'shift_payments: freela so pode confirmar recebimento (worker_confirmed_at).';
+            END IF;
+        ELSIF v_is_company THEN
+            -- Empresa: gerencia estorno lógico; NÃO toca a confirmação do freela.
+            IF NEW.worker_confirmed_at IS DISTINCT FROM OLD.worker_confirmed_at THEN
+                RAISE EXCEPTION 'shift_payments: empresa nao pode alterar a confirmacao do freela.';
+            END IF;
+        ELSE
+            RAISE EXCEPTION 'shift_payments: usuario nao autorizado a atualizar este registro.';
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_enforce_shift_payment_immutability ON public.shift_payments;
+CREATE TRIGGER trg_enforce_shift_payment_immutability
+    BEFORE UPDATE ON public.shift_payments
+    FOR EACH ROW
+    EXECUTE FUNCTION public.enforce_shift_payment_immutability();
+
+-- =============================================
+-- 4. RLS
+-- =============================================
+ALTER TABLE public.shift_payments ENABLE ROW LEVEL SECURITY;
+-- NÃO usar FORCE ROW LEVEL SECURITY (ver 20260318000000): FORCE + REVOKE bloquearia o
+-- service_role, que precisa LER o marcador para o BI. RLS normal basta (service_role bypassa).
+
+-- Sem acesso anônimo (padrão team_connections / company_spend_limits / applications / wallets).
+REVOKE ALL ON public.shift_payments FROM anon;
+-- SEM DELETE para authenticated — auditoria não se apaga (correção = 'voided').
+GRANT SELECT, INSERT, UPDATE ON public.shift_payments TO authenticated;
+-- service_role: leitura futura do BI (escrow ∪ marcador). NÃO é usado para ESCREVER no modo A.
+GRANT ALL ON public.shift_payments TO service_role;
+
+-- ---- SELECT: empresa dona OU freela pago veem o próprio registro (recibo bilateral) ----
+DROP POLICY IF EXISTS "sp_select_participants" ON public.shift_payments;
+CREATE POLICY "sp_select_participants" ON public.shift_payments
+    FOR SELECT TO authenticated
+    USING (
+        company_id IN (SELECT id FROM public.companies WHERE owner_id = auth.uid())
+        OR worker_id = auth.uid()
+    );
+
+-- ---- INSERT: SÓ a empresa dona registra; nasce 'recorded', limpo, por ela mesma ----
+DROP POLICY IF EXISTS "sp_insert_company" ON public.shift_payments;
+CREATE POLICY "sp_insert_company" ON public.shift_payments
+    FOR INSERT TO authenticated
+    WITH CHECK (
+        company_id IN (SELECT id FROM public.companies WHERE owner_id = auth.uid())
+        AND recorded_by = auth.uid()
+        AND status = 'recorded'
+        AND worker_confirmed_at IS NULL
+        AND voided_at IS NULL
+        AND void_reason IS NULL
+    );
+
+-- ---- UPDATE (empresa): estorno lógico de um registro ATIVO (recorded→voided) ----
+-- USING restringe a linhas ativas dela; WITH CHECK permite manter 'recorded' ou virar 'voided'.
+-- A imutabilidade coluna-a-coluna (não tocar worker_confirmed_at etc.) é do TRIGGER.
+DROP POLICY IF EXISTS "sp_update_company" ON public.shift_payments;
+CREATE POLICY "sp_update_company" ON public.shift_payments
+    FOR UPDATE TO authenticated
+    USING (
+        company_id IN (SELECT id FROM public.companies WHERE owner_id = auth.uid())
+        AND status = 'recorded'
+    )
+    WITH CHECK (
+        company_id IN (SELECT id FROM public.companies WHERE owner_id = auth.uid())
+        AND status IN ('recorded', 'voided')
+    );
+
+-- ---- UPDATE (freela): confirma recebimento em registro ATIVO; status permanece 'recorded' ----
+-- USING/CHECK travam o freela em linhas dele e ativas; o TRIGGER garante que SÓ
+-- worker_confirmed_at muda (bilateral ativo — HALT #2).
+DROP POLICY IF EXISTS "sp_update_worker" ON public.shift_payments;
+CREATE POLICY "sp_update_worker" ON public.shift_payments
+    FOR UPDATE TO authenticated
+    USING (
+        worker_id = auth.uid()
+        AND status = 'recorded'
+    )
+    WITH CHECK (
+        worker_id = auth.uid()
+        AND status = 'recorded'
+    );
+
+-- ---- DELETE: NENHUMA policy — negado a todos os papéis authenticated (auditoria imutável). ----
+
+-- ============================================================================
+-- DOWN (rollback) — sem impacto em saldo/escrow (nenhuma RPC tocada):
+--   DROP TABLE IF EXISTS public.shift_payments CASCADE;
+--   DROP FUNCTION IF EXISTS public.enforce_shift_payment_immutability();
+-- ============================================================================


### PR DESCRIPTION
## Contexto

Implementa o **piloto empresa-primeiro** após o refinamento do modelo (ADR-20260630): **pagamento pelo Worki é opcional**. O valor do dia 1 é **controle + dado** (histórico, recibo, avaliação), não o trilho financeiro. Naming decidido com pesquisa de mercado: **"Meu Elenco"** (empresa) e **"Carteira de Clientes"** (freela).

Corrida completa via harness (architect/builder/frontend-builder → security + frontend reviewers → evaluator), 6 features + docs, build/lint/testes verdes.

## Features (commits)

| # | Item | Commit | Gate |
|---|---|---|---|
| 1 | **Modo A: pagamento externo + recibo** | `c0049765` | architect→builder→2 reviewers→evaluator ✅ |
| 2 | **BI de gasto unificado** (escrow ∪ marcador) | `e82d89ee` | builder→evaluator ✅ |
| 3 | **Meu Elenco + Carteira de Clientes** | `3810bf0e` | frontend-builder ✅ |
| 4 | **Convite em tela cheia** (worker) | `3e6ae930` | frontend-builder ✅ |
| 5 | **QR scan + link transitivo** | `6862e17b` | frontend-builder→security-reviewer ✅ |
| 6 | **Expiração de convite** (visão + edge fn) | `00488cc6` | builder ✅ |
| — | docs + memory-bank | `f06a5499` | doc-writer + memory-updater |

### #1 — Modo A: marcador de pagamento externo + recibo
Empresa registra que pagou o freela **por fora** (PIX/dinheiro) ao concluir o turno → marcador por turno (`shift_payments`) + recibo in-app bilateral, **sem mover saldo** (Article 8 intacto: RLS bilateral, imutável, sem FK de/para wallets/escrow). Modal "Registrar Pagamento" (ramifica por `escrow.kind`, não regride postpago) + `/recibo/:jobId` com disclaimer declaratório, impressão e confirmação bilateral do freela.

### #2 — BI unificado
BI e teto liam só escrow → mostravam **zero** no modo A. Agora somam `escrow ∪ shift_payments` com **dedupe por job_id** (escrow precede). Alerta de teto dispara após pagamento externo.

### #3 — Meu Elenco / Carteira de Clientes
Renomeação (schema `team_connections` inalterado) + nova página `CarteiraClientes` (worker) consumindo o hook órfão `useWorkerStores`: lojas aceitas, aceitar/recusar convites, sair/bloquear.

### #4 — Convite em tela cheia
`InviteTakeover` (worker) via Realtime do NotificationContext; push leve do browser. WhatsApp/SMS/push mobile = Slice 4 (TODO).

### #5 — QR scan + link transitivo
Aba QR (`html5-qrcode`) lê o Worki ID do freela → `addToTeam('qr')`. Link transitivo: cada perfil tem link único compartilhável (reusa `/convite/:token`). Token só carrega ID; RLS segue como defesa, conexão nasce `pending` (security-reviewer APPROVED).

### #6 — Expiração de convite
Visão "Não respondeu (expirado)" + "Convidar outro" (derivada, robusta ao pré/pós-cron). Edge function `expire-invites` (Deno, CORS, service_role, idempotente) marca vencidos como `declined` (neutro), `invitation_response` NULL = auto-expirado. Sem migration.

## Verificação
- `cd frontend && npm run build` verde · `npm run lint` sem erros novos (3 pré-existentes DepositModal/Admin).
- Testes das features: 37/37 verdes. Suíte tem 12 falhas de baseline pré-existentes não relacionadas.

## Deferido / follow-up (fora deste PR)
- **#7 modo B (PIX-único → distribuição):** move saldo real → exige ADR próprio + gate architect + aval humano. Não é necessário pro piloto (default é modo A).
- **OPS:** deploy da edge function `expire-invites` + agendamento (pg_cron). Status `expired` dedicado exigiria migration.
- **LOW (security-reviewer #5):** label de redirect por papel real da sessão; mensagem dedicada p/ erro FK 23503.