### PR TITLE
fix: conexão de Elenco por link (RPC) + ruídos de console (E2E do zero)

### DIFF
--- a/.harness/memory-bank/decisions/ADR-20260702-worker-join-by-invite-token.md
+++ b/.harness/memory-bank/decisions/ADR-20260702-worker-join-by-invite-token.md
@@ -1,0 +1,69 @@
+# ADR-20260702 — Worker entra no elenco via link de convite (RPC SECURITY DEFINER, nasce 'accepted')
+
+## Status
+ACEITO
+
+## Contexto
+Fix bloqueante do GTM. A forcing-function do produto (pivô empresa-primeiro) é: a EMPRESA gera um link
+de convite (Meu Elenco → Adicionar → Link) e manda pro freela; o freela logado abre `/convite/:token`
+e entra no elenco da empresa.
+
+No E2E de prod (contas novas) o worker abrindo o link recebe "LINK INVÁLIDO" + **403 em
+`POST /rest/v1/team_connections`**. Causa-raiz: `teamConnectionService.addToTeamByToken` faz **INSERT
+direto como o worker**, mas a policy `tc_insert_company` (migration `20260622000000_team_connections.sql`)
+só autoriza a EMPRESA a inserir (`WITH CHECK company_id ∈ companies do auth.uid()`). Worker inserindo →
+viola RLS → 403.
+
+O caminho oposto funciona: empresa adiciona por Worki ID/QR (INSERT pela empresa, `pending`) → worker
+aceita (`UPDATE` via `tc_update_worker`, `pending→accepted`). Só o **link empresa→worker** está quebrado.
+
+Restrição de segurança: o token da empresa é `base64url(company_id)` — **não assinado, forjável**. Qualquer
+worker que conheça/derive um `company_id` pode forjar o token.
+
+## Decisão
+1. **RPC `SECURITY DEFINER` estreita** (`accept_company_invite_by_token(p_token text)`) em vez de abrir uma
+   policy de INSERT ampla pro worker. A RPC roda como owner (bypassa RLS) mas valida e **força server-side**:
+   `worker_id := auth.uid()`, `status := 'accepted'`, `source := 'link'`, empresa existe, caller é worker
+   (isolamento de papel). O INSERT direto do worker na tabela continua **proibido**; as policies existentes
+   ficam **intactas** → o fluxo que já funciona não muda.
+2. **A conexão nasce `accepted`** (não `pending`). Ambos os lados já consentiram: a empresa deliberadamente
+   gerou e enviou o link; o worker abriu e está logado. Um `pending` só adicionaria uma reconfirmação
+   redundante da empresa (ela iniciou o convite), **sem ganho de segurança** — o token é forjável de qualquer
+   forma e uma linha forjada exige a mesma remediação (empresa bloqueia/deleta) seja `pending` ou `accepted`.
+3. **Idempotente**: conexão existente é retornada sem alteração; em particular **não reabre `blocked`** (veto
+   do freela preservado).
+
+## Consequências
+### Positivas
+- GTM one-shot: worker abre o link → entra no elenco, sem passo extra.
+- Superfície mínima: nenhuma policy nova, nenhum INSERT direto do worker liberado; a lógica sensível fica
+  server-side numa função auditável. Reversível via `DROP FUNCTION`.
+- Caminho legado (empresa-adiciona-por-ID → worker-aceita) intocado.
+
+### Negativas / Trade-offs
+- **Auto-inserção como `accepted` via token forjável (spam leve).** Um worker malicioso pode se inserir no
+  roster de qualquer empresa cujo `company_id` conheça. Impacto **limitado**: (a) a RLS de SELECT só expõe a
+  própria linha do worker — **nenhum acesso indevido a dados** da empresa (jobs, outros workers, financeiro);
+  (b) a empresa dirige os convites de turno — não convida quem não reconhece; (c) remediação existente: a
+  empresa `DELETE` (`tc_delete_company`) ou bloqueia. O delta de risco entre spam-`pending` e spam-`accepted`
+  é pequeno e tem a mesma remediação.
+- A forjabilidade do token é a raiz do risco residual. Não é resolvida aqui (gatilho de reabertura abaixo).
+
+## Alternativas rejeitadas
+- **(b) Nova policy de INSERT `worker_id = auth.uid() AND status='pending'`**: mais simples, mas (i) abre
+  escrita direta do worker na tabela (menos controle sobre `source`/validação de empresa), e (ii) força um
+  passo de aceite adicional que a empresa/worker considera redundante — sem reduzir o risco de spam forjável.
+- **Nascer `pending`**: fricção redundante sem ganho de segurança sobre a forjabilidade do token.
+- **Assinar o token (HMAC) agora**: correto a longo prazo, mas fora do escopo do fix bloqueante e exigiria
+  segredo + mudança no `generateInviteToken` do frontend. Registrado como gatilho de reabertura.
+
+## Gatilhos de reabertura
+- Se o spam de auto-inserção virar problema real em prod → assinar o token (HMAC com segredo em Edge Function)
+  ou exigir expiração/nonce; então a RPC valida assinatura e o "ambos consentiram" deixa de depender de token
+  forjável.
+
+## Referências
+- Migration: `supabase/migrations/20260702120000_worker_join_by_invite_token.sql`
+- Bug/contrato: `teamConnectionService.addToTeamByToken`; policy `tc_insert_company` em
+  `supabase/migrations/20260622000000_team_connections.sql`
+- ADR relacionado: `ADR-20260622-aceite-convite-invited-hired.md` (máquina de estados de conexão/convite)

--- a/frontend/src/hooks/useShiftInvites.ts
+++ b/frontend/src/hooks/useShiftInvites.ts
@@ -118,7 +118,7 @@ export interface UseCompanyInvitesResult {
   refresh: () => void;
 }
 
-export function useCompanyInvites(jobId: string): UseCompanyInvitesResult {
+export function useCompanyInvites(jobId: string | null | undefined): UseCompanyInvitesResult {
   const [invites, setInvites] = useState<Application[]>([]);
   const [loading, setLoading] = useState(true);
   const [invitingWorkerId, setInvitingWorkerId] = useState<string | null>(null);
@@ -185,6 +185,11 @@ export function useCompanyInvites(jobId: string): UseCompanyInvitesResult {
       workerId: string,
       opts: { expiresInHours?: number; message?: string } = {},
     ): Promise<boolean> => {
+      // Guarda: sem jobId (turno ainda não criado/persistido) não há para onde convidar.
+      if (!jobId) {
+        addToast('Turno ainda não foi criado. Tente novamente em instantes.', 'error');
+        return false;
+      }
       setInvitingWorkerId(workerId);
       const result = await ShiftInviteService.inviteWorkerToShift(jobId, workerId, opts);
       setInvitingWorkerId(null);

--- a/frontend/src/services/shiftInviteService.ts
+++ b/frontend/src/services/shiftInviteService.ts
@@ -522,9 +522,11 @@ export const ShiftInviteService = {
    * Lista convites enviados por uma empresa para um job específico.
    * Para o operador acompanhar respostas.
    */
-  async listInvitesByJob(jobId: string): Promise<Application[]> {
-    // Guarda: sem jobId (ex.: turno ainda não criado/persistido), não há o que consultar.
-    // Evita `GET /applications?...&job_id=eq.&...` (400 — filtro vazio é inválido no PostgREST).
+  async listInvitesByJob(jobId: string | null | undefined): Promise<Application[]> {
+    // Guarda: sem jobId (ex.: turno ainda não criado/persistido, ou id ainda não resolvido pelo
+    // router), não há o que consultar. `!jobId` cobre '', null E undefined — evita tanto
+    // `GET /applications?...&job_id=eq.&...` (400, filtro vazio) quanto `...&job_id=eq.null`
+    // (400/dado incorreto, caso algum chamador passe null/undefined em vez de coalescer para '').
     if (!jobId) return [];
 
     try {

--- a/frontend/src/services/teamConnectionService.ts
+++ b/frontend/src/services/teamConnectionService.ts
@@ -300,49 +300,20 @@ export const TeamConnectionService = {
     if (!user) {
       return { connection: null, error: 'Sessão expirada. Faça login antes de aceitar o convite.' };
     }
-    const workerId = user.id;
-
-    // 3. Verificar que a empresa existe
-    const { data: company, error: cErr } = await supabase
-      .from('companies')
-      .select('id')
-      .eq('id', companyId)
-      .single();
-
-    if (cErr || !company) {
-      return { connection: null, error: 'Empresa do convite não encontrada.' };
-    }
-
-    // 4. Idempotência: verificar se já existe a conexão
-    const { data: existing } = await supabase
-      .from('team_connections')
-      .select('*')
-      .eq('company_id', companyId)
-      .eq('worker_id', workerId)
-      .maybeSingle();
-
-    if (existing) {
-      return { connection: existing as TeamConnection, alreadyExists: true };
-    }
-
-    // 5. Inserir conexão pending
-    const { data, error } = await supabase
-      .from('team_connections')
-      .insert({
-        company_id: companyId,
-        worker_id: workerId,
-        status: 'pending' as TeamConnectionStatus,
-        source: 'link' as TeamConnectionSource,
-      })
-      .select()
-      .single();
+    // 3. Registrar via RPC SECURITY DEFINER (accept_company_invite_by_token): o INSERT direto do
+    // worker viola tc_insert_company (só a empresa insere); a RPC força server-side
+    // worker_id=auth.uid() + status='accepted' + source='link' (a empresa consentiu ao gerar/mandar
+    // o link, o worker ao abrir logado). Idempotente. Ver ADR-20260702-worker-join-by-invite-token.
+    const { data, error } = await supabase.rpc('accept_company_invite_by_token', { p_token: token });
 
     if (error) {
-      if (error.code === '23505') {
-        return { connection: null, alreadyExists: true };
-      }
-      logError('teamConnection.addToTeamByToken.insert', error);
-      return { connection: null, error: 'Não foi possível registrar o convite.' };
+      logError('teamConnection.addToTeamByToken.rpc', error);
+      const m = error.message ?? '';
+      const msg = m.includes('company_not_found') ? 'Empresa do convite não encontrada.'
+        : m.includes('not_a_worker') ? 'Apenas freelas entram em um elenco por este link.'
+        : m.includes('invalid_token') ? 'Link de convite inválido ou expirado.'
+        : 'Não foi possível registrar o convite.';
+      return { connection: null, error: msg };
     }
 
     return { connection: data as TeamConnection };

--- a/frontend/src/services/walletService.test.ts
+++ b/frontend/src/services/walletService.test.ts
@@ -2,10 +2,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { Wallet, WalletTransaction, EscrowTransaction } from './walletService'
 
 // Mock supabase
+// mockSingle serve tanto .single() quanto .maybeSingle() — ambos resolvem { data, error } e o
+// teste controla o cenário (linha existe / ausente) via mockResolvedValueOnce, igual no client real.
 const mockSingle = vi.fn()
-const mockSelect = vi.fn(() => ({ single: mockSingle, eq: vi.fn(() => ({ single: mockSingle })), order: vi.fn(() => ({ data: [] })) }))
-const mockEq = vi.fn(() => ({ single: mockSingle, select: mockSelect, order: vi.fn(() => ({ data: [] })) }))
-const mockInsert = vi.fn(() => ({ select: vi.fn(() => ({ single: mockSingle })) }))
+const mockSelect = vi.fn(() => ({
+  single: mockSingle,
+  maybeSingle: mockSingle,
+  eq: vi.fn(() => ({ single: mockSingle, maybeSingle: mockSingle })),
+  order: vi.fn(() => ({ data: [] })),
+}))
+const mockEq = vi.fn(() => ({ single: mockSingle, maybeSingle: mockSingle, select: mockSelect, order: vi.fn(() => ({ data: [] })) }))
+const mockInsert = vi.fn(() => ({ select: vi.fn(() => ({ single: mockSingle, maybeSingle: mockSingle })) }))
 const mockFrom = vi.fn(() => ({ select: mockSelect, eq: mockEq, insert: mockInsert }))
 const mockRpc = vi.fn()
 
@@ -171,6 +178,28 @@ describe('WalletService methods', () => {
 
     expect(result).toEqual(existingWallet)
     expect(mockFrom).toHaveBeenCalledWith('wallets')
+  })
+
+  // Caracterização do fix B2: no primeiro acesso (onboarding) ainda não existe linha em `wallets`.
+  // A busca inicial usa `.maybeSingle()` (não `.single()`) para que a AUSÊNCIA de linha resolva
+  // como `{ data: null, error: null }` (sem 406) em vez de lançar erro — só então o fluxo cria a
+  // wallet via INSERT.
+  it('getOrCreateWallet cria wallet nova quando ainda nao existe (sem 406 na busca inicial)', async () => {
+    const newWallet = {
+      id: 'w-2', user_id: 'u-2', balance: 0, user_type: 'worker',
+      created_at: '2024-01-01', updated_at: '2024-01-01'
+    }
+
+    // 1ª resolução: busca inicial (.maybeSingle()) — ausência de linha, sem erro.
+    mockSingle.mockResolvedValueOnce({ data: null, error: null })
+    // 2ª resolução: INSERT ... .select().single() — cria e retorna a wallet nova.
+    mockSingle.mockResolvedValueOnce({ data: newWallet, error: null })
+
+    const { WalletService } = await import('./walletService')
+    const result = await WalletService.getOrCreateWallet('u-2', 'worker')
+
+    expect(result).toEqual(newWallet)
+    expect(mockInsert).toHaveBeenCalledWith({ user_id: 'u-2', balance: 0.00, user_type: 'worker' })
   })
 
   it('getBalance retorna 0 quando wallet nao existe', async () => {

--- a/frontend/src/services/walletService.ts
+++ b/frontend/src/services/walletService.ts
@@ -50,7 +50,7 @@ export const WalletService = {
             .from('wallets')
             .select('*')
             .eq('user_id', userId)
-            .single();
+            .maybeSingle();
 
         if (existing) return existing as Wallet;
 
@@ -83,7 +83,7 @@ export const WalletService = {
             .from('wallets')
             .select('balance')
             .eq('user_id', userId)
-            .single();
+            .maybeSingle();
 
         return data?.balance || 0;
     },
@@ -93,7 +93,7 @@ export const WalletService = {
             .from('wallets')
             .select('id')
             .eq('user_id', userId)
-            .single();
+            .maybeSingle();
 
         if (!wallet) return [];
 
@@ -264,7 +264,7 @@ export const WalletService = {
             .from('wallets')
             .select('id')
             .eq('user_id', companyUserId)
-            .single();
+            .maybeSingle();
 
         if (!wallet) return [];
 

--- a/supabase/migrations/20260702120000_worker_join_by_invite_token.sql
+++ b/supabase/migrations/20260702120000_worker_join_by_invite_token.sql
@@ -1,0 +1,119 @@
+-- Migration: Worker entra no elenco da empresa via LINK de convite (fix GTM bloqueante)
+-- File: supabase/migrations/20260702120000_worker_join_by_invite_token.sql
+-- ADR: .harness/memory-bank/decisions/ADR-20260702-worker-join-by-invite-token.md
+--
+-- PROBLEMA (E2E prod, contas novas):
+--   Fluxo pretendido (forcing-function do GTM): a EMPRESA gera um link de convite
+--   (Meu Elenco -> Adicionar -> Link) e manda pro freela; o freela (logado) abre
+--   /convite/:token e entra no elenco. O token é base64url(company_id).
+--   FALHA: o worker abrindo o link recebe 403 em POST /rest/v1/team_connections.
+--   CAUSA-RAIZ: teamConnectionService.addToTeamByToken faz INSERT direto como o
+--   worker, mas a policy tc_insert_company (20260622000000) só permite a EMPRESA
+--   inserir (WITH CHECK company_id IN companies do auth.uid()). Worker -> viola RLS.
+--
+-- SOLUÇÃO (opção a — RPC SECURITY DEFINER):
+--   Em vez de abrir uma policy de INSERT ampla pro worker (que abriria escrita
+--   direta na tabela financeira-adjacente de relações), introduzimos uma RPC
+--   estreita e auditada. Ela roda como owner (bypassa RLS), mas valida e FORÇA
+--   server-side tudo o que importa:
+--     - worker_id := auth.uid()  (worker não pode inserir em nome de terceiro)
+--     - status  := 'accepted'    (worker não pode forjar outro estado)
+--     - source  := 'link'
+--     - a empresa do token precisa existir
+--     - quem chama precisa ter perfil de worker (isolamento de papel — Art. 1)
+--   O INSERT direto do worker na tabela continua PROIBIDO. As policies existentes
+--   (tc_insert_company, tc_update_worker, tc_update_company, ...) ficam INTACTAS,
+--   então o caminho que já funciona (empresa-adiciona-por-ID -> worker-aceita) NÃO
+--   muda.
+--
+-- DECISÃO DE ESTADO (pending vs accepted): nasce 'accepted'. Ambos os lados já
+--   consentiram — a empresa deliberadamente GEROU e ENVIOU o link, e o worker
+--   ABRIU e está logado. 'pending' só adicionaria fricção redundante (a empresa
+--   teria que reconfirmar algo que ela mesma iniciou) sem ganho de segurança: o
+--   token é forjável de qualquer forma, e uma linha 'pending' forjada exigiria a
+--   mesma remediação (a empresa bloquear/deletar) que uma 'accepted' forjada.
+--   Ver ADR para a análise de risco (spam limitado, sem acesso indevido a dados).
+--
+-- Idempotência: se a conexão já existe (qualquer status), retorna a linha existente
+--   SEM alterá-la. Em particular NÃO reabre uma conexão 'blocked' (veto do freela).
+--
+-- NÃO toca saldo/escrow. Não é RPC financeira; mesmo assim segue o padrão
+--   SECURITY DEFINER + SET search_path = '' + GRANT EXECUTE explícito.
+--
+-- DOWN (rollback): DROP FUNCTION IF EXISTS public.accept_company_invite_by_token(text);
+
+-- =============================================
+-- RPC: accept_company_invite_by_token
+-- =============================================
+CREATE OR REPLACE FUNCTION public.accept_company_invite_by_token(p_token text)
+RETURNS public.team_connections
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_uid        uuid := auth.uid();
+    v_b64        text;
+    v_company_id uuid;
+    v_row        public.team_connections;
+BEGIN
+    -- 1. Precisa de sessão
+    IF v_uid IS NULL THEN
+        RAISE EXCEPTION 'not_authenticated' USING errcode = '28000';
+    END IF;
+
+    -- 2. Token de worker (prefixo w_) não entra por aqui — é o fluxo inverso
+    --    (empresa abrindo o link do worker), que continua via addToTeam.
+    IF p_token IS NULL OR left(p_token, 2) = 'w_' THEN
+        RAISE EXCEPTION 'invalid_token' USING errcode = '22023';
+    END IF;
+
+    -- 3. base64url -> base64 padrão + re-padding -> UUID da empresa
+    BEGIN
+        v_b64 := replace(replace(p_token, '-', '+'), '_', '/');
+        v_b64 := v_b64 || repeat('=', (4 - length(v_b64) % 4) % 4);
+        v_company_id := convert_from(decode(v_b64, 'base64'), 'utf8')::uuid;
+    EXCEPTION WHEN others THEN
+        RAISE EXCEPTION 'invalid_token' USING errcode = '22023';
+    END;
+
+    -- 4. A empresa do link precisa existir
+    IF NOT EXISTS (SELECT 1 FROM public.companies WHERE id = v_company_id) THEN
+        RAISE EXCEPTION 'company_not_found' USING errcode = 'P0002';
+    END IF;
+
+    -- 5. Isolamento de papel (Art. 1): só quem tem perfil de worker entra em elenco.
+    --    Uma sessão de empresa abrindo este link é rejeitada (usa addToTeam do lado dela).
+    IF NOT EXISTS (SELECT 1 FROM public.workers WHERE id = v_uid) THEN
+        RAISE EXCEPTION 'not_a_worker' USING errcode = '42501';
+    END IF;
+
+    -- 6. Idempotência: já existe? Retorna sem tocar (respeita 'blocked' = veto do freela).
+    SELECT * INTO v_row
+    FROM public.team_connections
+    WHERE company_id = v_company_id AND worker_id = v_uid;
+
+    IF FOUND THEN
+        RETURN v_row;
+    END IF;
+
+    -- 7. Ambos consentiram (empresa gerou+enviou o link; worker abriu) -> nasce 'accepted'.
+    INSERT INTO public.team_connections (company_id, worker_id, status, source, accepted_at)
+    VALUES (v_company_id, v_uid, 'accepted', 'link', now())
+    RETURNING * INTO v_row;
+
+    RETURN v_row;
+END;
+$$;
+
+COMMENT ON FUNCTION public.accept_company_invite_by_token(text) IS
+    'Worker entra no elenco da empresa via link de convite (base64url(company_id)). '
+    'SECURITY DEFINER: força worker_id=auth.uid() e status=accepted server-side, sem abrir INSERT direto ao worker. Idempotente; não reabre blocked.';
+
+-- Sem GRANT EXECUTE a RPC via PostgREST (.rpc()) falha. authenticated = worker logado; service_role por consistência.
+GRANT EXECUTE ON FUNCTION public.accept_company_invite_by_token(text) TO authenticated, service_role;
+
+-- =============================================
+-- DOWN (rollback manual):
+--   DROP FUNCTION IF EXISTS public.accept_company_invite_by_token(text);
+-- =============================================


### PR DESCRIPTION
Bugs achados no E2E completo do zero (contas novas). B1 (crítico GTM): worker abrindo o link de convite dava 403/RLS ('LINK INVÁLIDO') — RPC SECURITY DEFINER `accept_company_invite_by_token` destrava (worker→accepted server-side, sem abrir INSERT), migration já aplicada em prod + ADR-20260702. B2: wallet 406 (single→maybeSingle). B3: guardas de jobId falsy. 233 testes verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)