### PR TITLE
feat(copy): reposicionamento de conversão (entrada + /sobre) + doc para sócios

### DIFF
--- a/docs/worki-pivot-para-socios.md
+++ b/docs/worki-pivot-para-socios.md
@@ -1,0 +1,44 @@
+# Worki — Do marketplace ao operador de confiança
+*Documento para sócios · jul/2026*
+
+## Uma frase
+**Worki é a camada de confiança e pagamento da operação de freelancers das empresas:** a empresa centraliza contratar, pagar e registrar num só lugar; o freela ganha uma carteira de trabalho portátil.
+
+---
+
+## Como era
+**Marketplace de freelance.** Feed público de vagas, o freela busca e se candidata, match score. A aposta era **velocidade** — "Uber de garçom": achar gente rápido quando falta.
+
+## O que a pesquisa de campo mostrou (MOMMA + rua)
+- **A contratação real não é por busca — é relacional.** Lojista e freela já se conhecem e trabalham juntos toda semana. Na MOMMA: **~70%** recorrentes conhecidos, **20%** já contratados antes, **~0%** de fora. "Sempre alguém da bolha."
+- **Grupos de WhatsApp são lixo** ("vagas ruins, zeradas rápido ou falsas"). O que funciona é **boca a boca / indicação**.
+- **A dor não é velocidade — é confiança e formalização precária.** Freela falta depois de confirmar; sem recibo, sem histórico, sem controle. A MOMMA gasta **R$10–25 mil/mês** com freela, tudo informal, lançado à mão.
+- **Recibo/comprovante foi pedido pelos dois lados.**
+- **Marketplace de estranhos morre:** o concorrente Freela Serviços tem **159 mil cadastros e 49 transações** — encheram um marketplace vazio.
+
+## O que entendemos (o pivô)
+O gig instantâneo é a fatia pequena. O coração do mercado é **recorrência relacional esperando ser formalizada sem virar prisão.** Não precisamos criar demanda — **capturamos uma transação que já acontece** (pavimentar um caminho de terra onde já tem gente andando).
+
+→ Pivotamos de **marketplace de estranhos** para **infraestrutura de operação de freelancer, empresa-primeiro (modelo push).**
+
+## Como é agora
+
+| Antes (marketplace / pull) | Agora (empresa-primeiro / push) |
+|---|---|
+| Freela busca vagas num feed público | Freela **recebe convites**; não busca |
+| Candidatura a estranhos + match score | Empresa monta seu **Elenco** (freelas de confiança) e **convida direto** |
+| Descoberta aberta | Conexão **fechada** por link de perfil / QR / telefone |
+| Foco em achar gente | Foco em **confiança + pagamento + registro** |
+
+Fluxo: empresa monta o Elenco → convida um freela para o turno (notificação) → freela aceita → check-in/checkout → empresa confirma → **paga (direto ou pelo Worki) + recibo**. O freela acumula **Carteira de Clientes**, histórico e avaliação — reputação portátil.
+
+## Por que (a tese)
+- **Wedge (entrada):** valor pra empresa — centralizar contratar+pagar+registrar num lugar, custo zero. É o cavalo de Troia que faz a empresa entrar e voltar toda semana.
+- **Moat (defesa):** a reputação portátil do freela — não migra pro concorrente.
+- **Go-to-market:** entrar por **1–3 empresas** (MOMMA, onde somos embedded), **take 0** no início, régua de fricção = ser **mais fácil que WhatsApp+PIX**.
+- **Métrica de verdade:** % dos turnos recorrentes que passam pelo Worki vs. voltam pro WhatsApp — **não** downloads/cadastros (vaidade).
+- **Receita (caminho):** take 0 → processamento de cartão/parcela → SaaS de controle/BI → crédito/float (regulado). Marketplace de estranhos = **Fase 2**, só depois da densidade de reputação.
+- **O que NÃO somos:** empregador/CLT (somos conector/registro), banco, nem marketplace de estranhos ainda.
+
+## Onde estamos
+MVP construído e **validado em produção do cadastro ao BI**: Elenco, convite push com notificação, pagamento com recibo bilateral, inteligência financeira (gasto/teto/no-show). Pronto para rodar o piloto com a MOMMA.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Worki - Marketplace de Freelancers</title>
-    <meta name="description" content="Worki conecta empresas a trabalhadores freelancers. Encontre talentos ou oportunidades de trabalho na sua região." />
+    <title>Worki — Trabalho freela com confiança, contrato e comprovante</title>
+    <meta name="description" content="Empresa contrata direto quem já confia e registra cada turno. Freela constrói histórico, avaliação e comprovante de renda que são seus." />
     <meta name="theme-color" content="#00A651" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta property="og:title" content="Worki - Marketplace de Freelancers" />
-    <meta property="og:description" content="Conecte-se a freelancers ou encontre oportunidades de trabalho." />
+    <meta property="og:title" content="Worki — Trabalho freela com confiança, contrato e comprovante" />
+    <meta property="og:description" content="Empresa contrata direto quem já confia e registra cada turno. Freela constrói histórico, avaliação e comprovante de renda que são seus." />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="pt_BR" />
     <meta property="og:image" content="/og-image.svg" />

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -8,8 +8,8 @@ export default function LandingPage() {
   return (
     <div className="min-h-screen bg-[#F4F4F0]">
       <PageMeta
-        title="Sobre a Worki - Confiança e Pagamento para Freelancers"
-        description="Worki é a camada de confiança e pagamento pra empresa e freela que já trabalham juntos. Monte seu elenco, convide para turnos, pague e registre tudo em um só lugar."
+        title="Confiança e registro para o trabalho freela"
+        description="Empresa organiza e registra sua equipe de freelas de confiança. Freela constrói uma carreira que é sua — histórico, avaliação e comprovante de renda. Sem vínculo, sem bagunça."
       />
 
       {/* Navigation Bar */}
@@ -33,12 +33,11 @@ export default function LandingPage() {
       <section className="relative overflow-hidden px-4 py-20 md:py-32">
         <div className="max-w-6xl mx-auto text-center">
           <h1 className="text-5xl md:text-7xl font-black uppercase tracking-tighter mb-6">
-            A camada de confiança e pagamento pra quem já trabalha junto
+            O trabalho freela, com a segurança que faltava
           </h1>
           <p className="text-xl md:text-2xl text-gray-600 max-w-3xl mx-auto mb-12 font-medium">
-            Empresa: centralize seu elenco de freelas de confiança — contrate, pague e registre tudo
-            num lugar só, sem virar vínculo e sem bagunça de WhatsApp. Freela: construa sua carteira de
-            trabalho portátil — histórico, avaliação e recebimento que são seus, onde você for.
+            A empresa organiza e registra sua equipe de freelas. O freela constrói uma carreira que é
+            sua. Sem vínculo, sem calote, sem bagunça.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <button
@@ -68,32 +67,32 @@ export default function LandingPage() {
               {
                 icon: <Shield className="w-10 h-10 text-primary" />,
                 title: 'Sem Calote, Sem Sumiço',
-                description: 'Cada turno vira recibo e histórico registrado. Empresa tem comprovante do pagamento, freela tem prova do trabalho feito. Confiança dos dois lados.'
+                description: 'Comprovante e histórico de cada turno registrado — você tem prova do pagamento e do trabalho feito, dos dois lados.'
               },
               {
                 icon: <Zap className="w-10 h-10 text-blue-600" />,
-                title: 'PIX Quando Quiser',
-                description: 'Pague direto ao freela ou use o Worki pra registrar e distribuir. Sem espera de dias úteis, sem intermediário — do jeito que fizer sentido pra vocês.'
+                title: 'Do Seu Jeito de Pagar',
+                description: 'PIX direto ao freela ou pelo Worki pra registrar tudo — você escolhe como pagar.'
               },
               {
                 icon: <Users className="w-10 h-10 text-primary" />,
                 title: 'Seu Elenco de Confiança',
-                description: 'Monte a lista dos freelas que você já testou e confia. Chame só quem já provou que entrega — sem depender de estranho de plataforma.'
+                description: 'Só quem você já conhece e testou — sem depender de estranho de plataforma.'
               },
               {
                 icon: <UserPlus className="w-10 h-10 text-blue-600" />,
                 title: 'Convite em Segundos',
-                description: 'Convide freelas por link ou telefone. Depois de aceitar, ele fica no seu elenco pra sempre — sem renegociar tudo de novo a cada turno.'
+                description: 'Chame o freela direto pro seu elenco — sem grupo de WhatsApp, sem renegociar tudo de novo.'
               },
               {
                 icon: <CreditCard className="w-10 h-10 text-primary" />,
                 title: 'Sem Mensalidade',
-                description: 'Usar o Worki pra organizar sua operação é gratuito. Sem taxa escondida, sem letra miúda — o valor é centralizar contratação, pagamento e registro.'
+                description: 'Comece de graça — organizar sua operação de freelas não custa nada.'
               },
               {
                 icon: <Clock className="w-10 h-10 text-blue-600" />,
-                title: 'Check-in e Check-out',
-                description: 'Controle de horas simples no turno. Histórico completo de quem trabalhou, quando e quanto recebeu, num único lugar.'
+                title: 'Comprovante Que É Seu',
+                description: 'Renda, avaliação e histórico portáteis — registrados a cada turno, que ninguém tira de você.'
               },
             ].map((feature, i) => (
               <div
@@ -124,7 +123,7 @@ export default function LandingPage() {
             <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
               {[
                 { step: '1', title: 'Monte seu Elenco', desc: 'Convide os freelas que você já confia por link ou telefone. Depois de aceitar, eles ficam na sua lista pra sempre.' },
-                { step: '2', title: 'Crie o Turno e Convide', desc: 'Defina data, horário e valor, e envie o convite direto pro freela do seu elenco — sem esperar candidatura de estranho.' },
+                { step: '2', title: 'Convide pra um Turno', desc: 'Defina data, horário e valor, e envie o convite direto pro freela do seu elenco — sem esperar candidatura de estranho.' },
                 { step: '3', title: 'Pague e Registre', desc: 'Confirme o turno, pague como preferir (direto ou pelo Worki) e receba o recibo automático pra seu controle.' },
               ].map((item) => (
                 <div key={item.step} className="flex flex-col items-center text-center">
@@ -147,7 +146,7 @@ export default function LandingPage() {
               {[
                 { step: '1', title: 'Aceite o Convite', desc: 'Receba o convite de empresas que já confiam em você e aceite em um toque. Sem cadastro complicado.' },
                 { step: '2', title: 'Trabalhe', desc: 'Faça check-in e check-out no turno combinado. Simples, sem burocracia extra.' },
-                { step: '3', title: 'Construa sua Carteira', desc: 'Cada turno vira histórico, avaliação e recibo — sua carteira de trabalho portátil, que ninguém tira.' },
+                { step: '3', title: 'Construa sua Reputação', desc: 'Cada turno vira histórico, avaliação e recibo — sua carteira de trabalho portátil, que ninguém tira.' },
               ].map((item) => (
                 <div key={item.step} className="flex flex-col items-center text-center">
                   <div className="w-16 h-16 bg-primary text-white rounded-full border-2 border-black flex items-center justify-center text-2xl font-black mb-4 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
@@ -166,10 +165,10 @@ export default function LandingPage() {
       <section className="px-4 py-16 md:py-24 bg-black text-white">
         <div className="max-w-4xl mx-auto text-center">
           <h2 className="text-3xl md:text-5xl font-black uppercase tracking-tighter mb-6">
-            Comece agora. É grátis.
+            Comece agora — leva menos de 2 minutos
           </h2>
           <p className="text-xl text-gray-300 mb-12 font-medium">
-            Centralize sua operação de freelancer — contrate, pague e registre em um só lugar.
+            A empresa organiza e registra sua equipe. O freela constrói uma carreira que é sua.
             Cadastro gratuito, sem compromisso.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
@@ -191,7 +190,7 @@ export default function LandingPage() {
 
       {/* Footer */}
       <footer className="px-4 py-8 bg-gray-100 text-center text-sm text-gray-500 font-medium">
-        <p>&copy; {new Date().getFullYear()} Worki — Confiança e pagamento para freelancers e empresas. Todos os direitos reservados.</p>
+        <p>&copy; {new Date().getFullYear()} Worki — Confiança e registro para o trabalho freela. Todos os direitos reservados.</p>
         <div className="flex gap-4 justify-center mt-4">
           <button onClick={() => navigate('/termos')} className="hover:text-black transition-colors">Termos de Uso</button>
           <button onClick={() => navigate('/privacidade')} className="hover:text-black transition-colors">Política de Privacidade</button>

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -45,12 +45,12 @@ export default function Onboarding() {
         {/* Left: Value Prop */}
         <div className="flex-1 space-y-8 max-w-xl">
           <h1 className="text-6xl md:text-8xl font-black leading-[0.9] tracking-tighter">
-            CONFIANÇA <br />
-            <span className="text-primary text-stroke-black">DE VERDADE.</span>
+            O JEITO CERTO DE TRABALHAR <br />
+            <span className="text-primary text-stroke-black">COM QUEM VOCÊ JÁ CONFIA.</span>
           </h1>
           <p className="text-xl font-medium text-gray-600 max-w-md border-l-4 border-primary pl-4">
-            A camada de confiança e pagamento entre empresas e freelas que já trabalham juntos.
-            Contrate, pague e registre tudo num só lugar — sem virar vínculo, sem bagunça de WhatsApp.
+            Empresa e freela que já trabalham juntos — agora com contrato, comprovante e reputação.
+            Sem virar vínculo, sem bagunça de WhatsApp.
           </p>
 
           <div className="flex items-center gap-2 text-sm font-bold text-gray-500">
@@ -68,13 +68,13 @@ export default function Onboarding() {
             className="group relative bg-white border-2 border-black rounded-2xl p-8 text-left transition-all hover:-translate-y-1 hover:shadow-[8px_8px_0px_0px_rgba(0,166,81,1)]"
           >
             <div className="absolute top-4 right-4 bg-primary text-white text-xs font-bold px-2 py-1 rounded-sm uppercase">
-              Para Freelas
+              Para Freelancers
             </div>
             <div className="w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center mb-4 group-hover:bg-primary group-hover:text-white transition-colors border-2 border-black">
               <DollarSign size={24} strokeWidth={3} />
             </div>
             <h3 className="text-2xl font-black uppercase mb-1">Quero Trabalhar</h3>
-            <p className="text-gray-500 font-medium text-sm">Sua carteira de trabalho portátil: histórico, avaliação e recebimento — seus, em qualquer job.</p>
+            <p className="text-gray-500 font-medium text-sm">Seja dono do seu trabalho. Seu histórico, sua avaliação e seu comprovante de renda — que ninguém tira de você.</p>
             <ArrowRight className="absolute bottom-8 right-8 opacity-0 group-hover:opacity-100 transition-opacity" />
           </button>
 
@@ -90,7 +90,7 @@ export default function Onboarding() {
               <Briefcase size={24} strokeWidth={3} />
             </div>
             <h3 className="text-2xl font-black uppercase mb-1">Quero Contratar</h3>
-            <p className="text-gray-400 font-medium text-sm">Centralize sua equipe de freelas de confiança: contrate, pague e registre tudo num só lugar.</p>
+            <p className="text-gray-400 font-medium text-sm">Monte seu elenco de freelas de confiança. Contrate direto, registre cada turno e controle o gasto — tudo num lugar só.</p>
             <ArrowRight className="absolute bottom-8 right-8 opacity-0 group-hover:opacity-100 transition-opacity" />
           </button>
 
@@ -166,7 +166,7 @@ export default function Onboarding() {
                     <CalendarCheck size={18} strokeWidth={2.5} />
                   </div>
                   <div>
-                    <p className="font-bold text-white">Confirme seus turnos</p>
+                    <p className="font-bold text-white">Trabalhe</p>
                     <p className="text-sm text-gray-400 font-medium">Faça check-in e checkout direto pelo app quando o turno acontecer.</p>
                   </div>
                 </li>
@@ -175,7 +175,7 @@ export default function Onboarding() {
                     <DollarSign size={18} strokeWidth={2.5} />
                   </div>
                   <div>
-                    <p className="font-bold text-white">Construa seu histórico</p>
+                    <p className="font-bold text-white">Construa sua reputação</p>
                     <p className="text-sm text-gray-400 font-medium">Cada turno vira histórico, avaliação e recibo — sua carteira de trabalho.</p>
                   </div>
                 </li>


### PR DESCRIPTION
Copy de conversão nas telas de entrada, baseada em pesquisa de técnicas world-class. Ângulo empresa (contratar+registrar+controle) e freela (dono do seu trabalho com prova — empresário de si mesmo, não emprego). Corrige o <title> 'Marketplace de Freelancers'. + doc de pivô para sócios. Só copy, 233 testes verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)