### PR TITLE
fix: bugs do E2E — workers.photo_url inexistente (crítico), naming Turno, fuso start_date

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -68,8 +68,8 @@ export default function Sidebar({ type = 'worker' }: SidebarProps) {
     const companyNavItems = [
         { icon: Home, label: 'Dashboard', path: '/company/dashboard' },
         { icon: Users, label: 'Meu Elenco', path: '/company/team' },
-        { icon: PlusCircle, label: 'Criar Vaga', path: '/company/create' },
-        { icon: Briefcase, label: 'Minhas Vagas', path: '/company/jobs' },
+        { icon: PlusCircle, label: 'Criar Turno', path: '/company/create' },
+        { icon: Briefcase, label: 'Meus Turnos', path: '/company/jobs' },
         { icon: MessageSquare, label: 'Mensagens', path: '/company/messages' },
         { icon: Wallet, label: 'Carteira', path: '/company/wallet' },
         { icon: TrendingDown, label: 'Financeiro', path: '/company/financeiro' },

--- a/frontend/src/pages/company/CompanyCreateJob.tsx
+++ b/frontend/src/pages/company/CompanyCreateJob.tsx
@@ -152,7 +152,8 @@ export default function CompanyCreateJob() {
                 location: formData.location,
                 budget: budgetAmount,
                 budget_type: formData.budget_type,
-                start_date: formData.start_date ? new Date(formData.start_date).toISOString() : null,
+                // meio-dia local evita o off-by-one de fuso (meia-noite UTC virava o dia anterior em BRT)
+                start_date: formData.start_date ? new Date(formData.start_date + 'T12:00:00').toISOString() : null,
                 scope: formData.scope,
                 work_start_time: formData.work_start_time,
                 work_end_time: formData.work_end_time,

--- a/frontend/src/services/financialBIService.ts
+++ b/frontend/src/services/financialBIService.ts
@@ -370,7 +370,7 @@ export const FinancialBIService = {
       // 4. Buscar perfis dos workers
       const { data: workers, error: workerErr } = await supabase
         .from('workers')
-        .select('id, full_name, avatar_url, photo_url')
+        .select('id, full_name, avatar_url')
         .in('id', workerIds);
 
       if (workerErr) {

--- a/frontend/src/services/paymentRecordService.ts
+++ b/frontend/src/services/paymentRecordService.ts
@@ -258,7 +258,7 @@ export const PaymentRecordService = {
           *,
           job:jobs ( id, title, location, start_date, work_start_time, work_end_time ),
           company:companies ( id, name, logo_url ),
-          worker:workers ( id, full_name, avatar_url, photo_url )
+          worker:workers ( id, full_name, avatar_url )
         `,
         )
         .eq('job_id', jobId)

--- a/frontend/src/services/shiftInviteService.ts
+++ b/frontend/src/services/shiftInviteService.ts
@@ -510,9 +510,7 @@ export const ShiftInviteService = {
           worker:workers (
             id,
             full_name,
-            avatar_url,
-            photo_url,
-            primary_role,
+            avatar_url,            primary_role,
             rating_average
           )
         `,

--- a/frontend/src/services/teamConnectionService.ts
+++ b/frontend/src/services/teamConnectionService.ts
@@ -482,9 +482,7 @@ export const TeamConnectionService = {
           worker:workers (
             id,
             full_name,
-            avatar_url,
-            photo_url,
-            primary_role,
+            avatar_url,            primary_role,
             roles,
             rating_average,
             reviews_count,
@@ -540,9 +538,7 @@ export const TeamConnectionService = {
           worker:workers (
             id,
             full_name,
-            avatar_url,
-            photo_url,
-            primary_role,
+            avatar_url,            primary_role,
             rating_average,
             city
           )


### PR DESCRIPTION
Bugs encontrados pelo **E2E visual (Playwright)** contra produção.

## BUG-1 (CRÍTICO — bloqueava todo o fluxo push)
O frontend fazia `select` de `workers.photo_url` — **coluna inexistente** → **HTTP 400** em Meu Elenco, painel de convite, candidatos, recibo (`getReceipt`) e BI-por-freela (`getSpendByWorker`). Removido `photo_url` dos 5 selects (o código já faz fallback `avatar_url ?? photo_url`; tipos mantidos). Fix validado no nível de API (mesmas queries sem `photo_url` → 200).
- `teamConnectionService.ts` (listTeamMembers, listAllConnections)
- `shiftInviteService.ts` (listInvitesByJob)
- `paymentRecordService.ts` (getReceipt)
- `financialBIService.ts` (getSpendByWorker)

## BUG-2 (escopo/naming)
Menu da empresa "Criar Vaga"/"Minhas Vagas" → "Criar Turno"/"Meus Turnos".

## BUG-3 (fuso)
`start_date` gravava meia-noite UTC → virava o dia anterior em BRT, quebrando o check-in "hoje". Agora grava meio-dia local.

Build/lint/testes verdes. Escopo enxuto (pivô push-first) confirmado pelo E2E — worker sem "Buscar Vagas", /jobs e /analytics 404, convite obrigatório, token preservado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)