### PR TITLE
feat: avaliações no perfil, XP coerente e pagamento agendado

### DIFF
--- a/.harness/memory-bank/architecture.md
+++ b/.harness/memory-bank/architecture.md
@@ -121,9 +121,10 @@ Cancelamento/no-show ──→ asaas-release-hold ──→ release_hold_postpag
 
 - **`payment_methods`** (nova tabela): `(id, company_id, asaas_credit_card_token, brand, last4, is_default, created_at)`.
   RLS por `company_id`. NUNCA carrega PAN/CVV (Article 10).
-- **`shift_payments`** (modo A — pagamento externo registrado): `(id, job_id, worker_id, company_id, application_id, amount, source, paid_at, status, recorded_by_company_at, confirmed_by_worker_at, note, created_at)`.
-  UNIQUE parcial `(job_id)` WHERE `status='recorded'` — garante 1 registro pago por turno.
-  RLS bilateral: empresa vê seu registro, worker vê seu recibo. **NUNCA toca saldo** (auditoria, não liquidação).
+- **`shift_payments`** (modo A — pagamento externo registrado): `(id, job_id, worker_id, company_id, application_id, amount, source, paid_at, status, scheduled_for, recorded_by, worker_confirmed_at, voided_at, void_reason, note, created_at)`.
+  Status: `scheduled | recorded | voided`. `scheduled_for` (data prevista) é material/imutável; `paid_at` é nullable (NULL em scheduled, setado na efetivação) e depois imutável.
+  UNIQUE parcial `(job_id) WHERE status IN ('scheduled','recorded')` — garante 1 marcador ativo por turno.
+  RLS bilateral: empresa (registra/efetiva/cancela), worker (confirma recebimento em recorded). **NUNCA toca saldo** (auditoria, não liquidação).
 - **`escrow_transactions`** (estendida):
   - `kind`: `'prepaid'` (default) | `'postpaid'`
   - `status`: `'reserved' | 'authorized' | 'captured' | 'released' | 'refunded'`
@@ -140,6 +141,60 @@ Cancelamento/no-show ──→ asaas-release-hold ──→ release_hold_postpag
 - **Taxa de plataforma:** 5% no saque (worker), TBD no escrow (empresa).
 - **Coexistência:** prepago e postpago rodam em paralelo por `kind`. Ramificação acontece em `walletService.releaseOrCaptureEscrow(jobId, workerId, kind)`
   que despacha para `asaas-checkout` (prepago) ou `asaas-capture-payment` (postpago).
+
+## Agregados do worker (Slice 4: engajamento)
+
+Campos derivados (`xp`, `level`, `completed_jobs_count`, `earnings_total`) são **recomputados canonicamente** por uma única função Postgres
+`recompute_worker_aggregates(worker_id)` (SECURITY DEFINER, search_path='', idempotente).
+
+**Fórmula (XP):** `xp = completed_jobs_count * 100 + profile_bonus`
+- `completed_jobs_count` = COUNT de `applications` com `status='completed'` (source de verdade)
+- `profile_bonus` = 50 (foto/avatar_url) + 75 (especialidades: primary_role OU roles array) = até +125
+- `level` derivado via função `worker_level_for_xp(xp)`
+- `earnings_total` = SUM dos budgets dos turnos concluídos (agregado de exibição, não saldo — Article 8 intacto)
+
+**Fontes de chamada:**
+1. **Trigger `trg_worker_completion_aggregates` (AFTER INSERT/UPDATE OF status ON applications WHEN status→'completed')** — empresa conclui turno, recomputa do worker.
+2. **Cliente via `recompute_my_aggregates()` (SECURITY DEFINER)** — após worker editar foto/especialidades no perfil (mudou bônus).
+
+**Segurança:**
+- `recompute_worker_aggregates(uuid)` é SECURITY DEFINER com search_path='', **sem GRANT a PUBLIC/anon/authenticated** — só service_role e trigger interno.
+- Cliente acessa via wrapper `recompute_my_aggregates()` (auth-scoped, trabalha sobre `auth.uid()` apenas) — GRANT EXECUTE TO authenticated.
+- Landmine corrigido: trigger legado `award_xp_on_job_completion` NÃO era SECURITY DEFINER → quando a empresa concluía o turno, o RLS bloqueava o UPDATE em workers (invoker não tinha permissão na linha do worker) = causa real de "XP não sobe"; **foi removido** e substituído pelo novo que é DEFINER.
+
+## Pagamento agendado (Slice 3: modo A pós-turno)
+
+`shift_payments` (modo A — pagamento externo registrado) ganhou suporte a **agendamento** com status `scheduled` + data prevista.
+
+**Máquina de estados (mesma linha):**
+```
+INSERT → scheduled (promessa) ──efetivar──► recorded (realizado) ──estornar──► voided
+             │                                                                   ▲
+             └─────────────────── cancelar ───────────────────────────────────┘
+INSERT → recorded (direto legado) ──estornar──► voided
+```
+
+**Colunas novas:**
+- `scheduled_for date` — data prevista do pagamento (imutável; reagendar = void + novo). NULL em registros diretos (`recorded` sem agendamento prévio).
+- `paid_at` — agora **NULLABLE** (era NOT NULL). NULL enquanto `scheduled`; setado **UMA vez** na efetivação (`scheduled→recorded`) e depois imutável. Timestamps reais (nunca data futura disfarçada).
+
+**Dedupe:** UNIQUE parcial `(job_id) WHERE status IN ('scheduled','recorded')` = **um marcador ativo por turno**, impedindo duas promessas ou promessa+pagamento em linhas separadas. N linhas `voided` permitidas (re-agendar/re-registrar).
+
+**Trigger `enforce_shift_payment_immutability` reescrito:**
+- Material columns (job_id, company_id, worker_id, application_id, source, amount, recorded_by, note, created_at, **scheduled_for**) → imutáveis sempre.
+- `paid_at` → imutável, EXCETO na única transição permitida: `scheduled→recorded` (NULL→data real, uma vez).
+- Transições válidas (só empresa): `scheduled→recorded` (efetivar), `scheduled→voided` (cancelar), `recorded→voided` (estornar). Qualquer outra é rejeitada.
+- Partição por papel: empresa efetiva/cancela/estorna; worker só confirma recebimento em `recorded`.
+
+**BI e comprovante:**
+- BI de gasto conta **SÓ** `recorded` (promessa ≠ liquidação — `scheduled` não infla gasto).
+- `ReceiptView` reutilizável: ramifica por status (scheduled → "Comprovante de Agendamento", recorded → recibo bilateral).
+- ZERO impacto em saldo/escrow/RPC — Article 8 intacto.
+
+## Briefing padrão (Slice 3: operação)
+
+`companies.default_briefing` (text, nullable) — a empresa cadastra UMA vez o briefing padrão do negócio (ex.: "calça jeans, barba feita, camisa branca").
+Ao criar um turno, pré-preenche o campo Briefing; empresa ajusta/incrementa por turno (ex.: "camisa verde" para estoquista). Simples editável, NÃO toca saldo (Article 8).
 
 ## Segurança
 

--- a/.harness/memory-bank/glossary.md
+++ b/.harness/memory-bank/glossary.md
@@ -152,5 +152,25 @@ no aceite de convite, hold no cartão; na conclusão, captura. Reservado para ex
 exibe detalhes do turno, valor, método (PIX/dinheiro/outro), confirmação bilateral, para auditoria/arquivo.
 
 **Shift payment / Marcador de pagamento** — Registro em `shift_payments` indicando que um turno foi pago fora do Worki
-(modo A). Tabela: `(id, job_id, worker_id, company_id, application_id, amount, source, paid_at, status, recorded_by_company_at,
-confirmed_by_worker_at, note)`. UNIQUE `(job_id)` WHERE `status='recorded'` garante 1 pagamento por turno. NUNCA move saldo.
+(modo A). Tabela: `(id, job_id, worker_id, company_id, application_id, amount, source, paid_at, status, scheduled_for, recorded_by,
+worker_confirmed_at, voided_at, void_reason, note, created_at)`. Status: `scheduled | recorded | voided`. UNIQUE `(job_id)` WHERE 
+`status IN ('scheduled','recorded')` garante 1 marcador ativo por turno. NUNCA move saldo.
+
+**Pagamento agendado (scheduled)** — Status novo de `shift_payments` (modo A). Empresa cria promessa: data prevista (`scheduled_for`), 
+`status='scheduled'`, `paid_at=null`. Comprovante de agendamento no ReceiptView. Transições: `scheduled→recorded` (efetivar, `paid_at` 
+setado UMA vez) ou `scheduled→voided` (cancelar). BI NÃO conta promessas (SÓ `recorded`). Zero impacto em saldo.
+
+**Efetivação de agendamento** — Transição `scheduled→recorded` de um `shift_payment`. Empresa seta `paid_at` (data real do pagamento). 
+Depois imutável. Torna-se `recorded` e entra no BI de gasto. Service: `paymentRecordService.effectivateScheduledPayment`.
+
+**Comprovante de agendamento** — Documento exibido no ReceiptView quando `shift_payment.status='scheduled'`. Mostra "Pagamento agendado 
+para {scheduled_for}", sem "Confirmar Recebimento" (nada recebido ainda). Respaldo ao freela; não é garantia de pagamento nem documento fiscal.
+
+**Agregados do worker** — Campos derivados e recomputados: `xp`, `level`, `completed_jobs_count`, `earnings_total`. Função canônica: 
+`recompute_worker_aggregates(worker_id)` (SECURITY DEFINER, service_role only). Fórmula: `xp = completed_jobs_count*100 + bônus_perfil 
+(+50 foto, +75 especialidades)`. Chamada pelo trigger de conclusão DE turno E por cliente via `recompute_my_aggregates()` após editar perfil. 
+Landmark: trigger legado `award_xp_on_job_completion` NÃO era DEFINER → RLS bloqueava UPDATE do freela quando empresa concluía turno (causa 
+real de "XP não sobe") = foi removido.
+
+**Briefing padrão** — Campo `companies.default_briefing` (text). Empresa cadastra UMA vez (ex.: "calça jeans, boa apresentação, barba feita"). 
+Ao criar turno, pré-preenche a descrição; empresa ajusta/incrementa por turno (ex.: "camisa verde"). Operacional, NÃO toca saldo.

--- a/.harness/memory-bank/patterns.md
+++ b/.harness/memory-bank/patterns.md
@@ -255,6 +255,130 @@ garante que o mesmo alerta NÃO é gravado em dobro. SELECT-before-INSERT cai em
 e o pior caso (dois alerts chegam simultâneos) expõe 2 notificações idênticas por 1 segundo — UX aceitável em alerta (não dinheiro).
 Policy `WITH CHECK (auth.uid() = user_id)` (nova 20260623000200) destrava INSERT do client (spendLimitService roda com role authenticated, owner inserindo para si).
 
+## Agregados do worker via função idempotente SECURITY DEFINER (Slice 4)
+
+```sql
+-- Função canônica — recomputa XP/level/earnings_total a partir de source of truth (applications com status='completed')
+-- SECURITY DEFINER porque invoker (trigger ou cliente via wrapper) não tem permissão direta em workers.
+CREATE OR REPLACE FUNCTION public.recompute_worker_aggregates(p_worker_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_count int; v_earnings numeric; v_bonus int; v_xp int;
+BEGIN
+  -- Source: aplicações concluídas
+  SELECT COUNT(*)::int, COALESCE(SUM(j.budget), 0)
+    INTO v_count, v_earnings
+  FROM public.applications a
+  JOIN public.jobs j ON j.id = a.job_id
+  WHERE a.worker_id = p_worker_id AND a.status = 'completed';
+
+  -- Bônus de perfil: foto +50, especialidades +75
+  SELECT
+    (CASE WHEN w.avatar_url IS NOT NULL AND w.avatar_url <> '' THEN 50 ELSE 0 END)
+    + (CASE WHEN (w.primary_role IS NOT NULL AND w.primary_role <> '')
+             OR (w.roles IS NOT NULL AND jsonb_typeof(w.roles) = 'array' AND jsonb_array_length(w.roles) > 0)
+          THEN 75 ELSE 0 END)
+    INTO v_bonus
+  FROM public.workers w WHERE w.id = p_worker_id;
+
+  v_xp := v_count * 100 + COALESCE(v_bonus, 0);
+
+  UPDATE public.workers SET
+    completed_jobs_count = v_count,
+    earnings_total = v_earnings,
+    xp = v_xp,
+    level = public.worker_level_for_xp(v_xp)
+  WHERE id = p_worker_id;
+END;
+$$;
+
+-- Wrapper auth-scoped para cliente recomputar PRÓPRIO XP após editar perfil (foto/especialidades).
+CREATE OR REPLACE FUNCTION public.recompute_my_aggregates()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    IF auth.uid() IS NULL THEN RETURN; END IF;
+    PERFORM public.recompute_worker_aggregates(auth.uid());
+END;
+$$;
+
+-- No trigger: chamada SECURITY DEFINER quando aplicação → 'completed'.
+-- Trigger `trg_worker_completion_aggregates` (AFTER INSERT/UPDATE OF status ON applications WHEN status→'completed')
+-- → PERFORM public.recompute_worker_aggregates(NEW.worker_id);
+```
+
+**Razão:** agregados (xp, level, completed_jobs_count, earnings_total) são derivados, não fonte. Uma função idempotente é a 
+**única fonte de verdade**. SECURITY DEFINER (com search_path='') protege contra RLS no invoker; service_role chama indiretamente via 
+trigger DEFINER; cliente chama via wrapper auth-scoped (`recompute_my_aggregates`). Landmark: trigger legado `award_xp_on_job_completion` 
+NÃO era DEFINER → RLS bloqueava UPDATE do freela quando empresa concluía turno (causa real de "XP não sobe") = **foi removido**.
+
+## Pagamento externo agendado (shift_payments com status 'scheduled') — Slice 3
+
+```sql
+-- Máquina de estados (mesma linha, in-place):
+-- scheduled (promessa) ──efetivar──► recorded (realizado) ──estornar──► voided
+--     │                                                                   ▲
+--     └────────────────── cancelar ────────────────────────────────────┘
+
+ALTER TABLE public.shift_payments
+    ADD COLUMN IF NOT EXISTS scheduled_for date;     -- promessa (imutável)
+ALTER TABLE public.shift_payments
+    ALTER COLUMN paid_at DROP NOT NULL;              -- nullable (NULL em scheduled)
+
+-- Trigger de imutabilidade reescrito: libera ÚNICA transição (scheduled→recorded) de paid_at
+CREATE OR REPLACE FUNCTION public.enforce_shift_payment_immutability()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    -- scheduled_for: material, imutável sempre (reagendar = void + novo)
+    IF NEW.scheduled_for IS DISTINCT FROM OLD.scheduled_for THEN
+        RAISE EXCEPTION 'shift_payments: scheduled_for e imutavel.';
+    END IF;
+
+    -- paid_at: imutável, EXCETO transição scheduled→recorded
+    IF NEW.paid_at IS DISTINCT FROM OLD.paid_at THEN
+        IF NOT (OLD.status = 'scheduled' AND NEW.status = 'recorded'
+                AND OLD.paid_at IS NULL AND NEW.paid_at IS NOT NULL) THEN
+            RAISE EXCEPTION 'shift_payments: paid_at so pode ser definido na efetivacao.';
+        END IF;
+    END IF;
+
+    -- Transições válidas (só empresa): scheduled→recorded (efetivar), scheduled→voided (cancelar), recorded→voided (estornar)
+    IF NEW.status IS DISTINCT FROM OLD.status THEN
+        IF NOT (
+            (OLD.status = 'scheduled' AND NEW.status IN ('recorded', 'voided'))
+            OR (OLD.status = 'recorded' AND NEW.status = 'voided')
+        ) THEN
+            RAISE EXCEPTION 'shift_payments: transicao invalida (% -> %).', OLD.status, NEW.status;
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+-- UNIQUE parcial: 1 marcador ativo por turno (scheduled OU recorded)
+CREATE UNIQUE INDEX IF NOT EXISTS uq_shift_payments_job_active
+    ON public.shift_payments (job_id)
+    WHERE status IN ('scheduled', 'recorded');
+```
+
+**Razão:** modo A (pagamento externo registrado) precisa de promessa com data (uso real: empresa paga freela em data futura, não na hora). 
+`scheduled` é **auditoria** (não move saldo, Article 8 intacto). `paid_at` deve ser **fato verdadeiro** (data real), nunca data futura disfarçada; 
+logo nullable até efetivação. Trigger libera SÓ a transição `scheduled→recorded` do `paid_at` (NULL→data real, uma vez) — garante imutabilidade pós-efetivação. 
+UNIQUE ativo barra 2 promessas OU promessa+pagamento em linhas distintas do mesmo turno; N linhas `voided` OK (reagendar). BI conta SÓ `recorded` 
+(promessa ≠ liquidação).
+
 ---
 
 ## Padrões a serem extraídos

--- a/.harness/memory-bank/tech.md
+++ b/.harness/memory-bank/tech.md
@@ -21,7 +21,7 @@
   TanStack React Query 5.90.20 está no `package.json` e um `QueryClient` é montado em `App.tsx`, mas
   **as páginas NÃO usam `useQuery` na prática.** Seguir o padrão existente (useState/useEffect) ao
   implementar features novas, salvo decisão explícita de migrar.
-- **Services de negócio:** `walletService` (escrow), `paymentMethodService` (cartão on-file), **`paymentRecordService`** (modo A — registro de pagamento externo, sem mover saldo), `teamConnectionService` (equipe), `shiftInviteService` (convites push), `financialBIService` (BI unificado), `spendLimitService` (teto + alerta).
+- **Services de negócio:** `walletService` (escrow), `paymentMethodService` (cartão on-file), **`paymentRecordService`** (modo A — registro de pagamento externo + agendamento, sem mover saldo), `teamConnectionService` (equipe), `shiftInviteService` (convites push), `financialBIService` (BI unificado), `spendLimitService` (teto + alerta).
 - **Toda query autenticada começa com** `supabase.auth.getUser()` → redireciona para `/login` se `null`.
 - **Backend:** Supabase (PostgREST + Realtime + Auth + Storage + Edge Functions Deno)
 - **Supabase JS:** 2.91.0 — client em `frontend/src/lib/supabase.ts` (`VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`)
@@ -41,6 +41,8 @@
 - **QR code:** `qrcode.react` 4.2.0 (geração em `<QRCodeSVG>` para links de convite); **`html5-qrcode` 2.3.8** (leitura de QR/Worki ID via câmera, aba QR em team connections)
 - **Util:** `clsx` + `tailwind-merge` + `class-variance-authority`; datas via `date-fns`
 - **Fonte:** Inter (sans-serif), pesos pesados (`font-black`, `uppercase`)
+- **Componentes novos (Slice 4):**
+  - **`ProfileReviews`** — lista avaliações recebidas (estrelas + comentário). Props: `reviewedId`, `reviewerRole` ('company' | 'worker'). Filtra por `direction` inverso (worker que avalia company = direction='company'). Neo-brutalista com border 2px + sombra offset.
 
 ## Pagamentos — Asaas (único gateway)
 
@@ -88,10 +90,18 @@
 - **Config tables (Slice 3, sem RPC de saldo — Article 8):**
   - **`company_spend_limits`** (20260623000000) — teto mensal por empresa. Campos: `company_id, period='month', amount, alert_thresholds[]` (default [80,90,100]), `scope` ('' = empresa inteira, v1 single-store), `financial_contact_email/phone`. RLS por owner. Sem saldo.
   - **`company_monthly_revenue`** (20260623000100) — faturamento mensal declarado (input para BI-3). Campos: `company_id, year_month` (DATE dia 1), `amount`. Upsert (company_id, year_month). RLS por owner.
+  - **`companies.default_briefing`** (20260710000100) — texto de briefing padrão do negócio (pré-preenche turno). Simples, NÃO toca saldo.
+- **Mudanças em shift_payments (Slice 3, modo A + agendamento):**
+  - **20260712000000** — novo status `scheduled`, coluna `scheduled_for date` (promessa imutável), `paid_at` agora nullable (NULL em scheduled, setado na efetivação). UNIQUE parcial `(job_id) WHERE status IN ('scheduled','recorded')`. Trigger reescrito para liberar SÓ transição `scheduled→recorded` de `paid_at`. Máquina de estados: `scheduled→recorded|voided`, `recorded→voided`. ZERO impacto em saldo/escrow.
 - **Policy adicional (20260623000200):**
   - **`notifications` INSERT** — `WITH CHECK (auth.uid() = user_id)` destrava alerta in-app inserido pelo cliente (`spendLimitService.evaluateSpendAlert`).
 - Tabelas principais: `workers`, `companies`, `jobs`, `applications`, `wallets`, `wallet_transactions`,
-  `escrow_transactions`, `notifications`, `analytics_events`, `payment_methods`, **`company_spend_limits`** (nova), **`company_monthly_revenue`** (nova).
+  `escrow_transactions`, `notifications`, `analytics_events`, `payment_methods`, **`company_spend_limits`** (nova), **`company_monthly_revenue`** (nova), **`shift_payments`** (estendida com scheduled + scheduled_for).
+- **RPCs de agregados do worker (Slice 4):**
+  - **`recompute_worker_aggregates(uuid)`** — recomputa `xp`, `level`, `completed_jobs_count`, `earnings_total`. SECURITY DEFINER, service_role only, idempotente. Fórmula: `xp = completed_jobs_count*100 + bônus_perfil` (foto +50, especialidades +75).
+  - **`recompute_my_aggregates()`** — wrapper auth-scoped para cliente recomputar próprios agregados após editar perfil. GRANT EXECUTE TO authenticated.
+  - **Trigger `trg_worker_completion_aggregates`** (AFTER INSERT/UPDATE status ON applications WHEN →'completed') — chama `recompute_worker_aggregates(worker_id)` (SECURITY DEFINER).
+  - **Landmark:** trigger legado `award_xp_on_job_completion` NÃO era DEFINER → RLS bloqueava UPDATE do freela quando empresa concluía turno (causa real de "XP não sobe") = **foi removido**.
 - **Chat:** o frontend lê/escreve a tabela **`Conversation`** (capital C — ex.: `supabase.from('Conversation')`
   em `hooks/useJobApplication.ts`, `pages/company/CompanyJobCandidates.tsx`). Existe também uma tabela
   `messages` no DB, mas **o chat do frontend usa `Conversation`** — não confundir.

--- a/.harness/spec/pagamento-agendado/adr-pagamento-agendado.md
+++ b/.harness/spec/pagamento-agendado/adr-pagamento-agendado.md
@@ -1,0 +1,150 @@
+# ADR-20260712 — Pagamento agendado por turno (status 'scheduled' + data prevista)
+
+## Status
+ACEITO (proposto pelo owner, decisão de modelo pelo architect)
+
+## Contexto
+
+No mercado real (ex.: MoMA / eventos), o freela **não recebe na hora** — o pagamento é
+**agendado** para uma data futura. A empresa precisa emitir um **"comprovante de agendamento"**
+que dê respaldo ao freela de que será pago numa data prevista. Decisão do owner (aprovada):
+modelar com **status `scheduled` + data prevista**.
+
+Isto vive no **modo A** (pagamento externo registrado — ADR-20260630): é **auditoria/comprovante**,
+**não move saldo** (Article 8 intacto), sem RPC, sem tocar `wallets`/`escrow_transactions`. Escrow
+(modo B/C) permanece o caminho opt-in de liquidação real.
+
+### Restrição crítica herdada de `shift_payments` (20260630000000)
+
+- `paid_at` é `NOT NULL` **e imutável** (trigger `enforce_shift_payment_immutability`).
+- Um pagamento `scheduled` **ainda não foi pago** → não tem `paid_at` real.
+- Na efetivação é preciso gravar a **data real** do pagamento — mas `paid_at` é imutável.
+- `status` **não** está na lista de colunas imutáveis do trigger → transições de status já são possíveis.
+- O CHECK `shift_payments_void_consistency` e o CHECK inline de `status` **rejeitam** qualquer valor
+  fora de `('recorded','voided')` → precisam ser reescritos para admitir `scheduled`.
+
+## Decisão
+
+Adotar a **opção (a)**: nova coluna `scheduled_for date` (a promessa) + tornar `paid_at` **NULLABLE**,
+setando-o **apenas na efetivação** (`scheduled → recorded`), com o trigger de imutabilidade liberando
+**exclusivamente** essa transição (NULL → data real, uma vez; depois congela).
+
+### Máquina de estados (mesma linha, transição in-place)
+
+```
+INSERT ─► scheduled ──efetivar (empresa, seta paid_at)──► recorded ──estornar──► voided
+              │                                                                    ▲
+              └──────────────── cancelar (empresa) ────────────────────────────────┘
+INSERT ─► recorded  (registro direto legado, inalterado) ──estornar──► voided
+```
+
+- `scheduled`: `scheduled_for` NOT NULL, `paid_at` NULL, sem confirmação, sem void. **Não conta como gasto no BI.**
+- `recorded`: `paid_at` NOT NULL (data real da efetivação, ou registro direto). Entra no BI.
+- `voided`: terminal/imutável.
+- Transições válidas (só empresa): `scheduled→recorded`, `scheduled→voided`, `recorded→voided`.
+  `recorded→scheduled` e qualquer saída de `voided` são **proibidas** (trigger).
+
+### Dedupe
+
+O UNIQUE parcial passa de `(job_id) WHERE status='recorded'` para
+`(job_id) WHERE status IN ('scheduled','recorded')` — **um marcador ativo por turno**, impedindo
+duas promessas ou promessa+pagamento em linhas separadas. N linhas `voided` seguem permitidas
+(re-agendar / re-registrar após cancelamento). O BI (`status='recorded'`) segue correto:
+promessa ≠ liquidação.
+
+### Comprovante = mesma superfície do recibo (ReceiptView)
+
+O `ReceiptView` (`/recibo/:jobId`) renderiza os dois estados:
+- `scheduled` → título "Comprovante de Agendamento", mostra **"Pagamento agendado para {scheduled_for}"**,
+  **não** oferece "Confirmar Recebimento" (nada foi recebido), disclaimer de respaldo (não é garantia
+  nem documento fiscal).
+- `recorded` → recibo atual (data real em `paid_at`, confirmação bilateral do freela).
+
+## Consequências
+
+### Positivas
+- `paid_at` carrega sempre um **fato verdadeiro** (data real) — nunca uma data futura disfarçada.
+- Auditoria coerente: a promessa (`scheduled_for`) e a liquidação (`paid_at`) são campos distintos.
+- BI de gasto inalterado (filtra `recorded`); promessa não infla gasto.
+- Reaproveita 100% da superfície de recibo, RLS bilateral e imutabilidade existentes.
+- Zero impacto em saldo/escrow/RPC — Article 8/9/10 intactos.
+
+### Negativas / Trade-offs
+- `paid_at` deixa de ser `NOT NULL` (widening) — o invariante "sempre há data de pagamento" agora
+  depende do CHECK por estado, não da coluna. Mitigado por `shift_payments_state_consistency`.
+- O trigger ganhou um caso especial (a única mutação material permitida). Complexidade adicional
+  concentrada e testável.
+- Troca do UNIQUE parcial usa `CREATE UNIQUE INDEX` simples (não `CONCURRENTLY`) — lock breve.
+  Aceitável por ser tabela de **baixo volume (piloto)**; se crescer, migrar para índice concorrente
+  fora de transação. **Minor**, documentado.
+- "Reagendar" não é transição: exige `void` + novo `scheduled` (mantém a filosofia append-only de
+  auditoria). Pode surpreender quem espera editar a data — decisão consciente.
+
+## Alternativas rejeitadas
+
+- **(b) `paid_at` NOT NULL, `paid_at = scheduled_for` provisório**: gravaria um **fato falso** (data
+  futura como "data paga") e, sendo imutável, **travaria a data real** na efetivação. Corrompe o
+  significado de auditoria. Rejeitada.
+- **(c) Tabela separada `payment_schedules`**: duplicaria RLS, imutabilidade e dedupe; quebraria a
+  unicidade "1 marcador ativo por turno" entre duas tabelas; e o ReceiptView teria de unir duas
+  fontes. Mais superfície, sem ganho. Rejeitada.
+- **Reagendamento in-place (mutar `scheduled_for`)**: violaria a imutabilidade material da declaração;
+  contradiz o padrão "correção = estorno lógico + novo registro". Rejeitada.
+
+## Gatilhos de reabertura
+- Se o piloto exigir **reagendamento frequente** com histórico da própria promessa → considerar
+  `scheduled_for` mutável com trilha de auditoria (nova tabela de eventos) — reabrir este ADR.
+- Se `scheduled` precisar **entrar no BI** como "compromisso a pagar" (fluxo de caixa projetado) →
+  o BI passa a unir `recorded` + `scheduled` com rótulos distintos — reabrir.
+- Se a tabela crescer a ponto do lock do índice importar → migrar UNIQUE para `CONCURRENTLY`.
+- Se algum dia o agendado precisar **mover saldo** (escrow com data futura) → sai do modo A, vira
+  fluxo B/C e exige gate de escrow (ADR próprio).
+
+## Contrato para frontend / service
+
+### `types/index.ts`
+```ts
+export type ShiftPaymentStatus = 'scheduled' | 'recorded' | 'voided';
+
+export interface ShiftPayment {
+  // ...campos atuais...
+  scheduled_for: string | null; // NOVO — data prevista (YYYY-MM-DD) quando scheduled
+  paid_at: string | null;       // ALTERADO — agora nullable (NULL enquanto scheduled)
+}
+```
+
+### `paymentRecordService`
+- **`scheduleExternalPayment(params)`** — NOVO. `params: { jobId, workerId, applicationId,
+  source, amount, scheduledFor: string /*YYYY-MM-DD*/, note? }`. INSERT com
+  `status='scheduled'`, `scheduled_for=scheduledFor`, `paid_at=null`. Reutiliza a **mesma
+  validação defensiva de "turno concluído"** de `recordExternalPayment` (checkin+checkout
+  confirmados). 23505 → `{ alreadyActive: true }` (já há marcador ativo — scheduled ou recorded).
+- **`effectivateScheduledPayment(paymentId, paidAt?)`** — NOVO. UPDATE
+  `{ status: 'recorded', paid_at: paidAt ?? now }`. Só a empresa dona (RLS + trigger). Transição
+  `scheduled→recorded`.
+- **`voidPayment(paymentId, reason)`** — INALTERADO no código; passa a cobrir também
+  `scheduled→voided` (RLS `sp_update_company` já inclui `scheduled` no USING).
+- **`getPaymentByJob` / `getReceipt`** — ALTERAR o filtro de `.eq('status','recorded')` para
+  `.in('status',['scheduled','recorded'])` + `.maybeSingle()` (o UNIQUE ativo garante ≤1),
+  para que o comprovante de agendamento apareça.
+
+### `ReceiptView`
+- Ramificar por `payment.status`:
+  - `scheduled`: título "Comprovante de Agendamento"; bloco "Pagamento agendado para
+    {formatDateOnly(scheduled_for)}"; ocultar "Data do pagamento"; **sem** botão "Confirmar
+    Recebimento"; disclaimer "respaldo de que o pagamento será feito na data prevista — não é
+    garantia de pagamento nem documento fiscal".
+  - `recorded`: comportamento atual (usa `paid_at`, confirmação bilateral).
+- Ação "Efetivar pagamento" (company) pode viver em `CompanyJobCandidates` ou no próprio ReceiptView
+  para o viewer empresa.
+
+### Ponto em aberto (para clarifier/humano)
+- `scheduleExternalPayment` **exige turno concluído** (herdado de `recordExternalPayment`) —
+  default adotado por consistência de auditoria. Se o produto quiser agendar **no ato da
+  contratação** (antes do turno), relaxar a guarda (mantendo `application` válida como lastro).
+
+## Referências
+- Migration: `supabase/migrations/20260712000000_shift_payment_scheduled.sql`
+- Base: `supabase/migrations/20260630000000_shift_payments.sql`
+- ADR-mãe (modo A): `.harness/memory-bank/decisions/ADR-20260630-pagamento-opcional-piloto.md`
+- Service: `frontend/src/services/paymentRecordService.ts` · Tela: `frontend/src/pages/ReceiptView.tsx`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/).
 
 ### Adicionado
 
+#### Agregados e Histórico Detalhado do Freela (2026-07-12)
+
+**Freela:**
+- **XP e nível corretos:** ao concluir turnos, XP sobe (100 por turno) + bônus de perfil (foto +50, especialidades +75), nível progride automaticamente
+- **Ganhos totais visíveis:** o total de ganhos e número de turnos concluídos agora aparecem corretos na tela inicial
+- **Histórico detalhado:** ao clicar em um turno concluído, vê chegada/saída (timestamps), valor, status de pagamento e avaliação recebida
+- **Avaliações no perfil:** tanto freela quanto empresa veem a lista de avaliações recebidas (estrelas + comentário) em seus perfis públicos
+- **Avaliação obrigatória após pagamento:** ao receber um turno pago, o freela é solicitado uma vez (por visita) a avaliar a empresa antes de deixar a tela de histórico
+
+#### Pagamento Agendado e Comprovante (2026-07-12)
+
+**Empresa e Freelancer:**
+- **Agendamento de pagamento:** a empresa pode agendar pagamento com data prevista, gerando um "Comprovante de Agendamento" que dá respaldo ao freela
+- **Transição para pago:** após o agendamento, a empresa marca como efetivamente pago (status → 'recorded'), gerando o recibo normal
+
+#### Briefing Padrão (2026-07-12)
+
+**Empresa:**
+- **Briefing padrão do negócio:** configurar uma vez no perfil da empresa (regras da casa, dress code, apresentação)
+- **Pré-preenchimento ao criar turno:** ao criar novo turno, o briefing padrão vem preenchido e pode ser ajustado por turno
+
 #### Modo A — Pagamento Externo (Piloto 2026-07-01)
 
 **Empresa e Freelancer:**

--- a/frontend/src/components/ProfileReviews.tsx
+++ b/frontend/src/components/ProfileReviews.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from 'react';
+import { Star, MessageSquareQuote } from 'lucide-react';
+import { supabase } from '../lib/supabase';
+import { formatDistanceToNow } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { logError } from '../lib/logger';
+
+interface ReviewRow {
+    id: string;
+    rating: number;
+    comment: string | null;
+    created_at: string;
+    reviewer_id: string;
+    reviewer_name: string;
+}
+
+/**
+ * Lista as avaliações RECEBIDAS por um perfil (com estrelas + comentário).
+ * `reviewerRole` = quem ESCREVEU a avaliação (define de qual tabela buscar o nome
+ * e qual `direction` filtrar):
+ *   - reviewerRole='company' → avaliações de EMPRESAS sobre um FREELA (direction='worker')
+ *   - reviewerRole='worker'  → avaliações de FREELAS sobre uma EMPRESA (direction='company')
+ */
+export default function ProfileReviews({
+    reviewedId,
+    reviewerRole,
+}: {
+    reviewedId: string;
+    reviewerRole: 'company' | 'worker';
+}) {
+    const [reviews, setReviews] = useState<ReviewRow[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        let active = true;
+        const direction = reviewerRole === 'company' ? 'worker' : 'company';
+        const table = reviewerRole === 'company' ? 'companies' : 'workers';
+        const nameField = reviewerRole === 'company' ? 'name' : 'full_name';
+
+        void (async () => {
+            if (!reviewedId) { setLoading(false); return; }
+            setLoading(true);
+            try {
+                const { data, error } = await supabase
+                    .from('reviews')
+                    .select('id, rating, comment, created_at, reviewer_id')
+                    .eq('reviewed_id', reviewedId)
+                    .eq('direction', direction)
+                    .order('created_at', { ascending: false });
+                if (error) throw error;
+
+                const rows = (data ?? []) as Omit<ReviewRow, 'reviewer_name'>[];
+                const reviewerIds = [...new Set(rows.map(r => r.reviewer_id).filter(Boolean))];
+                const nameMap = new Map<string, string>();
+                if (reviewerIds.length > 0) {
+                    const { data: names } = await supabase
+                        .from(table)
+                        .select(`id, ${nameField}`)
+                        .in('id', reviewerIds);
+                    (names ?? []).forEach((n: Record<string, unknown>) => {
+                        nameMap.set(n.id as string, (n[nameField] as string) || '');
+                    });
+                }
+
+                if (!active) return;
+                setReviews(rows.map(r => ({
+                    ...r,
+                    reviewer_name: nameMap.get(r.reviewer_id) || (reviewerRole === 'company' ? 'Empresa' : 'Freela'),
+                })));
+            } catch (error) {
+                logError('ProfileReviews', error);
+            } finally {
+                if (active) setLoading(false);
+            }
+        })();
+        return () => { active = false; };
+    }, [reviewedId, reviewerRole]);
+
+    return (
+        <div className="mt-8 bg-white border-2 border-black rounded-2xl p-6 sm:p-8 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
+            <h3 className="text-xl font-black uppercase mb-4 flex items-center gap-2">
+                <MessageSquareQuote size={20} /> Avaliações sobre {reviewerRole === 'company' ? 'você' : 'sua empresa'}
+            </h3>
+
+            {loading ? (
+                <div className="space-y-3 animate-pulse">
+                    {[...Array(2)].map((_, i) => <div key={i} className="h-20 bg-gray-200 rounded-xl" />)}
+                </div>
+            ) : reviews.length === 0 ? (
+                <p className="text-sm font-bold text-gray-400 bg-gray-50 border-2 border-dashed border-gray-200 rounded-xl p-4 text-center">
+                    Ainda sem avaliações. Elas aparecem aqui após turnos concluídos.
+                </p>
+            ) : (
+                <div className="space-y-3">
+                    {reviews.map((r) => (
+                        <div key={r.id} className="border-2 border-gray-100 rounded-xl p-4">
+                            <div className="flex items-center justify-between gap-3 mb-1">
+                                <span className="font-black uppercase text-sm truncate">{r.reviewer_name}</span>
+                                <div className="flex items-center gap-0.5 flex-shrink-0">
+                                    {[1, 2, 3, 4, 5].map((s) => (
+                                        <Star
+                                            key={s}
+                                            size={14}
+                                            className={s <= r.rating ? 'text-yellow-500 fill-yellow-500' : 'text-gray-300'}
+                                        />
+                                    ))}
+                                </div>
+                            </div>
+                            {r.comment ? (
+                                <p className="text-sm text-gray-600 font-medium italic">"{r.comment}"</p>
+                            ) : (
+                                <p className="text-xs text-gray-400 font-bold">Sem comentário.</p>
+                            )}
+                            <p className="text-[10px] text-gray-400 font-bold uppercase mt-2">
+                                {formatDistanceToNow(new Date(r.created_at), { addSuffix: true, locale: ptBR })}
+                            </p>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -93,9 +93,12 @@ export default function Dashboard() {
     const { myStores, loading: storesLoading } = useWorkerStores();
 
     // Quests Logic (derived from worker data)
+    // R: XP só é concedido por foto de perfil (+50) e especialidades (+75) — ver RPC
+    // recompute_my_aggregates(). Confirmar email não gera XP, então essa quest não
+    // promete XP (xp: 0 e o selo "+XP" só renderiza quando quest.xp > 0).
     const quests = worker ? [
         { id: 1, title: 'Adicionar Foto de Perfil', xp: 50, done: !!worker.avatar_url, action: '/profile' },
-        { id: 2, title: 'Confirmar Email', xp: 100, done: !!authUser?.email_confirmed_at, action: '/profile' },
+        { id: 2, title: 'Confirmar Email', xp: 0, done: !!authUser?.email_confirmed_at, action: '/profile' },
         { id: 3, title: 'Adicionar Especialidades', xp: 75, done: (worker.roles && worker.roles.length > 0) || !!worker.primary_role, action: '/profile' },
     ] : [];
 
@@ -252,9 +255,15 @@ export default function Dashboard() {
                             {quests.filter(q => !q.done).slice(0, 2).map(quest => (
                                 <button key={quest.id} onClick={() => navigate('/profile')} className="flex items-center justify-between w-full md:w-80 bg-white p-3 rounded-xl border-2 border-gray-200 hover:border-black hover:shadow-md transition-all group text-left">
                                     <span className="text-sm font-bold text-gray-700">{quest.title}</span>
-                                    <span className="text-xs font-black bg-primary text-white px-2 py-1 rounded-md group-hover:scale-110 transition-transform">
-                                        +{quest.xp} XP
-                                    </span>
+                                    {quest.xp > 0 ? (
+                                        <span className="text-xs font-black bg-primary text-white px-2 py-1 rounded-md group-hover:scale-110 transition-transform">
+                                            +{quest.xp} XP
+                                        </span>
+                                    ) : (
+                                        <span className="text-xs font-black bg-gray-200 text-gray-600 px-2 py-1 rounded-md group-hover:scale-110 transition-transform">
+                                            Verificação
+                                        </span>
+                                    )}
                                 </button>
                             ))}
                         </div>

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { supabase } from '../lib/supabase';
 import { User, MapPin, Briefcase, Star, ShieldCheck, Phone, Edit2, Loader2, Award, Save, X, Camera, CreditCard, Lock, QrCode, Copy, Check, LogOut, Link2 } from 'lucide-react';
+import ProfileReviews from '../components/ProfileReviews';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { useToast } from '../contexts/ToastContext';
@@ -190,6 +191,36 @@ export default function Profile() {
         fetchProfile();
     }, [navigate]);
 
+    // Best-effort: recomputa XP/nível/ganhos/turnos via RPC (recompute_my_aggregates,
+    // SECURITY DEFINER, usa auth.uid()) e mescla o resultado no state do perfil, para a
+    // UI refletir o novo XP/nível na hora (sem esperar um reload). Erro aqui não deve
+    // quebrar o fluxo de salvar perfil / upload de foto.
+    const refreshAggregates = async (profileId: string) => {
+        try {
+            const { error: rpcError } = await supabase.rpc('recompute_my_aggregates');
+            if (rpcError) throw rpcError;
+
+            const { data, error: fetchError } = await supabase
+                .from('workers')
+                .select('xp, level, earnings_total, completed_jobs_count')
+                .eq('id', profileId)
+                .maybeSingle();
+            if (fetchError) throw fetchError;
+
+            if (data) {
+                setProfile(prev => prev ? { ...prev, ...data } : prev);
+                setStats(prev => ({
+                    ...prev,
+                    completedJobs: data.completed_jobs_count ?? prev.completedJobs,
+                    totalEarnings: data.earnings_total ?? prev.totalEarnings,
+                    hoursWorked: Math.floor((data.completed_jobs_count ?? prev.completedJobs) * 6)
+                }));
+            }
+        } catch (error) {
+            logError('Profile.refreshAggregates', error);
+        }
+    };
+
     const handleUpload = async (event: React.ChangeEvent<HTMLInputElement>, type: 'avatar' | 'cover') => {
         if (!profile) return;
         try {
@@ -234,6 +265,10 @@ export default function Profile() {
 
             setProfile({ ...profile, ...updates } as WorkerProfile);
             addToast(`${type === 'avatar' ? 'Foto de perfil' : 'Capa'} atualizada!`, 'success');
+
+            if (type === 'avatar') {
+                await refreshAggregates(profile.id);
+            }
         } catch (error) {
             addToast('Erro ao fazer upload!', 'error');
             logError('Erro inesperado', error);
@@ -270,6 +305,8 @@ export default function Profile() {
             initialFormDataRef.current = { ...formData };
             setIsEditing(false);
             addToast('Perfil atualizado com sucesso!', 'success');
+
+            await refreshAggregates(profile.id);
         } catch (error) {
             addToast('Erro ao atualizar perfil!', 'error');
             logError('Erro inesperado', error);
@@ -634,17 +671,8 @@ export default function Profile() {
                         </div>
                     </div>
 
-                    {/* Reviews Section - Placeholder for now until we have reviews table populated */}
-                    <div className="bg-white p-8 rounded-2xl border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,0.08)]">
-                        <h3 className="text-xl font-black uppercase mb-6 flex items-center gap-2">
-                            <Star size={20} /> Avaliações Recentes
-                        </h3>
-
-                        <div className="text-center py-8 text-gray-400 font-medium">
-                            <p>Nenhuma avaliação recebida ainda.</p>
-                            <p className="text-sm mt-2">Complete turnos para receber avaliações de empresas.</p>
-                        </div>
-                    </div>
+                    {/* Avaliações recebidas de empresas */}
+                    {workerId && <ProfileReviews reviewedId={workerId} reviewerRole="company" />}
 
                 </div>
 
@@ -657,8 +685,9 @@ export default function Profile() {
                 </h3>
 
                 <div className="mb-4">
-                    <label className="block text-sm font-bold uppercase mb-1">Nova Senha</label>
+                    <label htmlFor="new-password" className="block text-sm font-bold uppercase mb-1">Nova Senha</label>
                     <input
+                        id="new-password"
                         type="password"
                         value={newPassword}
                         onChange={e => { setNewPassword(e.target.value); setPasswordError(null); }}
@@ -678,8 +707,9 @@ export default function Profile() {
                 </div>
 
                 <div className="mb-2">
-                    <label className="block text-sm font-bold uppercase mb-1">Confirmar Nova Senha</label>
+                    <label htmlFor="confirm-password" className="block text-sm font-bold uppercase mb-1">Confirmar Nova Senha</label>
                     <input
+                        id="confirm-password"
                         type="password"
                         value={confirmPassword}
                         onChange={e => { setConfirmPassword(e.target.value); setPasswordError(null); }}
@@ -827,6 +857,7 @@ export default function Profile() {
                         onChange={(e) => setDeleteConfirmText(e.target.value)}
                         className="w-full border-2 border-gray-300 rounded-xl px-4 py-2 mb-6 font-bold focus:border-red-500 outline-none"
                         placeholder="EXCLUIR"
+                        aria-label="Confirmar exclusão"
                     />
                     <div className="flex gap-3">
                         <button

--- a/frontend/src/pages/ReceiptView.tsx
+++ b/frontend/src/pages/ReceiptView.tsx
@@ -121,10 +121,11 @@ export default function ReceiptView() {
     const isWorkerViewer = currentUserId === payment.worker_id;
     const isCompanyViewer = currentUserId === payment.company_id;
     const shortId = payment.id.slice(0, 8).toUpperCase();
+    const isScheduled = payment.status === 'scheduled';
 
     return (
         <div className="max-w-2xl mx-auto p-4 md:p-8 pb-20">
-            <PageMeta title="Recibo de Pagamento" />
+            <PageMeta title={isScheduled ? 'Comprovante de Agendamento' : 'Recibo de Pagamento'} />
 
             {/* Barra de ações — não imprime */}
             <div className="flex items-center justify-between mb-6 print:hidden">
@@ -147,9 +148,20 @@ export default function ReceiptView() {
             <div className="bg-white border-2 border-black rounded-2xl p-6 md:p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] print:shadow-none print:border-black">
                 <div className="text-center border-b-2 border-black pb-6 mb-6">
                     <p className="text-xs font-black uppercase tracking-widest text-gray-500 mb-1">Worki</p>
-                    <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">Recibo de Pagamento</h1>
+                    <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">
+                        {isScheduled ? 'Comprovante de Agendamento' : 'Recibo de Pagamento'}
+                    </h1>
                     <p className="text-xs font-bold text-gray-400 uppercase mt-1">Registro Worki (declaratório)</p>
                 </div>
+
+                {isScheduled && payment.scheduled_for && (
+                    <div className="bg-yellow-50 border-2 border-yellow-200 rounded-xl p-4 mb-6 flex items-center gap-3">
+                        <Clock size={20} className="text-yellow-700 flex-shrink-0" />
+                        <p className="font-bold text-yellow-800">
+                            Pagamento agendado para {formatDateOnly(payment.scheduled_for, "dd/MM/yyyy")}
+                        </p>
+                    </div>
+                )}
 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
                     <div>
@@ -182,19 +194,23 @@ export default function ReceiptView() {
                     </div>
                 </div>
 
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+                <div className={`grid grid-cols-1 ${isScheduled ? 'md:grid-cols-2' : 'md:grid-cols-3'} gap-4 mb-6`}>
                     <div className="border-2 border-black rounded-xl p-4">
-                        <span className="block text-xs font-black uppercase text-gray-400 mb-1">Valor pago</span>
+                        <span className="block text-xs font-black uppercase text-gray-400 mb-1">
+                            {isScheduled ? 'Valor previsto' : 'Valor pago'}
+                        </span>
                         <p className="font-black text-2xl tabular-nums">R$ {payment.amount.toFixed(2).replace('.', ',')}</p>
                     </div>
                     <div className="border-2 border-black rounded-xl p-4">
                         <span className="block text-xs font-black uppercase text-gray-400 mb-1">Forma</span>
                         <p className="font-bold text-lg">{PAYMENT_SOURCE_LABELS[payment.source]}</p>
                     </div>
-                    <div className="border-2 border-black rounded-xl p-4">
-                        <span className="block text-xs font-black uppercase text-gray-400 mb-1">Data do pagamento</span>
-                        <p className="font-bold text-lg">{formatDateOnly(payment.paid_at, 'dd/MM/yyyy')}</p>
-                    </div>
+                    {!isScheduled && payment.paid_at && (
+                        <div className="border-2 border-black rounded-xl p-4">
+                            <span className="block text-xs font-black uppercase text-gray-400 mb-1">Data do pagamento</span>
+                            <p className="font-bold text-lg">{formatDateOnly(payment.paid_at, 'dd/MM/yyyy')}</p>
+                        </div>
+                    )}
                 </div>
 
                 {payment.note && (
@@ -204,28 +220,41 @@ export default function ReceiptView() {
                     </div>
                 )}
 
-                {/* Confirmação bilateral do freela — não bloqueia ciclo/avaliação */}
-                <div className="border-t-2 border-black pt-6 mb-6">
-                    <span className="block text-xs font-black uppercase text-gray-400 mb-3">Confirmação de recebimento</span>
-                    {payment.worker_confirmed_at ? (
-                        <div className="flex items-center gap-2 bg-primary-light text-primary font-bold px-4 py-3 rounded-xl border-2 border-black w-fit">
-                            <CheckCircle size={18} />
-                            Recebimento confirmado em {format(new Date(payment.worker_confirmed_at), "dd/MM/yyyy 'às' HH:mm", { locale: ptBR })}
-                        </div>
-                    ) : isWorkerViewer ? (
-                        <button
-                            onClick={handleConfirmReceipt}
-                            disabled={confirming}
-                            className="print:hidden bg-primary hover:bg-black text-white px-6 py-3 rounded-xl font-black uppercase transition-colors disabled:opacity-50 flex items-center gap-2"
-                        >
-                            {confirming ? <><Loader2 size={16} className="animate-spin" /> Confirmando...</> : 'Confirmar Recebimento'}
-                        </button>
-                    ) : isCompanyViewer ? (
+                {/* Confirmação bilateral do freela — não bloqueia ciclo/avaliação. Só existe
+                    para pagamento EFETIVADO ('recorded'); 'scheduled' ainda não tem nada a
+                    confirmar (é uma promessa, não um recebimento). */}
+                {!isScheduled && (
+                    <div className="border-t-2 border-black pt-6 mb-6">
+                        <span className="block text-xs font-black uppercase text-gray-400 mb-3">Confirmação de recebimento</span>
+                        {payment.worker_confirmed_at ? (
+                            <div className="flex items-center gap-2 bg-primary-light text-primary font-bold px-4 py-3 rounded-xl border-2 border-black w-fit">
+                                <CheckCircle size={18} />
+                                Recebimento confirmado em {format(new Date(payment.worker_confirmed_at), "dd/MM/yyyy 'às' HH:mm", { locale: ptBR })}
+                            </div>
+                        ) : isWorkerViewer ? (
+                            <button
+                                onClick={handleConfirmReceipt}
+                                disabled={confirming}
+                                className="print:hidden bg-primary hover:bg-black text-white px-6 py-3 rounded-xl font-black uppercase transition-colors disabled:opacity-50 flex items-center gap-2"
+                            >
+                                {confirming ? <><Loader2 size={16} className="animate-spin" /> Confirmando...</> : 'Confirmar Recebimento'}
+                            </button>
+                        ) : isCompanyViewer ? (
+                            <p className="text-sm font-bold text-gray-500 bg-gray-100 px-4 py-3 rounded-xl w-fit">
+                                Aguardando confirmação do freela
+                            </p>
+                        ) : null}
+                    </div>
+                )}
+
+                {isScheduled && (
+                    <div className="border-t-2 border-black pt-6 mb-6">
                         <p className="text-sm font-bold text-gray-500 bg-gray-100 px-4 py-3 rounded-xl w-fit">
-                            Aguardando confirmação do freela
+                            Pagamento ainda não realizado — é uma promessa da empresa. A confirmação de
+                            recebimento fica disponível quando o pagamento for efetivado.
                         </p>
-                    ) : null}
-                </div>
+                    </div>
+                )}
 
                 <div className="flex flex-wrap items-center justify-between gap-2 text-xs font-bold text-gray-400 border-t-2 border-black pt-4">
                     <span>Registro Nº {shortId}</span>
@@ -234,8 +263,9 @@ export default function ReceiptView() {
 
                 <div className="mt-6 bg-yellow-50 border-2 border-yellow-200 rounded-xl p-4">
                     <p className="text-xs font-bold text-yellow-800">
-                        O Worki registra a declaração de pagamento entre as partes; o dinheiro não passou pela
-                        plataforma. Não é documento fiscal.
+                        {isScheduled
+                            ? 'Este comprovante é o respaldo de que a empresa se comprometeu a pagar na data prevista — não é garantia de pagamento nem documento fiscal.'
+                            : 'O Worki registra a declaração de pagamento entre as partes; o dinheiro não passou pela plataforma. Não é documento fiscal.'}
                     </p>
                 </div>
             </div>

--- a/frontend/src/pages/__tests__/MyJobs.test.tsx
+++ b/frontend/src/pages/__tests__/MyJobs.test.tsx
@@ -69,26 +69,6 @@ interface ApplicationRow {
   } | null
 }
 
-const APP_APPLIED: ApplicationRow = {
-  id: 'app-1',
-  status: 'pending',
-  created_at: '2026-03-10T10:00:00Z',
-  worker_checkin_at: null,
-  worker_checkout_at: null,
-  company_checkin_confirmed_at: null,
-  company_checkout_confirmed_at: null,
-  job: {
-    id: 'job-1',
-    title: 'Garcom para Evento',
-    budget: 150,
-    start_date: '2026-04-10',
-    work_start_time: '18:00',
-    work_end_time: '23:00',
-    location: 'Sao Paulo',
-    company: { id: 'company-1', name: 'Buffet Premium', logo_url: null },
-  },
-}
-
 const APP_IN_PROGRESS: ApplicationRow = {
   id: 'app-2',
   status: 'in_progress',
@@ -183,108 +163,70 @@ beforeEach(() => {
 })
 
 describe('MyJobs - Tabs de status', () => {
-  it('renderiza todas as tabs de status', async () => {
-    setupMocks([APP_APPLIED])
+  it('renderiza todas as tabs de status (pivô: sem Candidaturas)', async () => {
+    setupMocks([APP_IN_PROGRESS])
     renderComponent()
 
     await waitFor(() => {
-      expect(screen.getByText('Candidaturas')).toBeInTheDocument()
+      expect(screen.getByText('Convites')).toBeInTheDocument()
     })
 
     expect(screen.getByText('Em Andamento')).toBeInTheDocument()
     expect(screen.getByText('Agendados')).toBeInTheDocument()
     expect(screen.getByText(/Histórico/)).toBeInTheDocument()
+    // Aba "Candidaturas" foi removida no pivô push (invite-only).
+    expect(screen.queryByText('Candidaturas')).not.toBeInTheDocument()
   })
 
-  it('troca de tab ao clicar e mostra jobs corretos', async () => {
-    setupMocks([APP_APPLIED, APP_COMPLETED])
+  it('troca de tab ao clicar e mostra turnos corretos', async () => {
+    setupMocks([APP_IN_PROGRESS, APP_COMPLETED])
     renderComponent()
 
     await waitFor(() => {
-      expect(screen.getByText('Meus Jobs')).toBeInTheDocument()
+      expect(screen.getByText('Meus Turnos')).toBeInTheDocument()
     })
 
-    // Click on Candidaturas tab
-    fireEvent.click(screen.getByText('Candidaturas'))
-
+    // Em Andamento
+    fireEvent.click(screen.getByText('Em Andamento'))
     await waitFor(() => {
-      expect(screen.getByText('Garcom para Evento')).toBeInTheDocument()
+      expect(screen.getByText('Barman para Festa')).toBeInTheDocument()
     })
 
-    // Click on History tab
+    // Histórico
     fireEvent.click(screen.getByText(/Histórico/))
-
     await waitFor(() => {
       expect(screen.getByText('Cozinheiro para Evento')).toBeInTheDocument()
     })
   })
 })
 
-describe('MyJobs - Botao check-in', () => {
-  it('exibe botao Check-in para jobs in_progress sem checkin', async () => {
+describe('MyJobs - Botao check-out', () => {
+  it('exibe botao Check-out para turnos in_progress com checkin e sem checkout', async () => {
     setupMocks([APP_IN_PROGRESS])
     renderComponent()
 
     await waitFor(() => {
-      expect(screen.getByText('Meus Jobs')).toBeInTheDocument()
+      expect(screen.getByText('Meus Turnos')).toBeInTheDocument()
     })
 
-    // Switch to In Progress tab
     fireEvent.click(screen.getByText('Em Andamento'))
 
     await waitFor(() => {
       expect(screen.getByText('Barman para Festa')).toBeInTheDocument()
     })
 
-    // Check-out button should be visible since worker_checkin_at is set but worker_checkout_at is null
+    // worker_checkin_at setado e worker_checkout_at null → botão Check-out visível
     expect(screen.getByText('Check-out')).toBeInTheDocument()
   })
 })
 
-describe('MyJobs - Botao cancelar aplicacao', () => {
-  it('exibe botao de cancelar para jobs applied', async () => {
-    setupMocks([APP_APPLIED])
-    renderComponent()
-
-    await waitFor(() => {
-      expect(screen.getByText('Meus Jobs')).toBeInTheDocument()
-    })
-
-    // Switch to Candidaturas tab
-    fireEvent.click(screen.getByText('Candidaturas'))
-
-    await waitFor(() => {
-      expect(screen.getByText('Garcom para Evento')).toBeInTheDocument()
-    })
-
-    // Cancel button should exist (XCircle icon button)
-    const cancelBtn = screen.getByTitle('Cancelar Candidatura')
-    expect(cancelBtn).toBeInTheDocument()
-  })
-})
-
 describe('MyJobs - Estado vazio por tab', () => {
-  it('exibe estado vazio na tab Candidaturas quando nao ha aplicacoes', async () => {
+  it('exibe estado vazio na tab Em Andamento quando nao ha turnos', async () => {
     setupMocks([])
     renderComponent()
 
     await waitFor(() => {
-      expect(screen.getByText('Meus Jobs')).toBeInTheDocument()
-    })
-
-    fireEvent.click(screen.getByText('Candidaturas'))
-
-    await waitFor(() => {
-      expect(screen.getByText('Você não tem candidaturas pendentes.')).toBeInTheDocument()
-    })
-  })
-
-  it('exibe estado vazio na tab Em Andamento quando nao ha jobs', async () => {
-    setupMocks([])
-    renderComponent()
-
-    await waitFor(() => {
-      expect(screen.getByText('Meus Jobs')).toBeInTheDocument()
+      expect(screen.getByText('Meus Turnos')).toBeInTheDocument()
     })
 
     fireEvent.click(screen.getByText('Em Andamento'))
@@ -294,28 +236,27 @@ describe('MyJobs - Estado vazio por tab', () => {
     })
   })
 
-  it('exibe estado vazio na tab Agendados quando nao ha jobs', async () => {
+  it('exibe estado vazio na tab Agendados quando nao ha turnos', async () => {
     setupMocks([])
     renderComponent()
 
     await waitFor(() => {
-      expect(screen.getByText('Meus Jobs')).toBeInTheDocument()
+      expect(screen.getByText('Meus Turnos')).toBeInTheDocument()
     })
 
-    // Convites e a tab padrao; trocar para Agendados
     fireEvent.click(screen.getByText('Agendados'))
 
     await waitFor(() => {
-      expect(screen.getByText('Nenhum job agendado no momento.')).toBeInTheDocument()
+      expect(screen.getByText('Nenhum turno agendado no momento.')).toBeInTheDocument()
     })
   })
 
-  it('exibe estado vazio na tab Historico quando nao ha jobs', async () => {
+  it('exibe estado vazio na tab Historico quando nao ha turnos', async () => {
     setupMocks([])
     renderComponent()
 
     await waitFor(() => {
-      expect(screen.getByText('Meus Jobs')).toBeInTheDocument()
+      expect(screen.getByText('Meus Turnos')).toBeInTheDocument()
     })
 
     fireEvent.click(screen.getByText(/Histórico/))

--- a/frontend/src/pages/company/CompanyJobCandidates.test.tsx
+++ b/frontend/src/pages/company/CompanyJobCandidates.test.tsx
@@ -333,7 +333,7 @@ describe('CompanyJobCandidates — modal de avaliação (review)', () => {
 
     // Rating modal should be open
     await waitFor(() => {
-      expect(screen.getByText('Avaliar Freelancer')).toBeInTheDocument()
+      expect(screen.getByText('Avaliar Freela')).toBeInTheDocument()
     })
 
     // Submit the review
@@ -341,7 +341,7 @@ describe('CompanyJobCandidates — modal de avaliação (review)', () => {
 
     await waitFor(() => {
       expect(mockAddToast).toHaveBeenCalledWith(
-        'Você já avaliou este profissional para este job.',
+        'Você já avaliou este freela para este turno.',
         'error'
       )
     })

--- a/frontend/src/pages/company/CompanyJobCandidates.tsx
+++ b/frontend/src/pages/company/CompanyJobCandidates.tsx
@@ -7,8 +7,8 @@ import { SpendLimitService } from '../../services/spendLimitService';
 import { TeamConnectionService } from '../../services/teamConnectionService';
 import { useCompanyInvites } from '../../hooks/useShiftInvites';
 import { logError } from '../../lib/logger';
-import { ArrowLeft, Star, MapPin, Clock, ChevronRight, CheckCircle, XCircle, MessageSquare, Play, Square, Loader2, Receipt, Send, Users, X } from 'lucide-react';
-import { formatDistanceToNow } from 'date-fns';
+import { ArrowLeft, Star, MapPin, Clock, ChevronRight, CheckCircle, XCircle, MessageSquare, Play, Square, Loader2, Receipt, Send, Users, X, CalendarClock } from 'lucide-react';
+import { formatDistanceToNow, format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { useToast } from '../../contexts/ToastContext';
 import JobLifecycleStepper from '../../components/JobLifecycleStepper';
@@ -36,6 +36,16 @@ const PAYMENT_SOURCE_LABELS: Record<PaymentSource, string> = {
     cash: 'Dinheiro',
     other: 'Outro',
 };
+
+/**
+ * Formata uma data "date-only" (`scheduled_for`, YYYY-MM-DD) como data LOCAL, sem shift de
+ * fuso. `new Date("YYYY-MM-DD")` é interpretado como meia-noite UTC; em BRT (UTC-3) isso
+ * recua a data em 1 dia. Mesmo padrão de `ReceiptView.formatDateOnly` / `components/JobCard.tsx`.
+ */
+function formatDateOnly(dateOnly: string): string {
+    const [y, m, d] = dateOnly.split('-').map(Number);
+    return format(new Date(y, m - 1, d), 'dd/MM/yyyy', { locale: ptBR });
+}
 
 // Fase 2 (piloto push-only): fluxo PULL "Contratar" aposentado — feed público escondido, contratação
 // é 100% via convite do Elenco (push). O pull-hire dispara reserve_escrow (HARD-requer saldo), o que
@@ -73,6 +83,17 @@ export default function CompanyJobCandidates() {
     const [paymentNote, setPaymentNote] = useState('');
     const [recordingPayment, setRecordingPayment] = useState(false);
     const [paymentRecorded, setPaymentRecorded] = useState(false);
+
+    // Modal "Agendar pagamento" (modo A — ADR-20260712, promessa com data prevista)
+    const [scheduleModalApp, setScheduleModalApp] = useState<Application | null>(null);
+    const [scheduleSource, setScheduleSource] = useState<PaymentSource>('external_pix');
+    const [scheduleAmount, setScheduleAmount] = useState(0);
+    const [scheduledFor, setScheduledFor] = useState(() => new Date().toISOString().slice(0, 10));
+    const [scheduleNote, setScheduleNote] = useState('');
+    const [scheduling, setScheduling] = useState(false);
+    const [paymentScheduled, setPaymentScheduled] = useState(false);
+    // Efetivação de um pagamento já agendado ("Marcar como pago") — guarda o id em efetivação.
+    const [effectivatingId, setEffectivatingId] = useState<string | null>(null);
 
     // "Convidar outro" — convite expirado sem resposta; o slot está livre para outro freela (R8).
     const [reopenApp, setReopenApp] = useState<Application | null>(null);
@@ -208,6 +229,21 @@ export default function CompanyJobCandidates() {
         setPaymentRecorded(false);
     };
 
+    // Modo A (pagamento agendado) — abre o modal "Agendar pagamento" pré-preenchido com o valor do turno.
+    const openScheduleModal = (app: Application) => {
+        setScheduleModalApp(app);
+        setScheduleSource('external_pix');
+        setScheduleAmount(jobBudget);
+        setScheduledFor(new Date().toISOString().slice(0, 10));
+        setScheduleNote('');
+        setPaymentScheduled(false);
+    };
+
+    const closeScheduleModal = () => {
+        setScheduleModalApp(null);
+        setPaymentScheduled(false);
+    };
+
     // Abre o picker "Convidar outro" para um convite expirado (status='invited' + prazo vencido).
     // O slot está livre: qualquer outro membro da equipe (que ainda não tenha application para
     // este job) pode ser convidado. Não escreve nada no convite antigo — é só leitura + novo convite.
@@ -319,6 +355,81 @@ export default function CompanyJobCandidates() {
             addToast('Erro ao registrar pagamento.', 'error');
         } finally {
             setRecordingPayment(false);
+        }
+    };
+
+    // ADR-20260712 — agenda a PROMESSA de pagamento (status='scheduled', data prevista).
+    // Mesma lógica de "marcar o turno como concluído só após sucesso" do registro imediato:
+    // a entrega (chegada+saída confirmadas) já aconteceu, só o pagamento fica pendente.
+    const handleSchedulePayment = async () => {
+        if (!scheduleModalApp) return;
+        if (!(scheduleAmount > 0)) {
+            addToast('Informe um valor previsto maior que zero.', 'error');
+            return;
+        }
+        if (!scheduledFor) {
+            addToast('Informe a data prevista do pagamento.', 'error');
+            return;
+        }
+        setScheduling(true);
+        try {
+            const result = await PaymentRecordService.scheduleExternalPayment({
+                jobId: scheduleModalApp.job_id,
+                workerId: scheduleModalApp.worker_id,
+                applicationId: scheduleModalApp.id,
+                source: scheduleSource,
+                amount: scheduleAmount,
+                scheduledFor,
+                note: scheduleNote.trim() || undefined,
+            });
+
+            if (!result.success) {
+                if (result.alreadyActive) {
+                    addToast('Este turno já tem um pagamento registrado ou agendado. Veja o comprovante.', 'info');
+                    closeScheduleModal();
+                    fetchCandidates();
+                    return;
+                }
+                addToast(result.error || 'Não foi possível agendar o pagamento.', 'error');
+                return;
+            }
+
+            const { error: updateError } = await supabase
+                .from('applications')
+                .update({ status: 'completed' })
+                .eq('id', scheduleModalApp.id);
+            if (updateError) {
+                logError('CompanyJobCandidates: handleSchedulePayment.updateStatus', updateError);
+                addToast('Pagamento agendado, mas houve erro ao concluir o turno. Contate o suporte.', 'error');
+            } else {
+                addToast('Pagamento agendado com sucesso!', 'success');
+            }
+            setPaymentScheduled(true);
+            fetchCandidates();
+        } catch (error) {
+            logError('CompanyJobCandidates: handleSchedulePayment', error);
+            addToast('Erro ao agendar pagamento.', 'error');
+        } finally {
+            setScheduling(false);
+        }
+    };
+
+    // Efetiva um pagamento agendado ("Marcar como pago") — scheduled → recorded, grava paid_at real.
+    const handleEffectivatePayment = async (paymentId: string) => {
+        setEffectivatingId(paymentId);
+        try {
+            const result = await PaymentRecordService.effectivateScheduledPayment(paymentId);
+            if (!result.success) {
+                addToast(result.error || 'Não foi possível marcar como pago.', 'error');
+                return;
+            }
+            addToast('Pagamento marcado como pago!', 'success');
+            fetchCandidates();
+        } catch (error) {
+            logError('CompanyJobCandidates: handleEffectivatePayment', error);
+            addToast('Erro ao marcar pagamento como pago.', 'error');
+        } finally {
+            setEffectivatingId(null);
         }
     };
 
@@ -468,8 +579,35 @@ export default function CompanyJobCandidates() {
         ];
     };
 
-    // Ramificação modo A (pagamento externo) vs C (postpago/cartão) vs prepago legado.
-    // Sem entrada em escrowKindMap = nenhum escrow reservado para este turno → modo A (default do piloto).
+    // Bloco de ações para um marcador 'scheduled' (promessa) — reaproveitado no gatilho de
+    // conclusão e na seção pós-conclusão (mesma lógica, dois pontos de renderização).
+    const renderScheduledPaymentBlock = (payment: ShiftPayment) => (
+        <div className="flex items-center gap-2 flex-wrap">
+            {payment.scheduled_for && (
+                <span className="flex items-center gap-1 text-xs font-black uppercase px-3 py-1 rounded-lg border-2 bg-yellow-50 border-yellow-200 text-yellow-700">
+                    <CalendarClock size={14} /> Agendado p/ {formatDateOnly(payment.scheduled_for)}
+                </span>
+            )}
+            <button
+                onClick={(e) => { e.stopPropagation(); handleEffectivatePayment(payment.id); }}
+                disabled={effectivatingId === payment.id}
+                className="py-2 px-3 bg-black text-white border-2 border-black rounded-lg text-xs font-bold uppercase hover:bg-primary transition-colors flex items-center gap-1 disabled:opacity-50"
+            >
+                {effectivatingId === payment.id && <Loader2 size={14} className="animate-spin" />}
+                Marcar como pago
+            </button>
+            <button
+                onClick={(e) => { e.stopPropagation(); navigate(`/recibo/${payment.job_id}`); }}
+                className="py-2 px-3 bg-white text-black border-2 border-black rounded-lg text-xs font-bold uppercase hover:bg-gray-50 transition-colors flex items-center gap-1"
+            >
+                <Receipt size={14} /> Ver Comprovante
+            </button>
+        </div>
+    );
+
+    // Ramificação modo A (pagamento externo, registrado OU agendado) vs C (postpago/cartão)
+    // vs prepago legado. Sem entrada em escrowKindMap = nenhum escrow reservado para este
+    // turno → modo A (default do piloto).
     const renderCompletionAction = (app: Application) => {
         const kind = escrowKindMap[app.id];
         if (kind === 'prepaid' || kind === 'postpaid') {
@@ -482,23 +620,38 @@ export default function CompanyJobCandidates() {
                 </button>
             );
         }
-        if (shiftPayment && shiftPayment.job_id === app.job_id && shiftPayment.worker_id === app.worker_id) {
+        const matchingPayment =
+            shiftPayment && shiftPayment.job_id === app.job_id && shiftPayment.worker_id === app.worker_id
+                ? shiftPayment
+                : null;
+        if (matchingPayment?.status === 'recorded') {
             return (
                 <button
                     onClick={(e) => { e.stopPropagation(); navigate(`/recibo/${app.job_id}`); }}
-                    className="p-1 px-3 bg-white text-black border-2 border-black rounded-lg text-xs font-bold uppercase hover:bg-gray-50 transition-colors flex items-center gap-1"
+                    className="py-2 px-3 bg-white text-black border-2 border-black rounded-lg text-xs font-bold uppercase hover:bg-gray-50 transition-colors flex items-center gap-1"
                 >
                     <Receipt size={14} /> Ver Recibo
                 </button>
             );
         }
+        if (matchingPayment?.status === 'scheduled') {
+            return renderScheduledPaymentBlock(matchingPayment);
+        }
         return (
-            <button
-                onClick={(e) => { e.stopPropagation(); openPaymentModal(app); }}
-                className="p-1 px-3 bg-black text-white border-2 border-black rounded-lg text-xs font-bold uppercase hover:bg-primary transition-colors flex items-center gap-1"
-            >
-                Registrar Pagamento
-            </button>
+            <div className="flex items-center gap-2 flex-wrap">
+                <button
+                    onClick={(e) => { e.stopPropagation(); openPaymentModal(app); }}
+                    className="py-2 px-3 bg-black text-white border-2 border-black rounded-lg text-xs font-bold uppercase hover:bg-primary transition-colors flex items-center gap-1"
+                >
+                    Registrar Pagamento
+                </button>
+                <button
+                    onClick={(e) => { e.stopPropagation(); openScheduleModal(app); }}
+                    className="py-2 px-3 bg-white text-black border-2 border-black rounded-lg text-xs font-bold uppercase hover:bg-gray-50 transition-colors flex items-center gap-1"
+                >
+                    <CalendarClock size={14} /> Agendar Pagamento
+                </button>
+            </div>
         );
     };
 
@@ -692,27 +845,45 @@ export default function CompanyJobCandidates() {
                                                         </>
                                                     )}
 
-                                                    {/* Ver Recibo — turno finalizado via modo A (pagamento externo) */}
-                                                    {app.status === 'completed' && shiftPayment && shiftPayment.job_id === app.job_id && shiftPayment.worker_id === app.worker_id && (
-                                                        <button
-                                                            onClick={(e) => { e.stopPropagation(); navigate(`/recibo/${app.job_id}`); }}
-                                                            className="p-1 px-3 bg-white text-black border-2 border-black rounded-lg text-xs font-bold uppercase hover:bg-gray-50 transition-colors flex items-center gap-1"
-                                                        >
-                                                            <Receipt size={14} /> Ver Recibo
-                                                        </button>
-                                                    )}
-
-                                                    {/* Rede de segurança (defense-in-depth): turno concluído em modo A (sem escrow)
-                                                        mas sem registro de pagamento — caminho de recuperação caso o registro tenha
-                                                        falhado depois da conclusão em algum fluxo legado/edge case. */}
-                                                    {app.status === 'completed' && !escrowKindMap[app.id] && !(shiftPayment && shiftPayment.job_id === app.job_id && shiftPayment.worker_id === app.worker_id) && (
-                                                        <button
-                                                            onClick={(e) => { e.stopPropagation(); openPaymentModal(app); }}
-                                                            className="p-1 px-3 bg-black text-white border-2 border-black rounded-lg text-xs font-bold uppercase hover:bg-primary transition-colors flex items-center gap-1"
-                                                        >
-                                                            Registrar Pagamento
-                                                        </button>
-                                                    )}
+                                                    {/* Turno finalizado via modo A (pagamento externo) — ramifica por status do marcador. */}
+                                                    {app.status === 'completed' && !escrowKindMap[app.id] && (() => {
+                                                        const matchingPayment =
+                                                            shiftPayment && shiftPayment.job_id === app.job_id && shiftPayment.worker_id === app.worker_id
+                                                                ? shiftPayment
+                                                                : null;
+                                                        if (matchingPayment?.status === 'recorded') {
+                                                            return (
+                                                                <button
+                                                                    onClick={(e) => { e.stopPropagation(); navigate(`/recibo/${app.job_id}`); }}
+                                                                    className="py-2 px-3 bg-white text-black border-2 border-black rounded-lg text-xs font-bold uppercase hover:bg-gray-50 transition-colors flex items-center gap-1"
+                                                                >
+                                                                    <Receipt size={14} /> Ver Recibo
+                                                                </button>
+                                                            );
+                                                        }
+                                                        if (matchingPayment?.status === 'scheduled') {
+                                                            return renderScheduledPaymentBlock(matchingPayment);
+                                                        }
+                                                        // Rede de segurança (defense-in-depth): turno concluído em modo A (sem escrow)
+                                                        // mas sem registro/agendamento de pagamento — caminho de recuperação caso o
+                                                        // registro tenha falhado depois da conclusão em algum fluxo legado/edge case.
+                                                        return (
+                                                            <div className="flex items-center gap-2 flex-wrap">
+                                                                <button
+                                                                    onClick={(e) => { e.stopPropagation(); openPaymentModal(app); }}
+                                                                    className="py-2 px-3 bg-black text-white border-2 border-black rounded-lg text-xs font-bold uppercase hover:bg-primary transition-colors flex items-center gap-1"
+                                                                >
+                                                                    Registrar Pagamento
+                                                                </button>
+                                                                <button
+                                                                    onClick={(e) => { e.stopPropagation(); openScheduleModal(app); }}
+                                                                    className="py-2 px-3 bg-white text-black border-2 border-black rounded-lg text-xs font-bold uppercase hover:bg-gray-50 transition-colors flex items-center gap-1"
+                                                                >
+                                                                    <CalendarClock size={14} /> Agendar Pagamento
+                                                                </button>
+                                                            </div>
+                                                        );
+                                                    })()}
 
                                                     {/* Botão Avaliar — apenas para candidatos já finalizados */}
                                                     {app.status === 'completed' && (
@@ -989,6 +1160,133 @@ export default function CompanyJobCandidates() {
                                         className="flex-1 py-3 bg-black text-white font-bold rounded-xl border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:bg-primary hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all flex items-center justify-center gap-2"
                                     >
                                         <Receipt size={16} /> Ver Recibo
+                                    </button>
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                </div>
+            )}
+
+            {/* Modal "Agendar Pagamento" — modo A, promessa com data prevista (ADR-20260712) */}
+            {scheduleModalApp && (
+                <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4 backdrop-blur-sm animate-in fade-in duration-200">
+                    <div className="bg-white rounded-2xl w-full max-w-md p-6 border-2 border-black shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+                        {!paymentScheduled ? (
+                            <>
+                                <h2 className="text-xl font-black uppercase tracking-tight mb-1">Agendar Pagamento</h2>
+                                <p className="text-xs font-bold text-gray-500 uppercase mb-5">
+                                    Promessa de pagamento por fora do Worki — comprovante para o freela
+                                </p>
+
+                                <div className="mb-4">
+                                    <span className="block text-sm font-bold uppercase mb-2">Forma de pagamento</span>
+                                    <div className="grid grid-cols-3 gap-2">
+                                        {(Object.keys(PAYMENT_SOURCE_LABELS) as PaymentSource[]).map((src) => (
+                                            <button
+                                                key={src}
+                                                type="button"
+                                                onClick={() => setScheduleSource(src)}
+                                                aria-pressed={scheduleSource === src}
+                                                className={`py-3 min-h-[44px] rounded-xl border-2 border-black font-black text-xs uppercase transition-colors ${scheduleSource === src ? 'bg-black text-white' : 'bg-white text-black hover:bg-gray-50'
+                                                    }`}
+                                            >
+                                                {PAYMENT_SOURCE_LABELS[src]}
+                                            </button>
+                                        ))}
+                                    </div>
+                                </div>
+
+                                <div className="mb-4">
+                                    <label htmlFor="schedule-amount" className="block text-sm font-bold uppercase mb-2">
+                                        Valor previsto (R$)
+                                    </label>
+                                    <div className="relative">
+                                        <span className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-500 font-bold">R$</span>
+                                        <input
+                                            id="schedule-amount"
+                                            type="number"
+                                            min="0.01"
+                                            step="0.01"
+                                            value={scheduleAmount}
+                                            onChange={(e) => setScheduleAmount(Number(e.target.value))}
+                                            className="w-full border-2 border-black rounded-xl pl-12 pr-4 py-3 focus:outline-none focus:ring-2 focus:ring-primary font-bold tabular-nums"
+                                        />
+                                    </div>
+                                </div>
+
+                                <div className="mb-4">
+                                    <label htmlFor="schedule-for" className="block text-sm font-bold uppercase mb-2">
+                                        Data prevista do pagamento
+                                    </label>
+                                    <input
+                                        id="schedule-for"
+                                        type="date"
+                                        value={scheduledFor}
+                                        onChange={(e) => setScheduledFor(e.target.value)}
+                                        className="w-full border-2 border-black rounded-xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-primary font-bold"
+                                    />
+                                </div>
+
+                                <div className="mb-6">
+                                    <label htmlFor="schedule-note" className="block text-sm font-bold uppercase mb-2">
+                                        Nota (opcional)
+                                    </label>
+                                    <textarea
+                                        id="schedule-note"
+                                        value={scheduleNote}
+                                        onChange={(e) => setScheduleNote(e.target.value)}
+                                        placeholder="Ex.: pagamento no fechamento do mês..."
+                                        className="w-full border-2 border-black rounded-xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-primary font-medium h-20 resize-none"
+                                    />
+                                </div>
+
+                                <div className="mb-6 bg-yellow-50 border-2 border-yellow-200 rounded-xl p-4">
+                                    <p className="text-xs font-bold text-yellow-800">
+                                        Isto é uma PROMESSA, ainda não um pagamento — o dinheiro não passa pelo Worki.
+                                        O comprovante de agendamento fica disponível para o freela; ao efetivar, marque
+                                        "Marcar como pago". Ao confirmar, o turno será marcado como concluído.
+                                    </p>
+                                </div>
+
+                                <div className="flex gap-3">
+                                    <button
+                                        onClick={closeScheduleModal}
+                                        disabled={scheduling}
+                                        className="flex-1 py-3 border-2 border-black font-bold rounded-xl hover:bg-gray-50 transition-colors disabled:opacity-50"
+                                    >
+                                        Cancelar
+                                    </button>
+                                    <button
+                                        onClick={handleSchedulePayment}
+                                        disabled={scheduling || !(scheduleAmount > 0) || !scheduledFor}
+                                        className="flex-1 py-3 bg-black text-white font-bold rounded-xl border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:bg-primary hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all disabled:opacity-50 flex items-center justify-center gap-2"
+                                    >
+                                        {scheduling ? <><Loader2 size={16} className="animate-spin" /> Agendando...</> : 'Confirmar Agendamento'}
+                                    </button>
+                                </div>
+                            </>
+                        ) : (
+                            <div className="flex flex-col items-center text-center py-4">
+                                <div className="w-16 h-16 rounded-full bg-primary-light border-2 border-black flex items-center justify-center mb-4">
+                                    <CalendarClock size={32} className="text-primary" />
+                                </div>
+                                <h2 className="text-xl font-black uppercase tracking-tight mb-2">Pagamento agendado!</h2>
+                                <p className="text-gray-600 font-medium mb-6">
+                                    O comprovante de agendamento já está disponível para você e para o profissional.
+                                </p>
+                                <div className="flex gap-3 w-full">
+                                    <button
+                                        onClick={closeScheduleModal}
+                                        className="flex-1 py-3 border-2 border-black font-bold rounded-xl hover:bg-gray-50 transition-colors"
+                                    >
+                                        Fechar
+                                    </button>
+                                    <button
+                                        onClick={() => navigate(`/recibo/${scheduleModalApp.job_id}`)}
+                                        className="flex-1 py-3 bg-black text-white font-bold rounded-xl border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:bg-primary hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all flex items-center justify-center gap-2"
+                                    >
+                                        <Receipt size={16} /> Ver Comprovante
                                     </button>
                                 </div>
                             </div>

--- a/frontend/src/pages/company/CompanyProfile.tsx
+++ b/frontend/src/pages/company/CompanyProfile.tsx
@@ -7,6 +7,7 @@ import { useToast } from '../../contexts/ToastContext';
 import { getPasswordStrength } from '../../lib/validation';
 import { logError } from '../../lib/logger';
 import { TeamConnectionService } from '../../services/teamConnectionService';
+import ProfileReviews from '../../components/ProfileReviews';
 
 interface Company {
     name: string;
@@ -637,6 +638,9 @@ export default function CompanyProfile() {
                 )}
             </div>
 
+            {/* Avaliações recebidas de freelas */}
+            {userId && <ProfileReviews reviewedId={userId} reviewerRole="worker" />}
+
             {/* Secao Seguranca */}
             <div className="mt-8 bg-white border-2 border-black rounded-2xl p-6 sm:p-8 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
                 <h3 className="text-xl font-black uppercase mb-4 flex items-center gap-2">
@@ -644,8 +648,9 @@ export default function CompanyProfile() {
                 </h3>
 
                 <div className="mb-4">
-                    <label className="block text-sm font-bold uppercase mb-1">Nova Senha</label>
+                    <label htmlFor="new-password" className="block text-sm font-bold uppercase mb-1">Nova Senha</label>
                     <input
+                        id="new-password"
                         type="password"
                         value={newPassword}
                         onChange={e => { setNewPassword(e.target.value); setPasswordError(null); }}
@@ -665,8 +670,9 @@ export default function CompanyProfile() {
                 </div>
 
                 <div className="mb-2">
-                    <label className="block text-sm font-bold uppercase mb-1">Confirmar Nova Senha</label>
+                    <label htmlFor="confirm-password" className="block text-sm font-bold uppercase mb-1">Confirmar Nova Senha</label>
                     <input
+                        id="confirm-password"
                         type="password"
                         value={confirmPassword}
                         onChange={e => { setConfirmPassword(e.target.value); setPasswordError(null); }}

--- a/frontend/src/services/paymentRecordService.test.ts
+++ b/frontend/src/services/paymentRecordService.test.ts
@@ -16,6 +16,7 @@ function makeChain(result: { data: any; error: any }) {
     insert: vi.fn(() => chain),
     update: vi.fn(() => chain),
     eq: vi.fn(() => chain),
+    in: vi.fn(() => chain),
     maybeSingle: vi.fn(() => promise),
     single: vi.fn(() => promise),
     then: promise.then.bind(promise),
@@ -70,6 +71,7 @@ const SHIFT_PAYMENT_ROW: ShiftPayment = {
   application_id: 'app-1',
   source: 'external_pix',
   amount: 150,
+  scheduled_for: null,
   paid_at: '2026-06-30T12:00:00Z',
   recorded_by: 'user-company-1',
   worker_confirmed_at: null,
@@ -78,6 +80,14 @@ const SHIFT_PAYMENT_ROW: ShiftPayment = {
   voided_at: null,
   void_reason: null,
   created_at: '2026-06-30T12:00:00Z',
+}
+
+const SCHEDULED_PAYMENT_ROW: ShiftPayment = {
+  ...SHIFT_PAYMENT_ROW,
+  id: 'sp-2',
+  status: 'scheduled',
+  scheduled_for: '2026-07-20',
+  paid_at: null,
 }
 
 // ---------------------------------------------------------------------------
@@ -96,9 +106,9 @@ describe('Tipos ShiftPayment', () => {
     sources.forEach((s) => expect(['external_pix', 'cash', 'other']).toContain(s))
   })
 
-  it('ShiftPaymentStatus aceita recorded | voided', () => {
-    const statuses: ShiftPaymentStatus[] = ['recorded', 'voided']
-    statuses.forEach((s) => expect(['recorded', 'voided']).toContain(s))
+  it('ShiftPaymentStatus aceita scheduled | recorded | voided', () => {
+    const statuses: ShiftPaymentStatus[] = ['scheduled', 'recorded', 'voided']
+    statuses.forEach((s) => expect(['scheduled', 'recorded', 'voided']).toContain(s))
   })
 
   it('ShiftPayment aceita voided com voided_at/void_reason preenchidos', () => {
@@ -110,6 +120,12 @@ describe('Tipos ShiftPayment', () => {
     }
     expect(voided.status).toBe('voided')
     expect(voided.voided_at).not.toBeNull()
+  })
+
+  it('ShiftPayment aceita scheduled com scheduled_for preenchido e paid_at nulo', () => {
+    expect(SCHEDULED_PAYMENT_ROW.status).toBe('scheduled')
+    expect(SCHEDULED_PAYMENT_ROW.scheduled_for).toBe('2026-07-20')
+    expect(SCHEDULED_PAYMENT_ROW.paid_at).toBeNull()
   })
 })
 
@@ -311,6 +327,154 @@ describe('PaymentRecordService.recordExternalPayment', () => {
 })
 
 // ---------------------------------------------------------------------------
+// scheduleExternalPayment (ADR-20260712 — pagamento agendado)
+// ---------------------------------------------------------------------------
+
+describe('PaymentRecordService.scheduleExternalPayment', () => {
+  it('rejeita amount <= 0 sem chamar o supabase', async () => {
+    const { PaymentRecordService } = await import('./paymentRecordService')
+
+    const result = await PaymentRecordService.scheduleExternalPayment({
+      jobId: 'job-1',
+      workerId: 'worker-1',
+      applicationId: 'app-1',
+      source: 'cash',
+      amount: 0,
+      scheduledFor: '2026-07-20',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/maior que zero/)
+    expect(mockFrom).not.toHaveBeenCalled()
+  })
+
+  it('rejeita scheduledFor vazio sem chamar o supabase', async () => {
+    const { PaymentRecordService } = await import('./paymentRecordService')
+
+    const result = await PaymentRecordService.scheduleExternalPayment({
+      jobId: 'job-1',
+      workerId: 'worker-1',
+      applicationId: 'app-1',
+      source: 'cash',
+      amount: 100,
+      scheduledFor: '',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/data prevista/)
+    expect(mockFrom).not.toHaveBeenCalled()
+  })
+
+  it('rejeita quando o turno (application) não está concluído', async () => {
+    routeFrom({
+      applications: makeChain({
+        data: { ...APPLICATION_COMPLETED, company_checkout_confirmed_at: null },
+        error: null,
+      }),
+    })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.scheduleExternalPayment({
+      jobId: 'job-1',
+      workerId: 'worker-1',
+      applicationId: 'app-1',
+      source: 'cash',
+      amount: 100,
+      scheduledFor: '2026-07-20',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/concluído/)
+  })
+
+  it('agenda com sucesso quando o turno está concluído — status scheduled, sem paid_at', async () => {
+    routeFrom({
+      applications: makeChain({ data: APPLICATION_COMPLETED, error: null }),
+      companies: makeChain({ data: COMPANY_ROW, error: null }),
+      shift_payments: makeChain({ data: SCHEDULED_PAYMENT_ROW, error: null }),
+    })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.scheduleExternalPayment({
+      jobId: 'job-1',
+      workerId: 'worker-1',
+      applicationId: 'app-1',
+      source: 'external_pix',
+      amount: 150,
+      scheduledFor: '2026-07-20',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.payment?.status).toBe('scheduled')
+    expect(result.payment?.paid_at).toBeNull()
+    expect(mockFrom).toHaveBeenCalledWith('shift_payments')
+  })
+
+  it('trata violação do UNIQUE parcial (23505) como alreadyActive, sem crashar', async () => {
+    routeFrom({
+      applications: makeChain({ data: APPLICATION_COMPLETED, error: null }),
+      companies: makeChain({ data: COMPANY_ROW, error: null }),
+      shift_payments: makeChain({
+        data: null,
+        error: { code: '23505', message: 'duplicate key value violates unique constraint' },
+      }),
+    })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.scheduleExternalPayment({
+      jobId: 'job-1',
+      workerId: 'worker-1',
+      applicationId: 'app-1',
+      source: 'cash',
+      amount: 100,
+      scheduledFor: '2026-07-20',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.alreadyActive).toBe(true)
+    expect(result.error).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// effectivateScheduledPayment (scheduled → recorded)
+// ---------------------------------------------------------------------------
+
+describe('PaymentRecordService.effectivateScheduledPayment', () => {
+  it('efetiva com sucesso — status recorded, paid_at preenchido', async () => {
+    routeFrom({
+      shift_payments: makeChain({
+        data: { ...SCHEDULED_PAYMENT_ROW, status: 'recorded', paid_at: '2026-07-20T00:00:00Z' },
+        error: null,
+      }),
+    })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.effectivateScheduledPayment('sp-2')
+
+    expect(result.success).toBe(true)
+    expect(result.payment?.status).toBe('recorded')
+    expect(result.payment?.paid_at).toBeTruthy()
+    expect(mockFrom).toHaveBeenCalledWith('shift_payments')
+  })
+
+  it('retorna erro quando o UPDATE falha (ex.: trigger de imutabilidade/transição inválida)', async () => {
+    routeFrom({
+      shift_payments: makeChain({
+        data: null,
+        error: { message: 'shift_payments: transicao de status invalida' },
+      }),
+    })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.effectivateScheduledPayment('sp-2')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBeTruthy()
+  })
+})
+
+// ---------------------------------------------------------------------------
 // getPaymentByJob
 // ---------------------------------------------------------------------------
 
@@ -323,6 +487,16 @@ describe('PaymentRecordService.getPaymentByJob', () => {
 
     expect(result).toEqual(SHIFT_PAYMENT_ROW)
     expect(mockFrom).toHaveBeenCalledWith('shift_payments')
+  })
+
+  it('retorna o registro scheduled (promessa) do turno — o comprovante de agendamento também deve aparecer', async () => {
+    routeFrom({ shift_payments: makeChain({ data: SCHEDULED_PAYMENT_ROW, error: null }) })
+
+    const { PaymentRecordService } = await import('./paymentRecordService')
+    const result = await PaymentRecordService.getPaymentByJob('job-1')
+
+    expect(result).toEqual(SCHEDULED_PAYMENT_ROW)
+    expect(result?.status).toBe('scheduled')
   })
 
   it('retorna null quando não há registro', async () => {

--- a/frontend/src/services/paymentRecordService.ts
+++ b/frontend/src/services/paymentRecordService.ts
@@ -63,6 +63,36 @@ export interface RecordExternalPaymentResult {
   error?: string;
 }
 
+/**
+ * ADR-20260712 — Pagamento agendado. `scheduleExternalPayment` registra a PROMESSA
+ * (`status='scheduled'`, `scheduled_for`), sem `paid_at`. NÃO move saldo, NÃO chama RPC.
+ */
+export interface ScheduleExternalPaymentParams {
+  jobId: string;
+  workerId: string;
+  applicationId: string;
+  source: PaymentSource;
+  /** Valor previsto a pagar (BRL). Deve ser > 0 (também reforçado por CHECK no DB). */
+  amount: number;
+  /** Data PREVISTA do pagamento (promessa), formato YYYY-MM-DD. */
+  scheduledFor: string;
+  note?: string;
+}
+
+export interface ScheduleExternalPaymentResult {
+  success: boolean;
+  payment?: ShiftPayment;
+  /** true quando já existe um marcador ATIVO (scheduled ou recorded) para este job_id (UNIQUE parcial, 23505). */
+  alreadyActive?: boolean;
+  error?: string;
+}
+
+export interface EffectivateScheduledPaymentResult {
+  success: boolean;
+  payment?: ShiftPayment;
+  error?: string;
+}
+
 export interface ConfirmReceiptResult {
   success: boolean;
   error?: string;
@@ -221,8 +251,128 @@ export const PaymentRecordService = {
   },
 
   /**
-   * Busca o registro 'recorded' (ativo) de um turno, se existir.
-   * Usado pela UI para decidir entre mostrar "Registrar pagamento" ou "Ver recibo".
+   * Agenda a PROMESSA de pagamento de um turno (ADR-20260712) — status='scheduled',
+   * `scheduled_for` preenchido, `paid_at` NULL (ainda não pagou). NÃO move saldo, NÃO
+   * chama RPC, NÃO toca wallets/escrow_transactions (mesma fronteira do modo A).
+   *
+   * Reutiliza a MESMA validação defensiva de "turno concluído" de `recordExternalPayment`
+   * (chegada e saída confirmadas pela empresa) — a promessa também exige lastro de trabalho.
+   *
+   * Idempotência: o UNIQUE parcial `(job_id) WHERE status IN ('scheduled','recorded')` rejeita
+   * um segundo marcador ATIVO para o mesmo turno (Postgres 23505) — tratado como `alreadyActive: true`.
+   */
+  async scheduleExternalPayment(
+    params: ScheduleExternalPaymentParams,
+  ): Promise<ScheduleExternalPaymentResult> {
+    try {
+      const { jobId, workerId, applicationId, source, amount, scheduledFor, note } = params;
+
+      if (!(amount > 0)) {
+        return { success: false, error: 'O valor previsto deve ser maior que zero.' };
+      }
+      if (!scheduledFor) {
+        return { success: false, error: 'Informe a data prevista do pagamento.' };
+      }
+
+      // 1. Validação defensiva: turno concluído (mesmo sinal REAL de recordExternalPayment).
+      const { data: application, error: appErr } = await supabase
+        .from('applications')
+        .select('id, job_id, worker_id, company_checkin_confirmed_at, company_checkout_confirmed_at')
+        .eq('id', applicationId)
+        .maybeSingle();
+
+      if (appErr) {
+        logError('paymentRecord.scheduleExternalPayment.checkApplication', appErr);
+        return { success: false, error: 'Erro ao verificar o turno.' };
+      }
+      if (!application) {
+        return { success: false, error: 'Candidatura/turno não encontrado.' };
+      }
+      if (application.job_id !== jobId || application.worker_id !== workerId) {
+        return {
+          success: false,
+          error: 'A candidatura informada não corresponde ao turno/freela informado.',
+        };
+      }
+      if (!application.company_checkin_confirmed_at || !application.company_checkout_confirmed_at) {
+        return {
+          success: false,
+          error: 'O turno precisa estar concluído (chegada e saída confirmadas) antes de agendar o pagamento.',
+        };
+      }
+
+      // 2. Resolver a empresa dona (RLS exige company_id = empresa do auth.uid()).
+      const companyId = await getAuthCompanyId();
+
+      // 3. INSERT — nasce 'scheduled': sem paid_at, sem confirmação, sem void.
+      const { data: payment, error: insertErr } = await supabase
+        .from('shift_payments')
+        .insert({
+          job_id: jobId,
+          company_id: companyId,
+          worker_id: workerId,
+          application_id: applicationId,
+          source,
+          amount,
+          status: 'scheduled',
+          scheduled_for: scheduledFor,
+          paid_at: null,
+          note: note ?? null,
+        })
+        .select()
+        .single();
+
+      if (insertErr) {
+        if (insertErr.code === '23505') {
+          return { success: false, alreadyActive: true };
+        }
+        logError('paymentRecord.scheduleExternalPayment.insert', insertErr);
+        return { success: false, error: 'Não foi possível agendar o pagamento.' };
+      }
+
+      return { success: true, payment: payment as ShiftPayment };
+    } catch (err) {
+      logError('paymentRecord.scheduleExternalPayment', err);
+      return { success: false, error: err instanceof Error ? err.message : 'Erro inesperado.' };
+    }
+  },
+
+  /**
+   * Efetiva uma promessa (`scheduled` → `recorded`), gravando a data REAL do pagamento em
+   * `paid_at` (uma única vez — o trigger `enforce_shift_payment_immutability` congela depois).
+   * Só a empresa dona pode efetivar (RLS `sp_update_company` + trigger). NÃO altera nenhuma
+   * outra coluna material (job_id, amount, source, scheduled_for, ...) — o trigger bloqueia.
+   */
+  async effectivateScheduledPayment(
+    paymentId: string,
+    paidAt?: string | Date,
+  ): Promise<EffectivateScheduledPaymentResult> {
+    try {
+      const { data: payment, error } = await supabase
+        .from('shift_payments')
+        .update({
+          status: 'recorded',
+          paid_at: normalizePaidAt(paidAt),
+        })
+        .eq('id', paymentId)
+        .select()
+        .single();
+
+      if (error) {
+        logError('paymentRecord.effectivateScheduledPayment', error);
+        return { success: false, error: 'Não foi possível marcar o pagamento como efetivado.' };
+      }
+      return { success: true, payment: payment as ShiftPayment };
+    } catch (err) {
+      logError('paymentRecord.effectivateScheduledPayment', err);
+      return { success: false, error: err instanceof Error ? err.message : 'Erro inesperado.' };
+    }
+  },
+
+  /**
+   * Busca o marcador ATIVO ('scheduled' ou 'recorded') de um turno, se existir.
+   * Usado pela UI para decidir entre "Registrar/Agendar pagamento", "Marcar como pago" ou
+   * "Ver recibo/comprovante". O UNIQUE parcial garante no máximo 1 linha ativa por job_id.
    */
   async getPaymentByJob(jobId: string): Promise<ShiftPayment | null> {
     // G3: guarda de id falsy — evita GET shift_payments?job_id=eq.null (400).
@@ -232,7 +382,7 @@ export const PaymentRecordService = {
         .from('shift_payments')
         .select('*')
         .eq('job_id', jobId)
-        .eq('status', 'recorded')
+        .in('status', ['scheduled', 'recorded'])
         .maybeSingle();
 
       if (error) {
@@ -266,7 +416,7 @@ export const PaymentRecordService = {
         `,
         )
         .eq('job_id', jobId)
-        .eq('status', 'recorded')
+        .in('status', ['scheduled', 'recorded'])
         .maybeSingle();
 
       if (error) {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -475,19 +475,22 @@ export interface FinancialBIData {
 export type PaymentSource = 'external_pix' | 'cash' | 'other';
 
 /**
- * Estado do registro. 'voided' é totalmente imutável (correção = novo registro).
+ * Estado do registro. 'scheduled' é a promessa (data prevista, sem paid_at). 'voided' é
+ * totalmente imutável (correção = novo registro). Ver ADR-20260712 (pagamento agendado).
  */
-export type ShiftPaymentStatus = 'recorded' | 'voided';
+export type ShiftPaymentStatus = 'scheduled' | 'recorded' | 'voided';
 
 /**
  * Espelha a tabela `shift_payments` (marcador de pagamento externo por turno).
  * Registro/auditoria declaratório — NÃO move saldo, NÃO toca wallets/escrow_transactions,
  * sem RPC (Article 8 intacto). Gerado à mão conforme migration
- * `20260630000000_shift_payments.sql`.
+ * `20260630000000_shift_payments.sql` + `20260712000000_shift_payment_scheduled.sql`.
  *
  * Imutabilidade (trigger `enforce_shift_payment_immutability`):
  *  - Colunas materiais (job_id, company_id, worker_id, application_id, source, amount,
- *    paid_at, recorded_by, note, created_at) são imutáveis após o INSERT.
+ *    recorded_by, note, created_at, scheduled_for) são imutáveis após o INSERT.
+ *  - `paid_at` é NULL enquanto `scheduled`; setado UMA vez na efetivação (scheduled→recorded)
+ *    e então imutável.
  *  - `worker_confirmed_at` é one-way (NULL → timestamp).
  *  - Correção = estorno lógico (status='voided' + voided_at + void_reason).
  */
@@ -502,15 +505,17 @@ export interface ShiftPayment {
   source: PaymentSource;
   /** Valor declarado pago (BRL). Sempre > 0. */
   amount: number;
-  /** Quando o pagamento aconteceu (declarado). */
-  paid_at: string;
+  /** Data prevista do pagamento (promessa, YYYY-MM-DD) quando status='scheduled'. Material/imutável. */
+  scheduled_for: string | null;
+  /** Quando o pagamento aconteceu de fato (declarado). NULL enquanto 'scheduled'. */
+  paid_at: string | null;
   /** auth.uid() de quem registrou (empresa no v1). */
   recorded_by: string;
   /** Confirmação de recebimento pelo freela (bilateral ativo). One-way NULL→ts. Não bloqueia ciclo. */
   worker_confirmed_at: string | null;
   /** Observação livre (ex.: "pago em 2x", referência PIX). Imutável. */
   note: string | null;
-  /** recorded (ativo) | voided (estornado, imutável). */
+  /** scheduled (promessa) | recorded (efetivado/ativo) | voided (estornado, imutável). */
   status: ShiftPaymentStatus;
   voided_at: string | null;
   void_reason: string | null;

--- a/supabase/migrations/20260712000000_shift_payment_scheduled.sql
+++ b/supabase/migrations/20260712000000_shift_payment_scheduled.sql
@@ -1,0 +1,276 @@
+-- Migration: Pagamento AGENDADO por turno (modo A) — status 'scheduled' + data prevista
+-- File: supabase/migrations/20260712000000_shift_payment_scheduled.sql
+-- ADR: .harness/spec/pagamento-agendado/adr-pagamento-agendado.md
+-- Depende de: 20260630000000_shift_payments.sql (tabela-base, trigger de imutabilidade, RLS)
+-- Gate: harness-architect (auditoria financeira — mesmo SEM mover saldo).
+--
+-- ============================================================================
+-- FRONTEIRA CRÍTICA (Article 8/9/10) — INALTERADA
+-- ----------------------------------------------------------------------------
+--   Modo A continua sendo REGISTRO/AUDITORIA, NÃO liquidação. 'scheduled' é um
+--   COMPROMISSO declarado (promessa de pagar numa data prevista) — não move saldo,
+--   não chama RPC, não toca wallets/escrow_transactions. Nenhuma RPC de saldo é
+--   criada ou alterada. Article 8 intacto.
+--
+-- ============================================================================
+-- MODELO (decisão do architect — ADR §Decisão)
+-- ----------------------------------------------------------------------------
+--   Máquina de estados (mesma linha, transição in-place):
+--       scheduled ──efetivar──► recorded
+--       scheduled ──cancelar──► voided
+--       recorded  ──estornar──► voided        (fluxo legado, inalterado)
+--   'voided' é terminal/imutável (trigger já garante).
+--
+--   OPÇÃO (a) ADOTADA para o dilema `paid_at`:
+--     - `paid_at` passa a ser NULLABLE. 'scheduled' NÃO tem paid_at (ainda não pagou).
+--     - Nova coluna `scheduled_for date` = a PROMESSA (data prevista). Imutável (material).
+--     - Na EFETIVAÇÃO (scheduled→recorded), `paid_at` é setado UMA vez (NULL→data real).
+--       Depois disso é imutável de novo. O trigger libera SÓ essa transição.
+--   Rejeitada opção (b) (paid_at = scheduled_for provisório): gravaria um FATO FALSO
+--   (data futura como "data paga") e, sendo imutável, travaria a data real na efetivação.
+--
+--   Dedupe: UM marcador ATIVO por turno. UNIQUE parcial passa a cobrir
+--   status IN ('scheduled','recorded') — impede promessa + pagamento em linhas
+--   separadas para o mesmo turno. N linhas 'voided' seguem permitidas (re-agendar/re-registrar).
+--   BI (status='recorded') NÃO conta 'scheduled' como gasto — promessa ≠ liquidação. Correto.
+--
+-- DOWN (rollback): ver rodapé.
+-- ============================================================================
+
+-- =============================================
+-- 1. COLUNAS
+-- =============================================
+-- Data prevista da promessa. Material/imutável (reagendar = void + novo scheduled).
+ALTER TABLE public.shift_payments
+    ADD COLUMN IF NOT EXISTS scheduled_for date;
+
+-- paid_at deixa de ser obrigatório: 'scheduled' não tem data de pagamento ainda.
+-- (Widening seguro; linhas existentes já têm paid_at preenchido.)
+ALTER TABLE public.shift_payments
+    ALTER COLUMN paid_at DROP NOT NULL;
+
+COMMENT ON COLUMN public.shift_payments.scheduled_for IS
+    'Data PREVISTA do pagamento (promessa) quando status=scheduled. Material/imutavel — reagendar = void + novo agendamento. NULL em registros diretos (recorded sem agendamento previo).';
+COMMENT ON COLUMN public.shift_payments.paid_at IS
+    'Data DECLARADA do pagamento. NULL enquanto scheduled; setada UMA vez na efetivacao (scheduled->recorded) e entao imutavel. Carimbo de periodo do BI.';
+COMMENT ON COLUMN public.shift_payments.status IS
+    'scheduled (agendado, promessa) | recorded (efetivado/ativo) | voided (cancelado, imutavel). Correcao = void + novo registro, nunca UPDATE do valor.';
+
+-- =============================================
+-- 2. CONSTRAINTS DE ESTADO (substituem status/void checks legados)
+-- =============================================
+-- Remove os CHECKs legados que referenciam `status` mas desconhecem 'scheduled'
+-- (o status-check inline `IN ('recorded','voided')` e o shift_payments_void_consistency).
+-- Introspectivo p/ não depender do nome auto-gerado; idempotente (os novos mencionam
+-- 'scheduled' e ficam de fora do filtro).
+DO $$
+DECLARE r record;
+BEGIN
+    FOR r IN
+        SELECT conname
+        FROM pg_constraint
+        WHERE conrelid = 'public.shift_payments'::regclass
+          AND contype = 'c'
+          AND pg_get_constraintdef(oid) ILIKE '%status%'
+          AND pg_get_constraintdef(oid) NOT ILIKE '%scheduled%'
+    LOOP
+        EXECUTE format('ALTER TABLE public.shift_payments DROP CONSTRAINT %I', r.conname);
+    END LOOP;
+END $$;
+
+-- Idempotência dos nomes fixos (caso a migration rode 2x).
+ALTER TABLE public.shift_payments DROP CONSTRAINT IF EXISTS shift_payments_status_check;
+ALTER TABLE public.shift_payments DROP CONSTRAINT IF EXISTS shift_payments_state_consistency;
+ALTER TABLE public.shift_payments DROP CONSTRAINT IF EXISTS shift_payments_void_consistency;
+
+-- Domínio do status (agora com 'scheduled').
+ALTER TABLE public.shift_payments
+    ADD CONSTRAINT shift_payments_status_check
+    CHECK (status IN ('scheduled', 'recorded', 'voided'));
+
+-- Coerência por estado:
+--   scheduled → promessa: tem data prevista, SEM paid_at, SEM confirmação, SEM void.
+--   recorded  → efetivado: tem paid_at, SEM void. scheduled_for livre (pode vir de agendamento).
+--   voided    → cancelado: tem voided_at (motivo opcional). Congela o que havia.
+ALTER TABLE public.shift_payments
+    ADD CONSTRAINT shift_payments_state_consistency CHECK (
+        (status = 'scheduled'
+            AND scheduled_for       IS NOT NULL
+            AND paid_at             IS NULL
+            AND worker_confirmed_at IS NULL
+            AND voided_at           IS NULL
+            AND void_reason         IS NULL)
+        OR
+        (status = 'recorded'
+            AND paid_at   IS NOT NULL
+            AND voided_at IS NULL
+            AND void_reason IS NULL)
+        OR
+        (status = 'voided'
+            AND voided_at IS NOT NULL)
+    );
+
+-- =============================================
+-- 3. UNIQUE PARCIAL — 1 marcador ATIVO por turno (scheduled OU recorded)
+-- =============================================
+-- Substitui uq_shift_payments_job_recorded por uma versão que também barra 2 promessas
+-- e a coexistência promessa+pagamento em linhas distintas do mesmo turno.
+-- Tabela é de baixo volume (piloto) → CREATE UNIQUE INDEX simples (lock breve aceitável;
+-- se algum dia crescer, migrar p/ CONCURRENTLY fora de transação). Ver ADR §Trade-offs.
+DROP INDEX IF EXISTS public.uq_shift_payments_job_recorded;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_shift_payments_job_active
+    ON public.shift_payments (job_id)
+    WHERE status IN ('scheduled', 'recorded');
+
+-- Lookup de agendamentos por empresa/data prevista (agenda de pagamentos futuros).
+CREATE INDEX IF NOT EXISTS idx_shift_payments_company_scheduled
+    ON public.shift_payments (company_id, scheduled_for)
+    WHERE status = 'scheduled';
+
+-- =============================================
+-- 4. TRIGGER DE IMUTABILIDADE — libera SÓ a transição scheduled→recorded p/ paid_at
+--    e valida a máquina de estados. Reescreve enforce_shift_payment_immutability.
+-- =============================================
+CREATE OR REPLACE FUNCTION public.enforce_shift_payment_immutability()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_is_company BOOLEAN;
+    v_is_worker  BOOLEAN;
+BEGIN
+    -- === COLUNAS MATERIAIS SEMPRE IMUTÁVEIS (todos os papéis, inclusive service_role) ===
+    -- scheduled_for entra aqui: a PROMESSA não se reescreve (reagendar = void + novo).
+    IF NEW.id             IS DISTINCT FROM OLD.id
+       OR NEW.job_id         IS DISTINCT FROM OLD.job_id
+       OR NEW.company_id     IS DISTINCT FROM OLD.company_id
+       OR NEW.worker_id      IS DISTINCT FROM OLD.worker_id
+       OR NEW.application_id IS DISTINCT FROM OLD.application_id
+       OR NEW.source         IS DISTINCT FROM OLD.source
+       OR NEW.amount         IS DISTINCT FROM OLD.amount
+       OR NEW.recorded_by    IS DISTINCT FROM OLD.recorded_by
+       OR NEW.note           IS DISTINCT FROM OLD.note
+       OR NEW.created_at     IS DISTINCT FROM OLD.created_at
+       OR NEW.scheduled_for  IS DISTINCT FROM OLD.scheduled_for
+    THEN
+        RAISE EXCEPTION 'shift_payments: colunas materiais sao imutaveis (job_id, company_id, worker_id, application_id, source, amount, recorded_by, note, created_at, scheduled_for). Correcao = estorno logico (voided).';
+    END IF;
+
+    -- === paid_at: imutável, EXCETO a efetivacao (scheduled->recorded) que o define UMA vez ===
+    IF NEW.paid_at IS DISTINCT FROM OLD.paid_at THEN
+        IF NOT (OLD.status = 'scheduled' AND NEW.status = 'recorded'
+                AND OLD.paid_at IS NULL AND NEW.paid_at IS NOT NULL) THEN
+            RAISE EXCEPTION 'shift_payments: paid_at so pode ser definido na efetivacao (scheduled->recorded) e depois e imutavel.';
+        END IF;
+    END IF;
+
+    -- === Registro estornado é IMUTÁVEL (não re-abre, não re-confirma) ===
+    IF OLD.status = 'voided' THEN
+        RAISE EXCEPTION 'shift_payments: registro estornado (voided) e imutavel.';
+    END IF;
+
+    -- === Transições de status permitidas ===
+    IF NEW.status IS DISTINCT FROM OLD.status THEN
+        IF NOT (
+            (OLD.status = 'scheduled' AND NEW.status IN ('recorded', 'voided'))
+            OR (OLD.status = 'recorded' AND NEW.status = 'voided')
+        ) THEN
+            RAISE EXCEPTION 'shift_payments: transicao de status invalida (% -> %).', OLD.status, NEW.status;
+        END IF;
+    END IF;
+
+    -- === worker_confirmed_at é ONE-WAY (NULL → timestamp; nunca altera/limpa) ===
+    IF OLD.worker_confirmed_at IS NOT NULL
+       AND NEW.worker_confirmed_at IS DISTINCT FROM OLD.worker_confirmed_at
+    THEN
+        RAISE EXCEPTION 'shift_payments: worker_confirmed_at nao pode ser alterado apos a confirmacao.';
+    END IF;
+
+    -- === PARTIÇÃO POR PAPEL (só p/ chamadas autenticadas; service_role/trigger tem auth.uid() NULL) ===
+    IF auth.uid() IS NOT NULL THEN
+        v_is_company := EXISTS (
+            SELECT 1 FROM public.companies WHERE id = NEW.company_id AND owner_id = auth.uid()
+        );
+        v_is_worker := (NEW.worker_id = auth.uid());
+
+        IF v_is_worker AND NOT v_is_company THEN
+            -- Freela: SÓ pode setar worker_confirmed_at (num registro já 'recorded'). Nada mais muda.
+            IF NEW.status      IS DISTINCT FROM OLD.status
+               OR NEW.voided_at   IS DISTINCT FROM OLD.voided_at
+               OR NEW.void_reason IS DISTINCT FROM OLD.void_reason
+               OR NEW.paid_at     IS DISTINCT FROM OLD.paid_at
+            THEN
+                RAISE EXCEPTION 'shift_payments: freela so pode confirmar recebimento (worker_confirmed_at).';
+            END IF;
+        ELSIF v_is_company THEN
+            -- Empresa: efetiva (scheduled->recorded), cancela (->voided), estorna; NÃO toca a confirmacao do freela.
+            IF NEW.worker_confirmed_at IS DISTINCT FROM OLD.worker_confirmed_at THEN
+                RAISE EXCEPTION 'shift_payments: empresa nao pode alterar a confirmacao do freela.';
+            END IF;
+        ELSE
+            RAISE EXCEPTION 'shift_payments: usuario nao autorizado a atualizar este registro.';
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+-- Trigger já existe (BEFORE UPDATE) da migration base; CREATE OR REPLACE acima basta.
+
+-- =============================================
+-- 5. RLS — permitir INSERT 'scheduled' e as transições da empresa
+-- =============================================
+-- INSERT: empresa dona registra 'scheduled' OU 'recorded' (limpo). A coerência de
+-- cada estado é do CHECK shift_payments_state_consistency.
+DROP POLICY IF EXISTS "sp_insert_company" ON public.shift_payments;
+CREATE POLICY "sp_insert_company" ON public.shift_payments
+    FOR INSERT TO authenticated
+    WITH CHECK (
+        company_id IN (SELECT id FROM public.companies WHERE owner_id = auth.uid())
+        AND recorded_by = auth.uid()
+        AND status IN ('scheduled', 'recorded')
+        AND worker_confirmed_at IS NULL
+        AND voided_at IS NULL
+        AND void_reason IS NULL
+    );
+
+-- UPDATE (empresa): opera sobre registro ATIVO (scheduled OU recorded); pode ir a
+-- recorded (efetivar) ou voided (cancelar/estornar). Imutabilidade coluna-a-coluna é do TRIGGER.
+DROP POLICY IF EXISTS "sp_update_company" ON public.shift_payments;
+CREATE POLICY "sp_update_company" ON public.shift_payments
+    FOR UPDATE TO authenticated
+    USING (
+        company_id IN (SELECT id FROM public.companies WHERE owner_id = auth.uid())
+        AND status IN ('scheduled', 'recorded')
+    )
+    WITH CHECK (
+        company_id IN (SELECT id FROM public.companies WHERE owner_id = auth.uid())
+        AND status IN ('scheduled', 'recorded', 'voided')
+    );
+
+-- UPDATE (freela): INALTERADO — só confirma recebimento em registro 'recorded'.
+-- (sp_update_worker já restringe a status='recorded' — freela não toca 'scheduled'.)
+
+-- ============================================================================
+-- DOWN (rollback) — sem impacto em saldo/escrow (nenhuma RPC tocada):
+--   -- 1. Restaurar RLS/estado anterior:
+--   DROP INDEX IF EXISTS public.uq_shift_payments_job_active;
+--   DROP INDEX IF EXISTS public.idx_shift_payments_company_scheduled;
+--   -- (só é seguro se NÃO houver linhas status='scheduled'; efetive/estorne-as antes)
+--   DELETE FROM public.shift_payments WHERE status = 'scheduled'; -- ou migre-as
+--   CREATE UNIQUE INDEX IF NOT EXISTS uq_shift_payments_job_recorded
+--       ON public.shift_payments (job_id) WHERE status = 'recorded';
+--   ALTER TABLE public.shift_payments DROP CONSTRAINT IF EXISTS shift_payments_state_consistency;
+--   ALTER TABLE public.shift_payments DROP CONSTRAINT IF EXISTS shift_payments_status_check;
+--   ALTER TABLE public.shift_payments
+--       ADD CONSTRAINT shift_payments_status_check CHECK (status IN ('recorded','voided'));
+--   ALTER TABLE public.shift_payments
+--       ADD CONSTRAINT shift_payments_void_consistency CHECK (
+--           (status='recorded' AND voided_at IS NULL AND void_reason IS NULL)
+--           OR (status='voided' AND voided_at IS NOT NULL));
+--   ALTER TABLE public.shift_payments ALTER COLUMN paid_at SET NOT NULL; -- exige paid_at preenchido
+--   ALTER TABLE public.shift_payments DROP COLUMN IF EXISTS scheduled_for;
+--   -- 2. Reaplicar a versão anterior de enforce_shift_payment_immutability (migration base).
+-- ============================================================================

--- a/supabase/migrations/20260712000100_worker_xp_with_profile_bonus.sql
+++ b/supabase/migrations/20260712000100_worker_xp_with_profile_bonus.sql
@@ -1,0 +1,66 @@
+-- XP coerente: fonte única de verdade recompute_worker_aggregates(worker).
+-- xp = turnos_concluidos*100 + bônus de perfil (foto +50, especialidades +75).
+-- Chamada pelo trigger de conclusão E via wrapper recompute_my_aggregates (migration
+-- seguinte) quando o perfil muda. SECURITY DEFINER + search_path='' + idempotente.
+-- (Aplicada em prod via MCP; versionada aqui para não haver drift — ADR pagamento/xp.)
+
+CREATE OR REPLACE FUNCTION public.recompute_worker_aggregates(p_worker_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_count int; v_earnings numeric; v_bonus int; v_xp int;
+BEGIN
+  IF p_worker_id IS NULL THEN RETURN; END IF;
+
+  SELECT COUNT(*)::int, COALESCE(SUM(j.budget), 0)
+    INTO v_count, v_earnings
+  FROM public.applications a
+  JOIN public.jobs j ON j.id = a.job_id
+  WHERE a.worker_id = p_worker_id AND a.status = 'completed';
+
+  SELECT
+    (CASE WHEN w.avatar_url IS NOT NULL AND w.avatar_url <> '' THEN 50 ELSE 0 END)
+    + (CASE WHEN (w.primary_role IS NOT NULL AND w.primary_role <> '')
+               OR (w.roles IS NOT NULL AND jsonb_typeof(w.roles) = 'array' AND jsonb_array_length(w.roles) > 0)
+            THEN 75 ELSE 0 END)
+    INTO v_bonus
+  FROM public.workers w WHERE w.id = p_worker_id;
+
+  v_xp := v_count * 100 + COALESCE(v_bonus, 0);
+
+  UPDATE public.workers SET
+    completed_jobs_count = v_count,
+    earnings_total       = v_earnings,
+    xp                   = v_xp,
+    level                = public.worker_level_for_xp(v_xp)
+  WHERE id = p_worker_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.recompute_worker_aggregates(uuid) TO service_role;
+
+-- Trigger de conclusão delega para a função única.
+CREATE OR REPLACE FUNCTION public.update_worker_completion_aggregates()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  PERFORM public.recompute_worker_aggregates(NEW.worker_id);
+  RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+  RETURN NEW;
+END;
+$$;
+
+DO $$
+DECLARE r record;
+BEGIN
+  FOR r IN SELECT id FROM public.workers LOOP
+    PERFORM public.recompute_worker_aggregates(r.id);
+  END LOOP;
+END $$;

--- a/supabase/migrations/20260712000200_worker_xp_consolidate_and_secure.sql
+++ b/supabase/migrations/20260712000200_worker_xp_consolidate_and_secure.sql
@@ -1,0 +1,45 @@
+-- Consolida e protege o cálculo de XP/agregados do worker (review do harness-architect).
+-- (Aplicada em prod via MCP; versionada aqui para não haver drift.)
+--
+-- DOWN (rollback): não recria os triggers legados (eram buggy); reexpor recompute a
+-- authenticated NÃO é recomendado.
+
+-- 1) Remove triggers/função LEGADOS de XP. `award_xp_on_job_completion` NÃO era
+--    SECURITY DEFINER → quando a EMPRESA concluía o turno o UPDATE em workers era
+--    bloqueado pelo RLS (invoker sem permissão na linha do worker) = causa REAL de
+--    "XP/ganhos/turnos não aumentavam". E coexistindo com o recompute novo, incrementava
+--    por cima (dupla contagem). Fica só o recompute SECURITY DEFINER.
+DROP TRIGGER IF EXISTS trigger_award_xp_on_completion ON public.applications;
+DROP TRIGGER IF EXISTS trigger_award_xp_on_completion_insert ON public.applications;
+DROP FUNCTION IF EXISTS public.award_xp_on_job_completion();
+
+-- 2) Least-privilege: recompute_worker_aggregates(uuid) aceita worker arbitrário e é
+--    SECURITY DEFINER — não pode ficar exposta a PUBLIC/anon/authenticated via PostgREST.
+REVOKE EXECUTE ON FUNCTION public.recompute_worker_aggregates(uuid) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.recompute_worker_aggregates(uuid) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.recompute_worker_aggregates(uuid) FROM authenticated;
+
+-- 3) Wrapper seguro para o CLIENT: worker recomputa o PRÓPRIO XP (auth.uid()) após editar
+--    o perfil (foto/especialidades mudam o bônus). Só a própria linha.
+CREATE OR REPLACE FUNCTION public.recompute_my_aggregates()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    IF auth.uid() IS NULL THEN RETURN; END IF;
+    PERFORM public.recompute_worker_aggregates(auth.uid());
+END;
+$$;
+REVOKE EXECUTE ON FUNCTION public.recompute_my_aggregates() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.recompute_my_aggregates() TO authenticated;
+
+-- 4) Backfill de limpeza (recompute canônico apaga dupla contagem anterior).
+DO $$
+DECLARE r record;
+BEGIN
+  FOR r IN SELECT id FROM public.workers LOOP
+    PERFORM public.recompute_worker_aggregates(r.id);
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Resumo
Lote fechado via harness (architect gate → builders → security + frontend reviewers → evaluator APROVADO). Migrations aplicadas em produção via MCP Supabase e versionadas no repo.

### A. Avaliações no perfil (comentários)
- Novo `ProfileReviews`: lista as avaliações recebidas (estrelas + comentário) no perfil do **freela** (avaliações de empresas) e da **empresa** (avaliações de freelas). O motor bidirecional já publicava a nota; faltava exibir os comentários.

### B. XP/nível/ganhos que realmente sobem (bug corrigido)
- **Causa raiz:** o trigger legado `award_xp_on_job_completion` **não era `SECURITY DEFINER`** → o RLS bloqueava o `UPDATE workers` quando a **empresa** concluía o turno = XP/ganhos/turnos nunca subiam. Removido.
- Fonte única `recompute_worker_aggregates` (SECURITY DEFINER): `xp = turnos×100 + foto(50) + especialidades(75)`, nível derivado. Trigger único de conclusão + wrapper `recompute_my_aggregates()` self-scoped chamado pelo `Profile` após salvar/upload. Função de arg arbitrário revogada de `authenticated`/`public` (só `service_role`).
- Dashboard: quests honestas (email não promete XP que não concede).

### C. Pagamento agendado + comprovante de agendamento (ADR)
- `shift_payments`: status `scheduled` + `scheduled_for` + `paid_at` nullable; máquina `scheduled → recorded | voided` (trigger de imutabilidade), UNIQUE de 1 marcador ativo por turno, RLS bilateral.
- `paymentRecordService`: `scheduleExternalPayment` / `effectivateScheduledPayment`; `getReceipt`/`getPaymentByJob` passam a `.in(['scheduled','recorded'])`.
- `ReceiptView`: "Comprovante de Agendamento" (promessa, sem confirmar recebimento). `CompanyJobCandidates`: "Agendar Pagamento" + "Marcar como pago".
- **Não move saldo** (modo A — Article 8/9/10 intactos). BI conta só `recorded`.

## Verificação
- Build ✓ · Lint 0 erros · **Testes 229/229** ✓
- Security review: **APROVADO** (rls/role/financial/service_role/pii OK)
- Frontend review: **APROVADO_COM_RESSALVAS** (achados de a11y/touch-target/cor já corrigidos)
- Evaluator: **APROVADO** (cobertura do ADR completa, sem findings bloqueantes)
- Migrations já aplicadas em prod (`vrklakcbkcsonarmhqhp`) e verificadas: agregados 0 inconsistentes, RLS/triggers corretos.

## Migrations
- `20260712000000_shift_payment_scheduled.sql`
- `20260712000100_worker_xp_with_profile_bonus.sql`
- `20260712000200_worker_xp_consolidate_and_secure.sql`
- ADR: `.harness/spec/pagamento-agendado/adr-pagamento-agendado.md`