### PR TITLE
fix: fecha residuais do E2E (notificar contraparte, postpago órfão, job_id vazio, data recibo)

### DIFF
--- a/frontend/src/hooks/useShiftInvites.ts
+++ b/frontend/src/hooks/useShiftInvites.ts
@@ -126,6 +126,14 @@ export function useCompanyInvites(jobId: string): UseCompanyInvitesResult {
   const { addToast } = useToast();
 
   const load = useCallback(async () => {
+    // Guarda: jobId ainda não existe (ex.: turno em criação) — não consulta, evita 400
+    // (`job_id=eq.` vazio é filtro inválido no PostgREST).
+    if (!jobId) {
+      setInvites([]);
+      setLoading(false);
+      return;
+    }
+
     const {
       data: { user },
     } = await supabase.auth.getUser();
@@ -142,7 +150,17 @@ export function useCompanyInvites(jobId: string): UseCompanyInvitesResult {
 
   useEffect(() => {
     let active = true;
+
     void (async () => {
+      // Guarda: jobId ainda não existe (ex.: turno em criação) — não consulta, evita 400
+      // (`job_id=eq.` vazio é filtro inválido no PostgREST).
+      if (!jobId) {
+        if (!active) return;
+        setInvites([]);
+        setLoading(false);
+        return;
+      }
+
       const {
         data: { user },
       } = await supabase.auth.getUser();

--- a/frontend/src/pages/ReceiptView.tsx
+++ b/frontend/src/pages/ReceiptView.tsx
@@ -17,6 +17,23 @@ const PAYMENT_SOURCE_LABELS: Record<PaymentSource, string> = {
     other: 'Outro',
 };
 
+/**
+ * Formata uma data "date-only" (ex.: `job.start_date`, ou `payment.paid_at` quando gravado
+ * a partir de um `<input type="date">` — ver CompanyJobCandidates `paymentPaidAt`) como data
+ * LOCAL, sem shift de fuso.
+ *
+ * `new Date("YYYY-MM-DD")` é interpretado pelo JS como meia-noite UTC; `date-fns format`
+ * formata em fuso local. Em BRT (UTC-3) isso recua a data em 1 dia (ex.: 01/07 vira 30/06).
+ * Mesmo padrão já usado em `components/JobCard.tsx` (fix do off-by-one em `start_date`).
+ * Só ajusta a EXIBIÇÃO — não altera como o dado é gravado.
+ */
+function formatDateOnly(isoOrDateOnly: string, pattern: string): string {
+    const dateStr = isoOrDateOnly.split('T')[0];
+    const [y, m, d] = dateStr.split('-').map(Number);
+    const date = new Date(y, m - 1, d);
+    return format(date, pattern, { locale: ptBR });
+}
+
 export default function ReceiptView() {
     const { jobId } = useParams<{ jobId: string }>();
     const navigate = useNavigate();
@@ -149,7 +166,7 @@ export default function ReceiptView() {
                         {job?.start_date && (
                             <span className="flex items-center gap-1">
                                 <Clock size={12} />
-                                {format(new Date(job.start_date), "dd/MM/yyyy", { locale: ptBR })}
+                                {formatDateOnly(job.start_date, "dd/MM/yyyy")}
                                 {job.work_start_time && ` • ${job.work_start_time}`}
                                 {job.work_end_time && ` – ${job.work_end_time}`}
                             </span>
@@ -173,7 +190,7 @@ export default function ReceiptView() {
                     </div>
                     <div className="border-2 border-black rounded-xl p-4">
                         <span className="block text-xs font-black uppercase text-gray-400 mb-1">Data do pagamento</span>
-                        <p className="font-bold text-lg">{format(new Date(payment.paid_at), 'dd/MM/yyyy', { locale: ptBR })}</p>
+                        <p className="font-bold text-lg">{formatDateOnly(payment.paid_at, 'dd/MM/yyyy')}</p>
                     </div>
                 </div>
 

--- a/frontend/src/services/shiftInviteService.ts
+++ b/frontend/src/services/shiftInviteService.ts
@@ -33,6 +33,26 @@ export type AuthorizePaymentOutcome =
   | { kind: 'card_declined'; errorMsg: string };
 
 // ---------------------------------------------------------------------------
+// Feature flag: pré-autorização postpago (Slice 2 / modo C — opt-in)
+// ---------------------------------------------------------------------------
+
+/**
+ * No piloto (ADR-20260630-pagamento-opcional-piloto) o modo padrão é (A) — pagamento externo
+ * registrado, SEM escrow/cartão. O caminho postpago (modo C, hold via `asaas-authorize-payment`)
+ * é opt-in / semente de expansão, não o trilho padrão.
+ *
+ * Por que uma flag e não uma checagem de "a empresa tem cartão on-file?": quem dispara este
+ * hold é o WORKER (ao aceitar o convite) e a RLS de `payment_methods` restringe SELECT ao owner
+ * da empresa (Article 4/8 — ver `20260622000600_payment_methods.sql`), então o client do worker
+ * nunca teria como saber, sem uma mudança de backend, se a empresa aderiu ao modo C.
+ *
+ * Mantemos o disparo desligado por flag para o piloto: evita a chamada órfã (e o erro de CORS
+ * no console) no modo A, sem remover o suporte postpago. Reversível: virar `true` (ou substituir
+ * por uma checagem real assim que existir um mecanismo seguro) quando o modo C for reaberto.
+ */
+const POSTPAY_AUTHORIZE_ENABLED = false;
+
+// ---------------------------------------------------------------------------
 // Helper interno: disparar pré-autorização postpago (best-effort, não bloqueia o aceite)
 // ---------------------------------------------------------------------------
 
@@ -410,7 +430,9 @@ export const ShiftInviteService = {
       //    Modo 'authorize': cria hold no cartão da empresa. Modo 'charge_on_demand': no-op aqui.
       //    A captura (ou cobrança direta) ocorre na conclusão via asaas-capture-payment.
       //    Em card_declined, dispatchAuthorizePayment já envia notificação à empresa.
-      if (response === 'accepted') {
+      //    Desligado no piloto (modo A — ver POSTPAY_AUTHORIZE_ENABLED): não dispara chamada
+      //    ao caminho postpago, evitando o erro de CORS órfão no console do worker.
+      if (response === 'accepted' && POSTPAY_AUTHORIZE_ENABLED) {
         await dispatchAuthorizePayment(current.job_id, applicationId, companyOwnerId ?? '');
       }
 
@@ -501,6 +523,10 @@ export const ShiftInviteService = {
    * Para o operador acompanhar respostas.
    */
   async listInvitesByJob(jobId: string): Promise<Application[]> {
+    // Guarda: sem jobId (ex.: turno ainda não criado/persistido), não há o que consultar.
+    // Evita `GET /applications?...&job_id=eq.&...` (400 — filtro vazio é inválido no PostgREST).
+    if (!jobId) return [];
+
     try {
       const { data, error } = await supabase
         .from('applications')

--- a/supabase/migrations/20260702000000_notifications_notify_counterpart.sql
+++ b/supabase/migrations/20260702000000_notifications_notify_counterpart.sql
@@ -1,0 +1,85 @@
+-- Migration: INSERT em `notifications` pode notificar a CONTRAPARTE de um vínculo aceito
+-- File: supabase/migrations/20260702000000_notifications_notify_counterpart.sql
+-- Contexto: fluxo push (Slice 1 / pivô empresa-primeiro) — ver .harness/memory-bank/architecture.md
+--
+-- PROBLEMA (HIGH, funcional — achado no E2E de produção):
+--   A policy de INSERT criada em 20260623000200_notifications_insert_policy.sql usa
+--   WITH CHECK (auth.uid() = user_id): só deixa o usuário inserir notificação PARA SI MESMO.
+--   O fluxo push precisa notificar a CONTRAPARTE:
+--     - Empresa notifica o worker ao convidar pra turno
+--       (shiftInviteService.inviteWorkerToShift → insert com user_id = workerId).
+--     - Worker notifica a empresa ao aceitar o convite / falha de cartão
+--       (shiftInviteService → insert com user_id = companyOwnerId).
+--   Resultado: POST /rest/v1/notifications → 403 → InviteTakeover (tela cheia) e o sino
+--   NÃO disparam (dependem do INSERT em notifications + Realtime). O freela só via o convite
+--   na aba Convites. Degrada a "notificação por todos os meios" que é parte da operação.
+--
+-- FIX:
+--   Substitui a policy de INSERT por uma que permite:
+--     (a) SELF   — auth.uid() = user_id  (preserva spendLimitService.evaluateSpendAlert,
+--                  em que o owner da empresa insere o alerta de teto PARA SI MESMO);  OU
+--     (b) CONTRAPARTE CONECTADA — existe team_connections com status='accepted' ligando
+--         auth.uid() ao user_id alvo, nas DUAS direções:
+--           - empresa (company_id = auth.uid()) notificando worker do seu Elenco
+--             (worker_id = user_id);
+--           - worker (worker_id = auth.uid()) notificando a empresa conectada
+--             (company_id = user_id).
+--   Invariante usada (documentada em 20260622000000_team_connections.sql):
+--     companies.id = companies.owner_id = auth.uid()  e  workers.id = auth.uid().
+--   Logo team_connections.company_id = auth.uid() (lado empresa) e
+--   team_connections.worker_id = auth.uid() (lado worker) são comparações diretas e corretas,
+--   e o user_id alvo da notificação (companyOwnerId) = company_id.
+--
+-- POR QUE NÃO É VETOR DE SPAM:
+--   - Só pares MUTUAMENTE CONSENTIDOS (handshake de equipe aceito) podem se notificar.
+--     A empresa só notifica workers que aceitaram entrar no seu Elenco; o worker só notifica
+--     empresas a que está conectado. Não há user→user arbitrário.
+--   - status DEVE ser 'accepted': conexões 'pending' ou 'blocked' NÃO autorizam INSERT.
+--     Se o freela bloqueia a loja (status='blocked'), as notificações da empresa param.
+--   - Não ampliamos para `applications`: o convite push já exige team_connection aceita
+--     (a política de INSERT de applications só deixa convidar membro aceito), então
+--     team_connections cobre o fluxo com a MENOR superfície. Incluir applications abriria
+--     candidaturas pull/pendentes como canal de notificação — desnecessário e mais largo.
+--
+-- COMPATIBILIDADE / SEGURANÇA:
+--   - Triggers SECURITY DEFINER que inserem notifications (ex.: notify_on_new_message) rodam
+--     como owner → não passam por RLS de authenticated → intactos.
+--   - service_role (send-notification, edge functions) bypassa RLS → intacto.
+--   - Article 4 (RLS 1ª linha de defesa) mantido; Article 9 não se aplica (notifications não é
+--     tabela financeira / não move saldo).
+--   - GRANT: `authenticated` JÁ possui INSERT em public.notifications (a policy self-only da
+--     20260623000200 funcionava para o alerta de teto). Nada a alterar em GRANT — o que muda é a
+--     policy. GRANT idempotente incluído abaixo por robustez (no-op se já existe).
+--   - Idempotente: DROP POLICY IF EXISTS da policy antiga E da nova antes do CREATE.
+--
+-- DOWN (rollback):
+--   DROP POLICY IF EXISTS "notifications_insert_self_or_connected" ON public.notifications;
+--   CREATE POLICY "Users insert own notifications" ON public.notifications
+--     FOR INSERT TO authenticated WITH CHECK (auth.uid() = user_id);
+
+GRANT INSERT ON public.notifications TO authenticated;
+
+-- Remove a policy antiga (self-only) e qualquer resíduo da nova.
+DROP POLICY IF EXISTS "Users insert own notifications" ON public.notifications;
+DROP POLICY IF EXISTS "notifications_insert_self_or_connected" ON public.notifications;
+
+CREATE POLICY "notifications_insert_self_or_connected"
+  ON public.notifications
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    -- (a) SELF: inserir na própria caixa (ex.: alerta de teto de gasto)
+    auth.uid() = notifications.user_id
+    -- (b) CONTRAPARTE de um vínculo de equipe ACEITO (as duas direções)
+    OR EXISTS (
+      SELECT 1
+      FROM public.team_connections tc
+      WHERE tc.status = 'accepted'
+        AND (
+          -- empresa (auth.uid()) notificando worker do seu Elenco
+          (tc.company_id = auth.uid() AND tc.worker_id = notifications.user_id)
+          -- worker (auth.uid()) notificando a empresa conectada
+          OR (tc.worker_id = auth.uid() AND tc.company_id = notifications.user_id)
+        )
+    )
+  );


### PR DESCRIPTION
Fecha os 4 residuais não-bloqueantes que o E2E visual deixou.

- **notifications 403 → notificar contraparte:** nova policy de INSERT (`notifications_insert_self_or_connected`) permite notificar quem é contraparte de um `team_connections` **accepted** (self OU conectado, nas 2 direções). Destrava o sino + a notificação tela-cheia (InviteTakeover) do convite. Sem spam (só contatos aceitos). Migration `20260702000000` **já aplicada em prod**.
- **postpago órfão (CORS):** flag `POSTPAY_AUTHORIZE_ENABLED=false` condiciona o hold `asaas-authorize-payment` — modo A não dispara a chamada órfã. Reversível (modo C reabre virando a flag).
- **400 job_id vazio:** guarda em `listInvitesByJob`/`useCompanyInvites`.
- **data do recibo off-by-one:** `formatDateOnly` parseia date-only como data local (BRT).

Build/lint/225 testes verdes. Sem tocar RPC/escrow/saldo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)