### PR TITLE
fix(onboarding): papel trocado no login/cadastro + logout mobile + copy do pivô

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ frontend/playwright-report/
 
 # Gemini API key for harness frontend-builder (do not commit)
 scripts/.gemini-key
+.env*

--- a/.harness/spec/onboarding-pivo-mvp/spec.md
+++ b/.harness/spec/onboarding-pivo-mvp/spec.md
@@ -1,0 +1,88 @@
+# Onboarding + logout — alinhar ao pivô empresa-primeiro (MVP) — spec
+
+## Context
+
+O usuário relatou, em linguagem direta: (1) ao tentar entrar/cadastrar como freela, o app está
+jogando a pessoa como empresa; (2) o botão "Sair" não funciona; (3) a tela de onboarding/landing e a
+separação worker/empresa estão "amadoras" e precisam ficar usáveis, funcionais e alinhadas ao pivô
+empresa-primeiro (ver `.harness/thesis.md`, [[pivot-company-first-2026]]), cortando tudo que não serve
+ao MVP reduzido.
+
+Investigação (Explore agent + leitura direta) confirmou causa-raiz dos dois bugs:
+
+**Bug 1 — papel trocado:** não existe tela de escolha de papel no cadastro em si; o papel vem só da
+query string `?type=work|hire` (`Onboarding.tsx` → `/login?type=...`). No signup, isso é gravado
+**uma única vez e para sempre** em `user_metadata.user_type` (`Login.tsx:37-45`). No **login** (conta já
+existente), `Login.tsx:70-79` **ignora completamente** o `type` da URL e redireciona só pelo metadata
+salvo. Como o Supabase Auth exige e-mail único, qualquer pessoa que já tenha uma conta com aquele e-mail
+cadastrada com o papel oposto (teste anterior, clique errado, reuso de e-mail) sempre volta pro papel
+antigo, **sem nenhum aviso** — bate exatamente com o relato "quero entrar de freela, entra de empresa
+direto". Não há UI de troca de papel nem checagem de conflito no onboarding (`WorkerOnboarding.tsx`,
+`CompanyOnboarding.tsx` fazem upsert sem validar `user_type`).
+
+**Bug 2 — logout não funciona:** existe **um único** botão "Sair" em toda a base autenticada —
+`Sidebar.tsx:143-148` — dentro de `<aside className="hidden md:flex ...">` (`Sidebar.tsx:82`), ou seja,
+**invisível em mobile**. `BottomNav.tsx` (usado no celular, canal primário do worker — ver
+`product.md`) **não tem nenhum item de logout**. As páginas de perfil (`Profile.tsx`,
+`CompanyProfile.tsx`) só chamam `signOut` dentro do fluxo de exclusão de conta, não como logout
+avulso. Em desktop, `handleLogout` (`Sidebar.tsx:25-28`) chama `supabase.auth.signOut()` direto
+(sem passar por `AuthContext.signOut`), sem try/catch, sem loading/disabled — falha de rede trava o
+clique sem feedback algum.
+
+**Desalinhamento de onboarding/landing com o pivô:** `Onboarding.tsx` ainda vende "marketplace" puro —
+"+5.000 vagas disponíveis agora", "10k+ Profissionais", grid de categorias, busca de vagas, seção "Como
+funciona" com "candidate-se com um clique". A tese (`.harness/thesis.md`) é explícita: **não somos
+marketplace de estranhos nessa fase** ("Não-objetivos do piloto"), o wedge é a empresa centralizando
+equipe+pagamento+confiança, o freela ganha "carteira de trabalho portátil". A landing hoje comunica o
+produto errado e usa métricas fictícias que não existem no piloto real.
+
+## Requirements
+
+- [ ] R1: Sign-in **respeita a conta real**, nunca mistura papel. Se a conta autenticada é `hire` mas o
+  usuário chegou via `/login?type=work` (ou vice-versa), mostrar mensagem clara explicando que aquele
+  e-mail já está cadastrado com o outro papel, com ação para ir ao dashboard correto ou usar outro
+  e-mail — nunca redirecionar silenciosamente sem explicação.
+- [ ] R2: Sign-up bloqueia e avisa (mensagem específica, não o genérico "Erro ao fazer login") quando o
+  e-mail já existe com o papel oposto, em vez de deixar o erro genérico do Supabase (`User already
+  registered`) confundir o usuário sobre por que ele "virou" o outro papel.
+- [ ] R3: Botão de logout funcional e acessível em **mobile** (canal primário do worker) — não pode
+  existir só no sidebar desktop.
+- [ ] R4: `handleLogout` usa `AuthContext.signOut` (fonte única de verdade do estado de auth), tem
+  tratamento de erro (toast) e estado de loading — nunca falha em silêncio.
+- [ ] R5: Copy da tela de escolha inicial (`Onboarding.tsx`, hero + 2 cards) alinhada ao pivô: sem
+  métricas fictícias de marketplace ("10k+", "+5.000 vagas"), mensagem que reflete "empresa centraliza
+  sua equipe de freelas de confiança" (lado empresa) e "sua carteira de trabalho portátil" (lado
+  freela) — linguagem da tese, nunca "CLT".
+
+## Out-of-scope (deliberado — MVP menor, não maior)
+
+- Reescrever as seções abaixo da dobra da landing (stats de vaidade, grade de categorias, busca de
+  vagas, depoimentos, seção "como funciona" com passos genéricos de marketplace). Ficam como estão
+  nesta rodada — são follow-up de marketing, não bloqueiam uso real do produto.
+- Permitir múltiplos papéis no mesmo e-mail (worker E empresa) — decisão de produto maior, fora do
+  escopo deste fix.
+- Redesenho completo de `WorkerOnboarding.tsx`/`CompanyOnboarding.tsx` (os formulários em si já
+  funcionam e coletam dados corretos); só ajustar se algo colidir com R1/R2.
+- QR check-in, grade drag-drop, gamificação nova — já são não-objetivos da tese.
+
+## Acceptance criteria
+
+- [ ] A1: DADO um e-mail já cadastrado como empresa, QUANDO o usuário tenta logar via
+  `/login?type=work`, ENTÃO o app mostra aviso claro (não redireciona silenciosamente pro dashboard
+  empresa) e oferece ir para `/company/dashboard` ou usar outro e-mail.
+- [ ] A2: DADO um cadastro novo com e-mail já existente no papel oposto, QUANDO o submit falha com
+  `User already registered`, ENTÃO a mensagem de erro menciona que o e-mail já é usado pelo outro papel.
+- [ ] A3: DADO um worker logado no celular, QUANDO ele procura sair da conta, ENTÃO existe uma ação de
+  logout visível e funcional na navegação mobile.
+- [ ] A4: DADO qualquer usuário (desktop ou mobile) clicando em "Sair", QUANDO `signOut` falha (rede
+  instável simulada), ENTÃO o app mostra um toast de erro em vez de travar sem feedback.
+- [ ] A5: DADO um visitante não autenticado, QUANDO ele vê a tela inicial de escolha (worker vs
+  empresa), ENTÃO a copy não usa números fictícios de marketplace e comunica a proposta do pivô
+  (equipe de confiança / carteira de trabalho portátil).
+
+## Clarifications log
+
+- Contexto dado diretamente pelo usuário (sem rodada de perguntas — pedido explícito para usar
+  julgamento com base na tese/pesquisa de campo já registradas em memória): fix dos 2 bugs é
+  prioridade, onboarding deve refletir o pivô empresa-primeiro, e o MVP deve ficar **menor**, não
+  ganhar escopo novo.

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,6 +1,9 @@
-import { Home, Briefcase, User, Wallet, Zap, PlusCircle, Building2, MessageSquare, LogOut, Users, TrendingDown, Contact, Inbox } from 'lucide-react';
+import { Home, Briefcase, User, Wallet, Zap, PlusCircle, Building2, MessageSquare, LogOut, Users, TrendingDown, Contact, Inbox, Loader2 } from 'lucide-react';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
+import { useAuth } from '../contexts/AuthContext';
+import { useToast } from '../contexts/ToastContext';
+import { logError } from '../lib/logger';
 import NotificationBell from './NotificationBell';
 import { useEffect, useState } from 'react';
 
@@ -21,10 +24,24 @@ export default function Sidebar({ type = 'worker' }: SidebarProps) {
 
     const [workerData, setWorkerData] = useState<WorkerData | null>(null);
     const navigate = useNavigate();
+    const { signOut } = useAuth();
+    const { addToast } = useToast();
+    const [loggingOut, setLoggingOut] = useState(false);
 
+    // R4: fonte única de verdade (AuthContext.signOut) + try/catch + toast de erro +
+    // estado de loading/disabled — nunca falha em silêncio.
     const handleLogout = async () => {
-        await supabase.auth.signOut();
-        navigate('/login');
+        if (loggingOut) return;
+        setLoggingOut(true);
+        try {
+            await signOut();
+            navigate('/login');
+        } catch (error) {
+            logError('Sidebar.handleLogout', error);
+            addToast('Não foi possível sair. Tente novamente.', 'error');
+        } finally {
+            setLoggingOut(false);
+        }
     };
 
     useEffect(() => {
@@ -143,9 +160,11 @@ export default function Sidebar({ type = 'worker' }: SidebarProps) {
 
                 <button
                     onClick={handleLogout}
-                    className="flex items-center justify-center gap-2 w-full py-2 rounded-xl font-bold uppercase text-xs text-red-600 hover:bg-red-50 border-2 border-transparent hover:border-red-200 transition-all"
+                    disabled={loggingOut}
+                    className="flex items-center justify-center gap-2 w-full py-2 rounded-xl font-bold uppercase text-xs text-red-600 hover:bg-red-50 border-2 border-transparent hover:border-red-200 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                    <LogOut size={16} /> Sair
+                    {loggingOut ? <Loader2 size={16} className="animate-spin" /> : <LogOut size={16} />}
+                    {loggingOut ? 'Saindo...' : 'Sair'}
                 </button>
             </div>
         </aside>

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -45,7 +45,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }, []);
 
     const signOut = async () => {
-        await supabase.auth.signOut();
+        // R4: propaga o erro pro chamador (Sidebar/Profile/CompanyProfile) tratar com
+        // toast + estado de loading — nunca falha em silêncio.
+        const { error } = await supabase.auth.signOut();
+        if (error) throw error;
         setUser(null);
     };
 

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -3,6 +3,7 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Lock, ArrowRight, Mail, Loader2 } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import { getPasswordStrength } from '../lib/validation';
+import { logError } from '../lib/logger';
 import PageMeta from '../components/PageMeta';
 import { PENDING_INVITE_TOKEN_KEY } from '../lib/inviteToken';
 
@@ -22,9 +23,18 @@ function resolvePendingInviteRedirect(explicitRedirect: string | null): string |
     return null;
 }
 
+/** Rótulo humano do papel da conta ('work' | 'hire') para mensagens de erro/aviso. */
+function roleLabel(userType: string | undefined | null): string {
+    return userType === 'hire' ? 'empresa' : 'freelancer';
+}
+
 export default function Login() {
     const [searchParams] = useSearchParams();
-    const type = searchParams.get('type') || 'work'; // 'work' or 'hire'
+    // 'explicitType' só existe quando o usuário chegou por um link que declara a intenção
+    // (ex.: card "Quero Trabalhar"/"Quero Contratar"). Convites (?redirect=...) não trazem
+    // 'type' — nesse caso não há intenção explícita de papel a comparar (R1).
+    const explicitType = searchParams.get('type');
+    const type = explicitType || 'work'; // 'work' or 'hire' — usado só para tema visual
     const reason = searchParams.get('reason');
     // Preserva o destino pretendido (ex.: /convite/<token>) quando o usuário chega ao
     // login vindo de um link que exigia sessão — ver InviteAccept.tsx (item 11 do GTM).
@@ -37,14 +47,39 @@ export default function Login() {
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [successMessage, setSuccessMessage] = useState<string | null>(null);
+    // R1: quando a conta autenticada tem um papel diferente do 'type' que trouxe o usuário
+    // até aqui, guardamos o papel REAL da conta e mostramos um aviso em vez de redirecionar
+    // silenciosamente para o dashboard errado.
+    const [roleMismatch, setRoleMismatch] = useState<{ actualType: 'work' | 'hire' } | null>(null);
 
     const isHire = type === 'hire';
+
+    const handleGoToCorrectDashboard = () => {
+        if (!roleMismatch) return;
+        navigate(roleMismatch.actualType === 'hire' ? '/company/dashboard' : '/dashboard');
+    };
+
+    const handleUseAnotherEmail = async () => {
+        // A conta logada não é a que o usuário queria acessar — encerra a sessão pra
+        // permitir tentar de novo com outro e-mail sem ficar "preso" no papel errado.
+        try {
+            await supabase.auth.signOut();
+        } catch (err) {
+            // Best-effort: mesmo se o signOut falhar, seguimos limpando o formulário local.
+            logError('Login.handleUseAnotherEmail', err);
+        }
+        setRoleMismatch(null);
+        setEmail('');
+        setPassword('');
+        setError(null);
+    };
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         setLoading(true);
         setError(null);
         setSuccessMessage(null);
+        setRoleMismatch(null);
 
         try {
             if (isSignUp) {
@@ -94,17 +129,23 @@ export default function Login() {
 
                 if (data.user) {
                     const pendingRedirect = resolvePendingInviteRedirect(redirectTo);
+                    const userType = data.user.user_metadata?.user_type;
+
                     if (pendingRedirect) {
                         navigate(pendingRedirect);
+                    } else if (
+                        explicitType &&
+                        (userType === 'work' || userType === 'hire') &&
+                        userType !== explicitType
+                    ) {
+                        // R1: o e-mail pertence a uma conta do OUTRO papel — nunca redirecionar
+                        // silenciosamente. Mostra aviso claro com ação pra ir ao dashboard
+                        // correto ou usar outro e-mail (A1).
+                        setRoleMismatch({ actualType: userType });
+                    } else if (userType === 'hire') {
+                        navigate('/company/dashboard');
                     } else {
-                        // Check user metadata for correct redirection
-                        const userType = data.user.user_metadata?.user_type;
-
-                        if (userType === 'hire') {
-                            navigate('/company/dashboard');
-                        } else {
-                            navigate('/dashboard');
-                        }
+                        navigate('/dashboard');
                     }
                 }
             }
@@ -115,7 +156,12 @@ export default function Login() {
             } else if (msg.includes('Email not confirmed')) {
                 setError('Por favor, verifique seu email antes de fazer login.');
             } else if (msg.includes('User already registered')) {
-                setError('Este email ja esta cadastrado. Faca login.');
+                // R2: mensagem específica (não o genérico "Erro ao fazer login") — a causa mais
+                // comum desse erro no cadastro é o e-mail já ter conta com o OUTRO papel (A2).
+                const oppositeType = type === 'hire' ? 'work' : 'hire';
+                setError(
+                    `Este e-mail já tem conta cadastrada como ${roleLabel(oppositeType)}. Entre por lá ou use outro e-mail.`
+                );
             } else if (msg.includes('rate_limit') || msg.includes('429') || msg.includes('over_email_send_rate_limit') || (err && typeof err === 'object' && 'status' in err && (err as { status: number }).status === 429)) {
                 setError('Muitas tentativas. Aguarde alguns minutos e tente novamente.');
             } else {
@@ -171,6 +217,31 @@ export default function Login() {
                     {error && (
                         <div className="mb-4 p-3 bg-red-100 border border-red-300 text-red-700 rounded-xl text-sm font-medium">
                             {error}
+                        </div>
+                    )}
+
+                    {roleMismatch && (
+                        <div className="mb-4 p-4 bg-amber-50 border-2 border-amber-400 text-amber-900 rounded-xl text-sm font-medium space-y-3">
+                            <p>
+                                Este e-mail já está cadastrado como <strong className="font-black">{roleLabel(roleMismatch.actualType)}</strong>.
+                                {' '}Não é possível entrar como {roleLabel(explicitType)} com esta conta.
+                            </p>
+                            <div className="flex flex-col sm:flex-row gap-2">
+                                <button
+                                    type="button"
+                                    onClick={handleGoToCorrectDashboard}
+                                    className="flex-1 bg-black text-white font-black uppercase text-xs py-2.5 rounded-lg hover:bg-primary transition-colors"
+                                >
+                                    Ir para o dashboard de {roleLabel(roleMismatch.actualType)}
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={handleUseAnotherEmail}
+                                    className="flex-1 border-2 border-amber-600 text-amber-900 font-black uppercase text-xs py-2.5 rounded-lg hover:bg-amber-100 transition-colors"
+                                >
+                                    Usar outro e-mail
+                                </button>
+                            </div>
                         </div>
                     )}
 
@@ -255,6 +326,7 @@ export default function Login() {
                                 setIsSignUp(!isSignUp);
                                 setError(null);
                                 setSuccessMessage(null);
+                                setRoleMismatch(null);
                             }}
                             className="underline decoration-2 hover:text-primary transition-colors font-bold"
                         >

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -45,29 +45,17 @@ export default function Onboarding() {
         {/* Left: Value Prop */}
         <div className="flex-1 space-y-8 max-w-xl">
           <h1 className="text-6xl md:text-8xl font-black leading-[0.9] tracking-tighter">
-            TRABALHE <br />
-            <span className="text-primary text-stroke-black">AGORA.</span>
+            CONFIANÇA <br />
+            <span className="text-primary text-stroke-black">DE VERDADE.</span>
           </h1>
           <p className="text-xl font-medium text-gray-600 max-w-md border-l-4 border-primary pl-4">
-            A plataforma gig para a força de trabalho moderna. Encontre turnos, receba rápido e cresça na carreira.
+            A camada de confiança e pagamento entre empresas e freelas que já trabalham juntos.
+            Contrate, pague e registre tudo num só lugar — sem virar vínculo, sem bagunça de WhatsApp.
           </p>
 
-          <div className="flex gap-4">
-            <div className="flex -space-x-3">
-              {[1, 2, 3, 4].map(i => (
-                <div key={i} className="w-10 h-10 rounded-full border-2 border-white bg-gray-300" />
-              ))}
-            </div>
-            <div>
-              <div className="flex items-center text-primary">
-                <Star fill="currentColor" size={16} />
-                <Star fill="currentColor" size={16} />
-                <Star fill="currentColor" size={16} />
-                <Star fill="currentColor" size={16} />
-                <Star fill="currentColor" size={16} />
-              </div>
-              <span className="text-sm font-bold">Aprovado por 10k+ Pros</span>
-            </div>
+          <div className="flex items-center gap-2 text-sm font-bold text-gray-500">
+            <Users size={18} className="text-primary" strokeWidth={2.5} />
+            Feito pra quem já trabalha junto — não pra estranhos.
           </div>
         </div>
 
@@ -80,13 +68,13 @@ export default function Onboarding() {
             className="group relative bg-white border-2 border-black rounded-2xl p-8 text-left transition-all hover:-translate-y-1 hover:shadow-[8px_8px_0px_0px_rgba(0,166,81,1)]"
           >
             <div className="absolute top-4 right-4 bg-primary text-white text-xs font-bold px-2 py-1 rounded-sm uppercase">
-              Para Profissionais
+              Para Freelas
             </div>
             <div className="w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center mb-4 group-hover:bg-primary group-hover:text-white transition-colors border-2 border-black">
               <DollarSign size={24} strokeWidth={3} />
             </div>
             <h3 className="text-2xl font-black uppercase mb-1">Quero Trabalhar</h3>
-            <p className="text-gray-500 font-medium text-sm">Ganhe dinheiro no seu horário. Bartender, Estoquista, Eventos e mais.</p>
+            <p className="text-gray-500 font-medium text-sm">Sua carteira de trabalho portátil: histórico, avaliação e recebimento — seus, em qualquer job.</p>
             <ArrowRight className="absolute bottom-8 right-8 opacity-0 group-hover:opacity-100 transition-opacity" />
           </button>
 
@@ -102,7 +90,7 @@ export default function Onboarding() {
               <Briefcase size={24} strokeWidth={3} />
             </div>
             <h3 className="text-2xl font-black uppercase mb-1">Quero Contratar</h3>
-            <p className="text-gray-400 font-medium text-sm">Preencha turnos instantaneamente com profissionais avaliados. Sem dor de cabeça.</p>
+            <p className="text-gray-400 font-medium text-sm">Centralize sua equipe de freelas de confiança: contrate, pague e registre tudo num só lugar.</p>
             <ArrowRight className="absolute bottom-8 right-8 opacity-0 group-hover:opacity-100 transition-opacity" />
           </button>
 

--- a/frontend/src/pages/Profile.test.tsx
+++ b/frontend/src/pages/Profile.test.tsx
@@ -27,6 +27,10 @@ vi.mock('../contexts/ToastContext', () => ({
   useToast: vi.fn(() => ({ addToast: vi.fn(), removeToast: vi.fn() })),
 }))
 
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({ user: { id: 'worker-1' }, loading: false, signOut: vi.fn().mockResolvedValue(undefined) })),
+}))
+
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom')
   return {
@@ -42,6 +46,7 @@ vi.mock('../lib/validation', () => ({
 
 import { supabase } from '../lib/supabase'
 import { useToast } from '../contexts/ToastContext'
+import { useAuth } from '../contexts/AuthContext'
 import { useNavigate } from 'react-router-dom'
 
 const WORKER_DATA = {
@@ -201,5 +206,40 @@ describe('Profile - Seguranca', () => {
     renderComponent()
     await waitFor(() => { expect(screen.getByText('Maria Silva')).toBeInTheDocument() })
     expect(screen.getByRole('button', { name: /alterar senha/i })).toBeDisabled()
+  })
+})
+
+describe('Profile — logout (R3/R4)', () => {
+  it('chama AuthContext.signOut e navega para /login ao clicar em Sair da conta', async () => {
+    setupMocks()
+    const mockSignOut = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(useAuth).mockReturnValue({ user: { id: 'worker-1' }, loading: false, signOut: mockSignOut } as unknown as ReturnType<typeof useAuth>)
+    const mockNavigate = vi.fn()
+    vi.mocked(useNavigate).mockReturnValue(mockNavigate)
+
+    renderComponent()
+    await waitFor(() => { expect(screen.getByText('Maria Silva')).toBeInTheDocument() })
+
+    fireEvent.click(screen.getByRole('button', { name: /sair da conta/i }))
+
+    await waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalled()
+      expect(mockNavigate).toHaveBeenCalledWith('/login')
+    })
+  })
+
+  it('mostra toast de erro quando signOut falha, sem travar em silencio', async () => {
+    const { mockAddToast } = setupMocks()
+    const mockSignOut = vi.fn().mockRejectedValue(new Error('network error'))
+    vi.mocked(useAuth).mockReturnValue({ user: { id: 'worker-1' }, loading: false, signOut: mockSignOut } as unknown as ReturnType<typeof useAuth>)
+
+    renderComponent()
+    await waitFor(() => { expect(screen.getByText('Maria Silva')).toBeInTheDocument() })
+
+    fireEvent.click(screen.getByRole('button', { name: /sair da conta/i }))
+
+    await waitFor(() => {
+      expect(mockAddToast).toHaveBeenCalledWith('Não foi possível sair. Tente novamente.', 'error')
+    })
   })
 })

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,8 +1,9 @@
 
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { supabase } from '../lib/supabase';
-import { User, MapPin, Briefcase, Star, ShieldCheck, Phone, Edit2, Loader2, Award, Save, X, Camera, CreditCard, Lock, QrCode, Copy, Check } from 'lucide-react';
+import { User, MapPin, Briefcase, Star, ShieldCheck, Phone, Edit2, Loader2, Award, Save, X, Camera, CreditCard, Lock, QrCode, Copy, Check, LogOut } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
 import { useToast } from '../contexts/ToastContext';
 import { getPasswordStrength } from '../lib/validation';
 import { logError } from '../lib/logger';
@@ -43,10 +44,12 @@ interface FormData {
 
 export default function Profile() {
     const navigate = useNavigate();
+    const { signOut } = useAuth();
     const [loading, setLoading] = useState(true);
     const [profile, setProfile] = useState<WorkerProfile | null>(null);
     const [isEditing, setIsEditing] = useState(false);
     const [uploading, setUploading] = useState(false);
+    const [loggingOut, setLoggingOut] = useState(false);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const coverInputRef = useRef<HTMLInputElement>(null);
     const { addToast } = useToast();
@@ -281,6 +284,22 @@ export default function Profile() {
         addToast('Senha alterada com sucesso.', 'success');
         setNewPassword('');
         setConfirmPassword('');
+    };
+
+    // R3/R4: logout acessível no mobile (via item "Perfil" do BottomNav) — fonte única
+    // AuthContext.signOut, com try/catch + toast de erro + estado de loading (A3/A4).
+    const handleLogout = async () => {
+        if (loggingOut) return;
+        setLoggingOut(true);
+        try {
+            await signOut();
+            navigate('/login');
+        } catch (error) {
+            logError('Profile.handleLogout', error);
+            addToast('Não foi possível sair. Tente novamente.', 'error');
+        } finally {
+            setLoggingOut(false);
+        }
     };
 
     const handleDeleteAccount = async () => {
@@ -665,6 +684,22 @@ export default function Profile() {
                 >
                     {passwordLoading ? <Loader2 className="animate-spin" size={18} /> : null}
                     Alterar Senha
+                </button>
+            </div>
+
+            {/* Sessão — logout avulso, acessível no mobile via item "Perfil" do BottomNav (R3) */}
+            <div className="border-t-2 border-gray-200 pt-8 mt-8">
+                <h3 className="text-xl font-black uppercase mb-4 flex items-center gap-2">
+                    <LogOut size={20} /> Sessão
+                </h3>
+                <p className="text-sm text-gray-600 mb-4">Sair da sua conta neste dispositivo.</p>
+                <button
+                    onClick={handleLogout}
+                    disabled={loggingOut}
+                    className="flex items-center justify-center gap-2 bg-black text-white px-6 py-3 rounded-xl font-black uppercase hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                    {loggingOut ? <Loader2 size={18} className="animate-spin" /> : <LogOut size={18} />}
+                    {loggingOut ? 'Saindo...' : 'Sair da conta'}
                 </button>
             </div>
 

--- a/frontend/src/pages/__tests__/Login.test.tsx
+++ b/frontend/src/pages/__tests__/Login.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import Login from '../Login'
@@ -10,13 +10,18 @@ vi.mock('../../lib/supabase', () => ({
     auth: {
       signInWithPassword: vi.fn(),
       signUp: vi.fn(),
+      signOut: vi.fn().mockResolvedValue({ error: null }),
     },
   },
 }))
 
-function renderLogin() {
+vi.mock('../../lib/logger', () => ({ logError: vi.fn() }))
+
+import { supabase } from '../../lib/supabase'
+
+function renderLogin(initialEntry = '/login?type=work') {
   return render(
-    <MemoryRouter initialEntries={['/login?type=work']}>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <Login />
     </MemoryRouter>
   )
@@ -61,5 +66,65 @@ describe('Login', () => {
     await user.click(screen.getByText('Cadastre-se'))
 
     expect(screen.getByRole('button', { name: /criar conta/i })).toBeInTheDocument()
+  })
+})
+
+describe('Login — R1: papel divergente no login (nunca redireciona silenciosamente)', () => {
+  it('mostra aviso claro e NAO redireciona quando conta ja existe com o OUTRO papel', async () => {
+    const user = userEvent.setup()
+    vi.mocked(supabase.auth.signInWithPassword).mockResolvedValue({
+      data: { user: { id: 'u1', user_metadata: { user_type: 'hire' } }, session: {} },
+      error: null,
+    } as unknown as Awaited<ReturnType<typeof supabase.auth.signInWithPassword>>)
+
+    // Usuario chega via ?type=work mas a conta é 'hire' (empresa)
+    renderLogin('/login?type=work')
+
+    await user.type(screen.getByLabelText('Email'), 'ja@existe.com')
+    await user.type(screen.getByLabelText('Senha'), 'senhaSegura123')
+    await user.click(screen.getByRole('button', { name: /entrar/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/já está cadastrado como/i)).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: /ir para o dashboard de empresa/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /usar outro e-mail/i })).toBeInTheDocument()
+  })
+
+  it('nao mostra aviso quando o papel da conta bate com o type da URL', async () => {
+    vi.mocked(supabase.auth.signInWithPassword).mockResolvedValue({
+      data: { user: { id: 'u2', user_metadata: { user_type: 'work' } }, session: {} },
+      error: null,
+    } as unknown as Awaited<ReturnType<typeof supabase.auth.signInWithPassword>>)
+
+    const user = userEvent.setup()
+    renderLogin('/login?type=work')
+
+    await user.type(screen.getByLabelText('Email'), 'ok@existe.com')
+    await user.type(screen.getByLabelText('Senha'), 'senhaSegura123')
+    await user.click(screen.getByRole('button', { name: /entrar/i }))
+
+    await waitFor(() => {
+      expect(supabase.auth.signInWithPassword).toHaveBeenCalled()
+    })
+    expect(screen.queryByText(/já está cadastrado como/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('Login — R2: cadastro com e-mail ja existente mostra mensagem especifica', () => {
+  it('exibe mensagem mencionando o outro papel quando signUp falha com "User already registered"', async () => {
+    const user = userEvent.setup()
+    vi.mocked(supabase.auth.signUp).mockRejectedValue(new Error('User already registered'))
+
+    renderLogin('/login?type=work')
+    await user.click(screen.getByText('Cadastre-se'))
+
+    await user.type(screen.getByLabelText('Email'), 'ja@existe.com')
+    await user.type(screen.getByLabelText('Senha'), 'senhaSegura123')
+    await user.click(screen.getByRole('button', { name: /criar conta/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/já tem conta cadastrada como empresa/i)).toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/pages/company/CompanyProfile.tsx
+++ b/frontend/src/pages/company/CompanyProfile.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Building2, MapPin, Globe, Mail, Save, Camera, Loader2, Star, LayoutDashboard, Pencil, Lock } from 'lucide-react';
+import { Building2, MapPin, Globe, Mail, Save, Camera, Loader2, Star, LayoutDashboard, Pencil, Lock, LogOut } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
+import { useAuth } from '../../contexts/AuthContext';
 import { useToast } from '../../contexts/ToastContext';
 import { getPasswordStrength } from '../../lib/validation';
 import { logError } from '../../lib/logger';
@@ -22,6 +23,7 @@ interface Company {
 
 export default function CompanyProfile() {
     const navigate = useNavigate();
+    const { signOut } = useAuth();
     const { addToast } = useToast();
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
@@ -30,6 +32,7 @@ export default function CompanyProfile() {
     const [deleteModalOpen, setDeleteModalOpen] = useState(false);
     const [deleteConfirmText, setDeleteConfirmText] = useState('');
     const [deleting, setDeleting] = useState(false);
+    const [loggingOut, setLoggingOut] = useState(false);
     const [company, setCompany] = useState<Company>({
         name: '',
         industry: '',
@@ -215,6 +218,22 @@ export default function CompanyProfile() {
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         setCompany({ ...company, [e.target.name]: e.target.value });
+    };
+
+    // R3/R4: logout acessível no mobile (via item "Perfil" do BottomNav) — fonte única
+    // AuthContext.signOut, com try/catch + toast de erro + estado de loading (A3/A4).
+    const handleLogout = async () => {
+        if (loggingOut) return;
+        setLoggingOut(true);
+        try {
+            await signOut();
+            navigate('/login');
+        } catch (error) {
+            logError('CompanyProfile.handleLogout', error);
+            addToast('Não foi possível sair. Tente novamente.', 'error');
+        } finally {
+            setLoggingOut(false);
+        }
     };
 
     const handleDeleteAccount = async () => {
@@ -628,6 +647,22 @@ export default function CompanyProfile() {
                     </button>
                 </div>
             )}
+
+            {/* Sessão — logout avulso, acessível no mobile via item "Perfil" do BottomNav (R3) */}
+            <div className="mt-8 bg-white border-2 border-gray-100 rounded-3xl p-8 shadow-xl">
+                <h3 className="text-xl font-black uppercase mb-4 flex items-center gap-2">
+                    <LogOut size={20} /> Sessão
+                </h3>
+                <p className="text-sm text-gray-600 mb-4">Sair da sua conta neste dispositivo.</p>
+                <button
+                    onClick={handleLogout}
+                    disabled={loggingOut}
+                    className="flex items-center justify-center gap-2 bg-black text-white px-6 py-3 rounded-xl font-black uppercase hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                    {loggingOut ? <Loader2 size={18} className="animate-spin" /> : <LogOut size={18} />}
+                    {loggingOut ? 'Saindo...' : 'Sair da conta'}
+                </button>
+            </div>
 
             {/* Zona de Perigo */}
             <div className="border-t-2 border-red-200 pt-8 mt-8">


### PR DESCRIPTION
Corrige os bugs reais de onboarding/cadastro (spec `onboarding-pivo-mvp`), que o E2E anterior tinha **pulado** por usar contas pré-criadas.

- **R1 — papel não troca no login:** se `?type` diverge do `user_type` real da conta, mostra aviso claro (ir ao dashboard correto / usar outro e-mail), sem redirect silencioso pro papel errado.
- **R2 — cadastro com e-mail existente:** mensagem específica (não o genérico "Erro ao fazer login").
- **R3/R4 — logout:** acessível no **mobile** (botão "Sair" no Perfil worker+empresa) + robusto (`AuthContext.signOut` como fonte única, try/catch, toast de erro, loading). Nunca falha em silêncio.
- **R5 — copy:** tela de escolha alinhada à tese (empresa centraliza equipe de confiança; freela = carteira portátil), sem métricas fictícias, nunca "CLT".

Trackeia a spec (era untracked); `.gitignore` passa a ignorar `.env*`. 230 testes verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)