### PR TITLE
feat: configurações da conta, próximo turno, cancelar turno e sino de mensagens

### DIFF
--- a/.harness/memory-bank/architecture.md
+++ b/.harness/memory-bank/architecture.md
@@ -81,6 +81,32 @@ trigger `auto_reserve_escrow_on_hire` pula a reserva no aceite de convite (ADR-2
 legado** (candidatura → hired) ainda reserva no aceite (modelo prepago original, inalterado). O pagamento do
 push é o **Slice 2: postpago** (cartão on-file + captura na conclusão, sem depósito antecipado).
 
+## Cancelamento de turno pelo worker (Slice 5: notificação obrigatória)
+
+Worker pode cancelar turno após aceite (status `hired` | `in_progress` → `cancelled`). A ação dispara automaticamente
+um trigger SECURITY DEFINER (`trg_notify_company_on_worker_cancel`) que insere uma notificação (type='status_change')
+para o **dono da empresa** — nenhum lado pode suprimir a notificação. **Landmark pattern:** notificação à contraparte
+que RLS não permite inserir direto (`applications` é worker-owned; company precisa saber via sistema automático, não
+query puxada).
+
+**Máquina de estados:** cancelamento é transição irreversível: `hired` → `cancelled`, `in_progress` → `cancelled`.
+Worker pode cancelar; empresa NÃO pode forçar cancelamento.
+
+**Trigger `trg_notify_company_on_worker_cancel` (SECURITY DEFINER, search_path=''):**
+```
+AFTER UPDATE ON applications
+WHEN (NEW.status='cancelled' AND OLD.status IN ('hired','in_progress'))
+→ INSERT INTO notifications: user_id = (SELECT company_id FROM jobs WHERE id=NEW.job_id),
+    type='status_change', title='Turno cancelado por freelancer', 
+    link='/company/candidatos?job_id=<job_id>'
+```
+
+**Princípio:** saldo intacto (Article 8) — refund de escrow (Slice 1 prepago) é manual, disparado por empresa via
+`refundEscrow` se desejado.
+
+**Fluxo complementar (Slice 1):** cancelamento não toca saldo; empresa se quiser devolver a reserva ao próprio saldo
+chama `refundEscrow(jobId, workerUserId, 'worker_cancelled')` (ADR-20260714-cancelamento-freela aguarda).
+
 ## Modelo de pagamento (carteira central + escrow + postpago Slice 2)
 
 > ⚠️ **REVISADO por ADR-20260630-pagamento-opcional-piloto (2026-06-30).** No piloto o pagamento pelo Worki é

--- a/.harness/memory-bank/tech.md
+++ b/.harness/memory-bank/tech.md
@@ -93,6 +93,8 @@
   - **`companies.default_briefing`** (20260710000100) — texto de briefing padrão do negócio (pré-preenche turno). Simples, NÃO toca saldo.
 - **Mudanças em shift_payments (Slice 3, modo A + agendamento):**
   - **20260712000000** — novo status `scheduled`, coluna `scheduled_for date` (promessa imutável), `paid_at` agora nullable (NULL em scheduled, setado na efetivação). UNIQUE parcial `(job_id) WHERE status IN ('scheduled','recorded')`. Trigger reescrito para liberar SÓ transição `scheduled→recorded` de `paid_at`. Máquina de estados: `scheduled→recorded|voided`, `recorded→voided`. ZERO impacto em saldo/escrow.
+- **Notificação de cancelamento pelo worker (Slice 5):**
+  - **20260714000000** — novo trigger `trg_notify_company_on_worker_cancel` (SECURITY DEFINER, search_path='') em `applications`. AFTER UPDATE WHEN (NEW.status='cancelled' AND OLD.status IN ('hired','in_progress')) → insere notificação para dono da empresa (type='status_change'). **Landmark:** notificação automática à contraparte que RLS bloqueia inserir direto.
 - **Policy adicional (20260623000200):**
   - **`notifications` INSERT** — `WITH CHECK (auth.uid() = user_id)` destrava alerta in-app inserido pelo cliente (`spendLimitService.evaluateSpendAlert`).
 - Tabelas principais: `workers`, `companies`, `jobs`, `applications`, `wallets`, `wallet_transactions`,

--- a/.harness/spec/freela-cancela-turno/adr-freela-cancela-turno.md
+++ b/.harness/spec/freela-cancela-turno/adr-freela-cancela-turno.md
@@ -1,0 +1,88 @@
+# ADR-20260714 — Freela cancela turno agendado (aceito) → notifica a empresa
+
+## Status
+ACEITO
+
+## Contexto
+O freela precisa poder cancelar um turno que **já aceitou** (`applications.status` em
+`'hired'` ou `'in_progress'`) e a empresa precisa **saber** para reabrir o slot / convidar outro
+freela do Elenco.
+
+Fatos do banco (verificados via MCP):
+- A **transição já é permitida**: o trigger `validate_application_update` (SECURITY DEFINER) NÃO
+  bloqueia `status='cancelled'`; a RLS `"Workers can update own applications"`
+  (USING `worker_id = auth.uid()`) deixa o freela atualizar a própria linha. Logo o freela **já
+  consegue** setar `'cancelled'` hoje. Nenhuma migration de transição é necessária.
+- **NÃO existe** trigger de notificação em `applications`.
+- A RLS de INSERT de `notifications` exige `auth.uid() = user_id` OU contraparte de
+  `team_connections` aceita. O freela **poderia** inserir via cláusula de contraparte, mas isso é
+  frágil (depende de vínculo aceito e de o client fazer o INSERT correto). O canal robusto é um
+  **trigger no servidor**, igual ao padrão já usado em `notify_new_message` e no fluxo push.
+- Invariante confirmada: `jobs.company_id = auth.uid()` do dono da empresa
+  (migration `20260622000300`, linha 57; e `notify_new_message` usa `jobs.company_id` direto como
+  `notifications.user_id`). Não é preciso join com `companies`.
+- Push/modo A (piloto): turnos push **não reservam escrow** (o trigger `auto_reserve_escrow` pula
+  convites). Só o **fluxo pull-legado prepago** reserva no aceite.
+
+## Decisão
+
+### Estados a partir dos quais o freela cancela
+`OLD.status IN ('hired', 'in_progress')` → `NEW.status = 'cancelled'`. Só essa transição dispara a
+notificação. Outras transições (aceite de convite, conclusão, etc.) são ignoradas pela cláusula
+`WHEN` do trigger.
+
+### Notificação (o que ESTA migration entrega)
+Trigger **AFTER UPDATE** em `public.applications`, `SECURITY DEFINER`, `SET search_path = ''`,
+`WHEN (NEW.status = 'cancelled' AND OLD.status IN ('hired','in_progress'))`, que INSERE **uma**
+notificação para `jobs.company_id` (dono da empresa):
+- `type = 'status_change'` (valor válido no CHECK de `notifications.type`).
+- `title = 'Turno cancelado pelo freela'`.
+- `message = '<nome do freela> cancelou o turno "<título da vaga>".'`
+- `link = '/company/jobs/<job_id>/candidates'` (rota real da empresa).
+- Resiliente: `EXCEPTION WHEN OTHERS THEN RETURN NEW` — falha de notificação **nunca** bloqueia o
+  cancelamento do freela (mesmo padrão de `notify_new_message`).
+- Idempotência não é crítica: a cláusula `WHEN` garante 1 disparo por transição de cancelamento.
+
+### Reabertura do slot — NADA a fazer no banco
+O `job` continua com seu status atual (ex.: `'open'`); a empresa convida outro freela do Elenco. A
+única unique relevante em `applications` é `(job_id, worker_id)`, que só impede **re-convidar o
+mesmo** worker — comportamento desejado. Não há constraint que impeça convidar **outro** freela
+após o cancelamento. Nenhuma alteração de schema é necessária para reabrir o slot.
+
+### Escrow — NÃO tocar saldo (Article 8)
+- **Turnos push (modo A, default do piloto):** não têm escrow; o cancelamento **só notifica**.
+- **Fluxo pull-legado prepago:** se `OLD` tinha escrow `kind='prepaid'` em `status='reserved'`, o
+  cancelamento pelo freela **deixa o valor travado**. Esta migration **NÃO** faz refund: mover saldo
+  exige RPC atômica (`refund_escrow`) e decisão de quem arca com o cancelamento (freela vs. empresa),
+  o que é escopo maior. O trigger de notificação **não move saldo**. O refund permanece a cargo do
+  **fluxo de estorno existente da empresa** (`refund_escrow`), disparado manualmente.
+  - **Risco documentado:** um refund automático dentro deste trigger violaria Article 8 (RPC de saldo
+    embutida em trigger de notificação, sem idempotência/reference_id estável e sem controle de quem
+    perde o valor). Fica explicitamente **fora** desta entrega e recomendado como follow-up separado
+    (edge function / ação da empresa) caso o piloto passe a usar pull-prepago com cancelamento.
+
+## Consequências
+### Positivas
+- Empresa é notificada em tempo real (Realtime já escuta `notifications`) sem client privilegiado.
+- Superfície mínima: uma função + um trigger; zero mudança de saldo, zero risco financeiro.
+- Reversível: `DROP TRIGGER` / `DROP FUNCTION` limpos.
+
+### Negativas / Trade-offs
+- Para o fluxo pull-prepago (não-piloto), o escrow reservado fica preso até a empresa estornar
+  manualmente. Aceitável no piloto (push/modo A não usa escrow); follow-up registrado.
+- Notificação best-effort: se o INSERT falhar (ex.: mudança futura de schema), o cancelamento
+  ocorre mesmo assim e a empresa não é avisada por esse canal (mitigado pelo bloco EXCEPTION +
+  observabilidade).
+
+## Alternativas rejeitadas
+- **INSERT de notificação pelo client (via cláusula de contraparte da RLS):** frágil, depende de
+  `team_connections` aceita e de o MyJobs fazer o INSERT — o servidor é a fonte da verdade.
+- **Refund automático no trigger:** viola Article 8 (RPC de saldo fora de contexto atômico
+  controlado) e mistura auditoria de notificação com liquidação financeira.
+- **Novo status/tabela de cancelamento:** desnecessário; `'cancelled'` já é aceito.
+
+## Referências
+- Migration: `supabase/migrations/20260714000000_notify_company_on_worker_cancel.sql`
+- Padrões: `20260314000005_final_fix_message_trigger.sql`,
+  `20260702000000_notifications_notify_counterpart.sql`
+- Invariante `jobs.company_id = auth.uid()`: `20260622000300_invite_accept_hired_transition.sql`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/).
 
 ### Adicionado
 
+#### Cancelamento de Turno Agendado (2026-07-14)
+
+**Freelancer:**
+- Botão "Cancelar turno" na aba Agendados permite cancelar um turno que já foi aceito
+- Empresa recebe notificação automática do cancelamento e o turno volta a ficar disponível
+
+### Corrigido
+
+#### Perfil, Home e Notificações (2026-07-14)
+
+**Freelancer e Empresa:**
+- **Perfil:** seções de Segurança (trocar senha), Sair e Zona de Perigo agora ficam ocultas atrás do botão "Configurações da Conta" (reduz poluição visual e risco de clique acidental)
+
+**Freelancer:**
+- **Próximo Turno na home:** exibe corretamente o próximo turno agendado (antes mostrava "Invalid Date")
+- **Status do turno em andamento:** destaca quando o freelancer está no turno agora
+- **Sem turnos:** exibe "Sem próximos turnos marcados" quando não há agendamento
+- **Notificações de mensagem:** o sino limpa as notificações de mensagem ao abrir a conversa (antes ficavam presas)
+
+### Adicionado
+
 #### Agregados e Histórico Detalhado do Freela (2026-07-12)
 
 **Freela:**

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -15,7 +15,7 @@ interface NextJobData {
     status: string;
     job: {
         title: string;
-        date: string;
+        start_date: string;
         start_time: string;
         company: { name: string };
     };
@@ -61,10 +61,29 @@ export default function Dashboard() {
                 .from('applications')
                 .select('status, job:jobs(*, company:companies(name))')
                 .eq('worker_id', user.id)
-                .in('status', ['approved', 'scheduled', 'hired', 'in_progress'])
-                .limit(1)
-                .maybeSingle();
-            return data as unknown as NextJobData;
+                .in('status', ['hired', 'in_progress']);
+
+            const rows = (data as unknown as NextJobData[] | null) ?? [];
+            if (rows.length === 0) return null;
+
+            // Turno em andamento tem prioridade sobre qualquer "próximo" agendado.
+            const inProgress = rows.find(r => r.status === 'in_progress');
+            if (inProgress) return inProgress;
+
+            // PostgREST não ordena de forma confiável por coluna de embed (job.start_date),
+            // então ordenamos no cliente e ignoramos linhas sem start_date válido.
+            const today = new Date();
+            today.setHours(0, 0, 0, 0);
+
+            const upcoming = rows
+                .filter(r => r.status === 'hired')
+                .filter(r => {
+                    const d = r.job?.start_date ? new Date(r.job.start_date) : null;
+                    return d instanceof Date && !isNaN(d.getTime()) && d >= today;
+                })
+                .sort((a, b) => new Date(a.job.start_date).getTime() - new Date(b.job.start_date).getTime());
+
+            return upcoming[0] ?? null;
         },
         enabled: !!worker
     });
@@ -183,14 +202,24 @@ export default function Dashboard() {
                 {/* Próximo Turno */}
                 <div className="bg-black text-white p-6 rounded-2xl border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,0.3)]">
                     <h3 className="text-lg font-black uppercase mb-4 flex items-center gap-2">
-                        <Clock size={18} className="text-primary" /> Próximo Turno
+                        <Clock size={18} className="text-primary" /> {nextJob?.status === 'in_progress' ? 'Você está no turno agora' : 'Próximo Turno'}
                     </h3>
                     {nextJob ? (
                         <>
                             <div className="bg-white/10 p-4 rounded-xl border border-white/10 mb-4">
                                 <div className="flex justify-between items-start mb-2">
-                                    <span className="text-2xl font-black">{new Date(nextJob.job.date).getDate()} {new Date(nextJob.job.date).toLocaleString('default', { month: 'short' }).toUpperCase()}</span>
-                                    <span className="bg-primary text-black text-[10px] font-bold px-2 py-0.5 rounded-full uppercase">{nextJob.status}</span>
+                                    {(() => {
+                                        const parsedDate = nextJob.job?.start_date ? new Date(nextJob.job.start_date) : null;
+                                        const hasValidDate = parsedDate instanceof Date && !isNaN(parsedDate.getTime());
+                                        return hasValidDate ? (
+                                            <span className="text-2xl font-black">{parsedDate!.getDate()} {parsedDate!.toLocaleString('default', { month: 'short' }).toUpperCase()}</span>
+                                        ) : (
+                                            <span className="text-sm font-black text-gray-400 uppercase">Data indefinida</span>
+                                        );
+                                    })()}
+                                    <span className="bg-primary text-black text-[10px] font-bold px-2 py-0.5 rounded-full uppercase">
+                                        {nextJob.status === 'in_progress' ? 'Em andamento' : 'Agendado'}
+                                    </span>
                                 </div>
                                 <p className="font-bold text-lg leading-tight">{nextJob.job.title}</p>
                                 <p className="text-sm text-gray-400">{nextJob.job.start_time || 'Horário indefinido'}</p>
@@ -201,7 +230,7 @@ export default function Dashboard() {
                         </>
                     ) : (
                         <div className="text-center py-6 text-gray-500 font-bold bg-white/5 rounded-xl border border-white/5">
-                            Nenhum turno agendado.
+                            Sem próximos turnos marcados.
                         </div>
                     )}
                 </div>

--- a/frontend/src/pages/Messages.tsx
+++ b/frontend/src/pages/Messages.tsx
@@ -58,6 +58,22 @@ export default function Messages() {
             .eq('conversationid', conversationId)
             .neq('senderid', userId)
             .is('read_at', null);
+
+        // Também limpa as notificações de mensagem do usuário (sino) — best-effort,
+        // não deve quebrar o fluxo de leitura da conversa se falhar.
+        try {
+            const { error: notifError } = await supabase
+                .from('notifications')
+                .update({ read_at: new Date().toISOString() })
+                .eq('user_id', userId)
+                .eq('type', 'message')
+                .is('read_at', null);
+            if (notifError) {
+                logError('Messages.markAsRead.notifications', notifError);
+            }
+        } catch (err) {
+            logError('Messages.markAsRead.notifications', err);
+        }
     };
 
     // Scroll to bottom when messages change

--- a/frontend/src/pages/MyJobs.tsx
+++ b/frontend/src/pages/MyJobs.tsx
@@ -95,6 +95,9 @@ export default function MyJobs() {
     const [actionLoading, setActionLoading] = useState<string | null>(null);
     // Detalhe do turno no histórico (chegada/saída, valor, avaliação, foto).
     const [detailJob, setDetailJob] = useState<JobApplication | null>(null);
+    // Confirmação de cancelamento de turno agendado (aba "Agendados").
+    const [cancelJob, setCancelJob] = useState<JobApplication | null>(null);
+    const [cancelLoading, setCancelLoading] = useState(false);
     // Avaliação obrigatória: abre automática 1x por visita para o 1º turno pago sem avaliação.
     const autoRatePrompted = useRef(false);
     const { addToast } = useToast();
@@ -295,6 +298,30 @@ export default function MyJobs() {
             addToast('Erro ao fazer check-out. Tente novamente.', 'error');
         } finally {
             setActionLoading(null);
+        }
+    };
+
+    // Cancelamento de turno agendado ('hired') pelo freela. A empresa é avisada
+    // automaticamente via trigger no banco (trg_notify_company_on_worker_cancel).
+    const handleCancelShift = async () => {
+        if (!cancelJob) return;
+        setCancelLoading(true);
+        try {
+            const { error } = await supabase
+                .from('applications')
+                .update({ status: 'cancelled' })
+                .eq('id', cancelJob.id);
+
+            if (error) throw error;
+
+            setCancelJob(null);
+            addToast('Turno cancelado. A empresa foi avisada.', 'success');
+            await fetchJobs();
+        } catch (err) {
+            logError('Error cancelling shift:', err);
+            addToast('Erro ao cancelar turno. Tente novamente.', 'error');
+        } finally {
+            setCancelLoading(false);
         }
     };
 
@@ -644,7 +671,15 @@ export default function MyJobs() {
                                 <span className="block text-sm font-bold text-gray-400 uppercase">Receber</span>
                                 <span className="block text-2xl font-black text-primary">R$ {job.pay}</span>
                             </div>
-                            <span className="bg-green-100 text-green-700 text-xs font-black uppercase px-3 py-1 rounded-full border border-green-200">Contratado</span>
+                            <div className="flex flex-col items-end gap-2">
+                                <span className="bg-green-100 text-green-700 text-xs font-black uppercase px-3 py-1 rounded-full border border-green-200">Contratado</span>
+                                <button
+                                    onClick={() => setCancelJob(job)}
+                                    className="text-xs font-black text-red-600 hover:text-white hover:bg-red-500 uppercase px-3 py-2 rounded-xl border-2 border-red-200 hover:border-red-500 transition-colors flex items-center gap-1 min-h-[44px]"
+                                >
+                                    <XCircle size={14} /> Cancelar turno
+                                </button>
+                            </div>
                         </div>
                     </div>
                 ))}
@@ -788,6 +823,51 @@ export default function MyJobs() {
                                 </button>
                             )
                         )}
+                    </div>
+                </div>
+            )}
+
+            {/* Confirmação de cancelamento de turno agendado */}
+            {cancelJob && (
+                <div
+                    className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 animate-in fade-in duration-200"
+                    onClick={(e) => { if (e.target === e.currentTarget && !cancelLoading) setCancelJob(null); }}
+                >
+                    <div className="bg-white rounded-2xl border-2 border-black shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] w-full max-w-sm p-6">
+                        <div className="flex items-start gap-3 mb-4">
+                            <div className="w-10 h-10 rounded-xl border-2 border-black bg-red-100 flex items-center justify-center flex-shrink-0">
+                                <XCircle size={20} className="text-red-600" />
+                            </div>
+                            <div>
+                                <h3 className="text-lg font-black uppercase tracking-tight">Cancelar este turno?</h3>
+                                <p className="text-sm font-bold text-gray-500 mt-1">
+                                    A empresa será avisada e o turno volta a ficar disponível.
+                                </p>
+                            </div>
+                        </div>
+
+                        <div className="bg-gray-50 border-2 border-gray-100 rounded-xl p-3 mb-5">
+                            <p className="font-black text-sm uppercase">{cancelJob.title}</p>
+                            <p className="text-xs font-bold text-gray-500">{cancelJob.date} • {cancelJob.time}</p>
+                        </div>
+
+                        <div className="flex gap-3">
+                            <button
+                                onClick={() => setCancelJob(null)}
+                                disabled={cancelLoading}
+                                className="flex-1 bg-white hover:bg-gray-50 text-gray-700 px-4 py-3 rounded-xl font-black uppercase border-2 border-gray-300 transition-colors disabled:opacity-50 min-h-[44px]"
+                            >
+                                Voltar
+                            </button>
+                            <button
+                                onClick={handleCancelShift}
+                                disabled={cancelLoading}
+                                className="flex-1 bg-red-500 hover:bg-black text-white px-4 py-3 rounded-xl font-black uppercase flex items-center justify-center gap-2 transition-colors disabled:opacity-50 min-h-[44px]"
+                            >
+                                {cancelLoading ? <Loader2 className="animate-spin" size={18} /> : <XCircle size={18} />}
+                                Cancelar turno
+                            </button>
+                        </div>
                     </div>
                 </div>
             )}

--- a/frontend/src/pages/Profile.test.tsx
+++ b/frontend/src/pages/Profile.test.tsx
@@ -103,6 +103,13 @@ function renderComponent() {
   )
 }
 
+// Segurança, Sessão e Zona de Perigo ficam ocultas por padrão atrás do botão
+// "Configurações da Conta" — os testes que interagem com essas seções
+// precisam abri-las primeiro.
+function openAccountSettings() {
+  fireEvent.click(screen.getByRole('button', { name: /configura(ç|c)ões da conta/i }))
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
 })
@@ -124,6 +131,7 @@ describe('Profile — modal de exclusão de conta', () => {
       expect(screen.getByText('Maria Silva')).toBeInTheDocument()
     })
 
+    openAccountSettings()
     fireEvent.click(screen.getByText('Excluir minha conta'))
 
     const confirmarBtn = screen.getByText('Confirmar Exclusão')
@@ -138,6 +146,7 @@ describe('Profile — modal de exclusão de conta', () => {
       expect(screen.getByText('Maria Silva')).toBeInTheDocument()
     })
 
+    openAccountSettings()
     fireEvent.click(screen.getByText('Excluir minha conta'))
 
     const input = screen.getByPlaceholderText('EXCLUIR')
@@ -159,6 +168,7 @@ describe('Profile — modal de exclusão de conta', () => {
       expect(screen.getByText('Maria Silva')).toBeInTheDocument()
     })
 
+    openAccountSettings()
     fireEvent.click(screen.getByText('Excluir minha conta'))
 
     const input = screen.getByPlaceholderText('EXCLUIR')
@@ -184,6 +194,7 @@ describe('Profile — modal de exclusão de conta', () => {
       expect(screen.getByText('Maria Silva')).toBeInTheDocument()
     })
 
+    openAccountSettings()
     fireEvent.click(screen.getByText('Excluir minha conta'))
 
     const input = screen.getByPlaceholderText('EXCLUIR')
@@ -205,6 +216,7 @@ describe('Profile - Seguranca', () => {
     setupMocks()
     renderComponent()
     await waitFor(() => { expect(screen.getByText('Maria Silva')).toBeInTheDocument() })
+    openAccountSettings()
     expect(screen.getByRole('button', { name: /alterar senha/i })).toBeDisabled()
   })
 })
@@ -220,6 +232,7 @@ describe('Profile — logout (R3/R4)', () => {
     renderComponent()
     await waitFor(() => { expect(screen.getByText('Maria Silva')).toBeInTheDocument() })
 
+    openAccountSettings()
     fireEvent.click(screen.getByRole('button', { name: /sair da conta/i }))
 
     await waitFor(() => {
@@ -236,6 +249,7 @@ describe('Profile — logout (R3/R4)', () => {
     renderComponent()
     await waitFor(() => { expect(screen.getByText('Maria Silva')).toBeInTheDocument() })
 
+    openAccountSettings()
     fireEvent.click(screen.getByRole('button', { name: /sair da conta/i }))
 
     await waitFor(() => {

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,7 +1,7 @@
 
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { supabase } from '../lib/supabase';
-import { User, MapPin, Briefcase, Star, ShieldCheck, Phone, Edit2, Loader2, Award, Save, X, Camera, CreditCard, Lock, QrCode, Copy, Check, LogOut, Link2 } from 'lucide-react';
+import { User, MapPin, Briefcase, Star, ShieldCheck, Phone, Edit2, Loader2, Award, Save, X, Camera, CreditCard, Lock, QrCode, Copy, Check, LogOut, Link2, Settings } from 'lucide-react';
 import ProfileReviews from '../components/ProfileReviews';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
@@ -123,6 +123,9 @@ export default function Profile() {
     const [workerId, setWorkerId] = useState<string | null>(null);
     const [linkCopied, setLinkCopied] = useState(false);
     const [idCopied, setIdCopied] = useState(false);
+
+    // Seções sensíveis (Segurança, Sessão, Zona de Perigo) ficam ocultas por padrão
+    const [showAccountSettings, setShowAccountSettings] = useState(false);
 
     const handleCopyMyLink = useCallback(async () => {
         if (!workerId) return;
@@ -678,59 +681,6 @@ export default function Profile() {
 
             </div>
 
-            {/* Secao Seguranca */}
-            <div className="border-t-2 border-gray-200 pt-8 mt-8">
-                <h3 className="text-xl font-black uppercase mb-4 flex items-center gap-2">
-                    <Lock size={20} /> Seguranca
-                </h3>
-
-                <div className="mb-4">
-                    <label htmlFor="new-password" className="block text-sm font-bold uppercase mb-1">Nova Senha</label>
-                    <input
-                        id="new-password"
-                        type="password"
-                        value={newPassword}
-                        onChange={e => { setNewPassword(e.target.value); setPasswordError(null); }}
-                        className="w-full border-2 border-gray-200 rounded-xl p-3 focus:border-black outline-none font-medium"
-                    />
-                    {newPassword && (() => {
-                        const strength = getPasswordStrength(newPassword);
-                        return (
-                            <div className="mt-1">
-                                <div className="h-1.5 bg-gray-200 rounded-full overflow-hidden">
-                                    <div className={`h-full ${strength.color} rounded-full ${strength.width}`} />
-                                </div>
-                                <p className="text-xs text-gray-500 mt-1">Forca: {strength.label}</p>
-                            </div>
-                        );
-                    })()}
-                </div>
-
-                <div className="mb-2">
-                    <label htmlFor="confirm-password" className="block text-sm font-bold uppercase mb-1">Confirmar Nova Senha</label>
-                    <input
-                        id="confirm-password"
-                        type="password"
-                        value={confirmPassword}
-                        onChange={e => { setConfirmPassword(e.target.value); setPasswordError(null); }}
-                        className="w-full border-2 border-gray-200 rounded-xl p-3 focus:border-black outline-none font-medium"
-                    />
-                </div>
-
-                {passwordError && (
-                    <p className="text-red-600 text-sm font-bold mb-4">{passwordError}</p>
-                )}
-
-                <button
-                    onClick={handleChangePassword}
-                    disabled={!newPassword || !confirmPassword || passwordLoading}
-                    className="bg-black text-white px-6 py-3 rounded-xl font-black uppercase hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-                >
-                    {passwordLoading ? <Loader2 className="animate-spin" size={18} /> : null}
-                    Alterar Senha
-                </button>
-            </div>
-
             {/* Meu link de perfil — seção top-level (G2). Espelha a seção equivalente
                 do CompanyProfile.tsx. O botão dentro do modal QR foi mantido também. */}
             <div className="border-t-2 border-gray-200 pt-8 mt-8">
@@ -751,33 +701,102 @@ export default function Profile() {
                 </button>
             </div>
 
-            {/* Sessão — logout avulso, acessível no mobile via item "Perfil" do BottomNav (R3) */}
+            {/* Botão de toggle para as seções sensíveis (Segurança, Sessão, Zona de Perigo) */}
             <div className="border-t-2 border-gray-200 pt-8 mt-8">
-                <h3 className="text-xl font-black uppercase mb-4 flex items-center gap-2">
-                    <LogOut size={20} /> Sessão
-                </h3>
-                <p className="text-sm text-gray-600 mb-4">Sair da sua conta neste dispositivo.</p>
                 <button
-                    onClick={handleLogout}
-                    disabled={loggingOut}
-                    className="flex items-center justify-center gap-2 bg-black text-white px-6 py-3 rounded-xl font-black uppercase hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    onClick={() => setShowAccountSettings(prev => !prev)}
+                    aria-expanded={showAccountSettings}
+                    className="flex items-center justify-center gap-2 bg-white text-black px-6 py-3 rounded-xl font-black uppercase border-2 border-black hover:bg-black hover:text-white transition-colors"
                 >
-                    {loggingOut ? <Loader2 size={18} className="animate-spin" /> : <LogOut size={18} />}
-                    {loggingOut ? 'Saindo...' : 'Sair da conta'}
+                    <Settings size={18} />
+                    {showAccountSettings ? 'Ocultar Configurações da Conta' : 'Configurações da Conta'}
                 </button>
             </div>
 
-            {/* Zona de Perigo */}
-            <div className="border-t-2 border-red-200 pt-8 mt-8">
-                <h3 className="text-red-600 font-black uppercase text-lg mb-4">Zona de Perigo</h3>
-                <p className="text-sm text-gray-600 mb-4">A exclusão da sua conta é irreversível. Todos os seus dados pessoais serão anonimizados.</p>
-                <button
-                    onClick={() => setDeleteModalOpen(true)}
-                    className="border-2 border-red-500 text-red-500 bg-white hover:bg-red-50 font-bold uppercase px-4 py-2 rounded-xl transition-colors"
-                >
-                    Excluir minha conta
-                </button>
-            </div>
+            {showAccountSettings && (
+                <>
+                    {/* Secao Seguranca */}
+                    <div className="border-t-2 border-gray-200 pt-8 mt-8">
+                        <h3 className="text-xl font-black uppercase mb-4 flex items-center gap-2">
+                            <Lock size={20} /> Seguranca
+                        </h3>
+
+                        <div className="mb-4">
+                            <label htmlFor="new-password" className="block text-sm font-bold uppercase mb-1">Nova Senha</label>
+                            <input
+                                id="new-password"
+                                type="password"
+                                value={newPassword}
+                                onChange={e => { setNewPassword(e.target.value); setPasswordError(null); }}
+                                className="w-full border-2 border-gray-200 rounded-xl p-3 focus:border-black outline-none font-medium"
+                            />
+                            {newPassword && (() => {
+                                const strength = getPasswordStrength(newPassword);
+                                return (
+                                    <div className="mt-1">
+                                        <div className="h-1.5 bg-gray-200 rounded-full overflow-hidden">
+                                            <div className={`h-full ${strength.color} rounded-full ${strength.width}`} />
+                                        </div>
+                                        <p className="text-xs text-gray-500 mt-1">Forca: {strength.label}</p>
+                                    </div>
+                                );
+                            })()}
+                        </div>
+
+                        <div className="mb-2">
+                            <label htmlFor="confirm-password" className="block text-sm font-bold uppercase mb-1">Confirmar Nova Senha</label>
+                            <input
+                                id="confirm-password"
+                                type="password"
+                                value={confirmPassword}
+                                onChange={e => { setConfirmPassword(e.target.value); setPasswordError(null); }}
+                                className="w-full border-2 border-gray-200 rounded-xl p-3 focus:border-black outline-none font-medium"
+                            />
+                        </div>
+
+                        {passwordError && (
+                            <p className="text-red-600 text-sm font-bold mb-4">{passwordError}</p>
+                        )}
+
+                        <button
+                            onClick={handleChangePassword}
+                            disabled={!newPassword || !confirmPassword || passwordLoading}
+                            className="bg-black text-white px-6 py-3 rounded-xl font-black uppercase hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                        >
+                            {passwordLoading ? <Loader2 className="animate-spin" size={18} /> : null}
+                            Alterar Senha
+                        </button>
+                    </div>
+
+                    {/* Sessão — logout avulso, acessível no mobile via item "Perfil" do BottomNav (R3) */}
+                    <div className="border-t-2 border-gray-200 pt-8 mt-8">
+                        <h3 className="text-xl font-black uppercase mb-4 flex items-center gap-2">
+                            <LogOut size={20} /> Sessão
+                        </h3>
+                        <p className="text-sm text-gray-600 mb-4">Sair da sua conta neste dispositivo.</p>
+                        <button
+                            onClick={handleLogout}
+                            disabled={loggingOut}
+                            className="flex items-center justify-center gap-2 bg-black text-white px-6 py-3 rounded-xl font-black uppercase hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            {loggingOut ? <Loader2 size={18} className="animate-spin" /> : <LogOut size={18} />}
+                            {loggingOut ? 'Saindo...' : 'Sair da conta'}
+                        </button>
+                    </div>
+
+                    {/* Zona de Perigo */}
+                    <div className="border-t-2 border-red-200 pt-8 mt-8">
+                        <h3 className="text-red-600 font-black uppercase text-lg mb-4">Zona de Perigo</h3>
+                        <p className="text-sm text-gray-600 mb-4">A exclusão da sua conta é irreversível. Todos os seus dados pessoais serão anonimizados.</p>
+                        <button
+                            onClick={() => setDeleteModalOpen(true)}
+                            className="border-2 border-red-500 text-red-500 bg-white hover:bg-red-50 font-bold uppercase px-4 py-2 rounded-xl transition-colors"
+                        >
+                            Excluir minha conta
+                        </button>
+                    </div>
+                </>
+            )}
 
         </div>
 

--- a/frontend/src/pages/company/CompanyProfile.tsx
+++ b/frontend/src/pages/company/CompanyProfile.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Building2, MapPin, Globe, Mail, Save, Camera, Loader2, Star, LayoutDashboard, Pencil, Lock, LogOut, Link2, Copy, Check, ClipboardList } from 'lucide-react';
+import { Building2, MapPin, Globe, Mail, Save, Camera, Loader2, Star, LayoutDashboard, Pencil, Lock, LogOut, Link2, Copy, Check, ClipboardList, Settings } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
 import { useAuth } from '../../contexts/AuthContext';
 import { useToast } from '../../contexts/ToastContext';
@@ -40,6 +40,8 @@ export default function CompanyProfile() {
     // freela) para ser encontrada/adicionada por quem abrir (InviteAccept →
     // addToTeamByToken). Espelha o "meu link" do worker em Profile.tsx.
     const [linkCopied, setLinkCopied] = useState(false);
+    // Seções sensíveis (Segurança, Sessão, Zona de Perigo) ficam ocultas por padrão
+    const [showAccountSettings, setShowAccountSettings] = useState(false);
     const [company, setCompany] = useState<Company>({
         name: '',
         industry: '',
@@ -641,59 +643,6 @@ export default function CompanyProfile() {
             {/* Avaliações recebidas de freelas */}
             {userId && <ProfileReviews reviewedId={userId} reviewerRole="worker" />}
 
-            {/* Secao Seguranca */}
-            <div className="mt-8 bg-white border-2 border-black rounded-2xl p-6 sm:p-8 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
-                <h3 className="text-xl font-black uppercase mb-4 flex items-center gap-2">
-                    <Lock size={20} /> Seguranca
-                </h3>
-
-                <div className="mb-4">
-                    <label htmlFor="new-password" className="block text-sm font-bold uppercase mb-1">Nova Senha</label>
-                    <input
-                        id="new-password"
-                        type="password"
-                        value={newPassword}
-                        onChange={e => { setNewPassword(e.target.value); setPasswordError(null); }}
-                        className="w-full border-2 border-gray-200 rounded-xl p-3 focus:border-black outline-none font-medium"
-                    />
-                    {newPassword && (() => {
-                        const strength = getPasswordStrength(newPassword);
-                        return (
-                            <div className="mt-1">
-                                <div className="h-1.5 bg-gray-200 rounded-full overflow-hidden">
-                                    <div className={`h-full ${strength.color} rounded-full ${strength.width}`} />
-                                </div>
-                                <p className="text-xs text-gray-500 mt-1">Forca: {strength.label}</p>
-                            </div>
-                        );
-                    })()}
-                </div>
-
-                <div className="mb-2">
-                    <label htmlFor="confirm-password" className="block text-sm font-bold uppercase mb-1">Confirmar Nova Senha</label>
-                    <input
-                        id="confirm-password"
-                        type="password"
-                        value={confirmPassword}
-                        onChange={e => { setConfirmPassword(e.target.value); setPasswordError(null); }}
-                        className="w-full border-2 border-gray-200 rounded-xl p-3 focus:border-black outline-none font-medium"
-                    />
-                </div>
-
-                {passwordError && (
-                    <p className="text-red-600 text-sm font-bold mb-4">{passwordError}</p>
-                )}
-
-                <button
-                    onClick={handleChangePassword}
-                    disabled={!newPassword || !confirmPassword || passwordLoading}
-                    className="bg-black text-white px-6 py-3 rounded-xl font-black uppercase hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-                >
-                    {passwordLoading ? <Loader2 className="animate-spin" size={18} /> : null}
-                    Alterar Senha
-                </button>
-            </div>
-
             {/* Meu link de perfil — a empresa compartilha o PRÓPRIO link para ser
                 adicionada/conectada por quem abrir (nunca manda o link do freela). */}
             <div className="mt-8 bg-white border-2 border-black rounded-2xl p-6 sm:p-8 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
@@ -714,33 +663,102 @@ export default function CompanyProfile() {
                 </button>
             </div>
 
-            {/* Sessão — logout avulso, acessível no mobile via item "Perfil" do BottomNav (R3) */}
-            <div className="mt-8 bg-white border-2 border-black rounded-2xl p-6 sm:p-8 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
-                <h3 className="text-xl font-black uppercase mb-4 flex items-center gap-2">
-                    <LogOut size={20} /> Sessão
-                </h3>
-                <p className="text-sm text-gray-600 mb-4">Sair da sua conta neste dispositivo.</p>
+            {/* Botão de toggle para as seções sensíveis (Segurança, Sessão, Zona de Perigo) */}
+            <div className="mt-8">
                 <button
-                    onClick={handleLogout}
-                    disabled={loggingOut}
-                    className="flex items-center justify-center gap-2 bg-black text-white px-6 py-3 rounded-xl font-black uppercase hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    onClick={() => setShowAccountSettings(prev => !prev)}
+                    aria-expanded={showAccountSettings}
+                    className="flex items-center justify-center gap-2 bg-white text-black px-6 py-3 rounded-xl font-black uppercase border-2 border-black hover:bg-black hover:text-white transition-colors"
                 >
-                    {loggingOut ? <Loader2 size={18} className="animate-spin" /> : <LogOut size={18} />}
-                    {loggingOut ? 'Saindo...' : 'Sair da conta'}
+                    <Settings size={18} />
+                    {showAccountSettings ? 'Ocultar Configurações da Conta' : 'Configurações da Conta'}
                 </button>
             </div>
 
-            {/* Zona de Perigo */}
-            <div className="mt-8 bg-white border-2 border-red-500 rounded-2xl p-6 sm:p-8 shadow-[6px_6px_0px_0px_rgba(239,68,68,1)]">
-                <h3 className="text-red-600 font-black uppercase text-lg mb-4">Zona de Perigo</h3>
-                <p className="text-sm text-gray-600 mb-4">A exclusão da sua empresa é irreversível. Todos os dados da empresa serão anonimizados.</p>
-                <button
-                    onClick={() => setDeleteModalOpen(true)}
-                    className="border-2 border-red-500 text-red-500 bg-white hover:bg-red-50 font-bold uppercase px-4 py-2 rounded-xl transition-colors"
-                >
-                    Excluir minha empresa
-                </button>
-            </div>
+            {showAccountSettings && (
+                <>
+                    {/* Secao Seguranca */}
+                    <div className="mt-8 bg-white border-2 border-black rounded-2xl p-6 sm:p-8 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
+                        <h3 className="text-xl font-black uppercase mb-4 flex items-center gap-2">
+                            <Lock size={20} /> Seguranca
+                        </h3>
+
+                        <div className="mb-4">
+                            <label htmlFor="new-password" className="block text-sm font-bold uppercase mb-1">Nova Senha</label>
+                            <input
+                                id="new-password"
+                                type="password"
+                                value={newPassword}
+                                onChange={e => { setNewPassword(e.target.value); setPasswordError(null); }}
+                                className="w-full border-2 border-gray-200 rounded-xl p-3 focus:border-black outline-none font-medium"
+                            />
+                            {newPassword && (() => {
+                                const strength = getPasswordStrength(newPassword);
+                                return (
+                                    <div className="mt-1">
+                                        <div className="h-1.5 bg-gray-200 rounded-full overflow-hidden">
+                                            <div className={`h-full ${strength.color} rounded-full ${strength.width}`} />
+                                        </div>
+                                        <p className="text-xs text-gray-500 mt-1">Forca: {strength.label}</p>
+                                    </div>
+                                );
+                            })()}
+                        </div>
+
+                        <div className="mb-2">
+                            <label htmlFor="confirm-password" className="block text-sm font-bold uppercase mb-1">Confirmar Nova Senha</label>
+                            <input
+                                id="confirm-password"
+                                type="password"
+                                value={confirmPassword}
+                                onChange={e => { setConfirmPassword(e.target.value); setPasswordError(null); }}
+                                className="w-full border-2 border-gray-200 rounded-xl p-3 focus:border-black outline-none font-medium"
+                            />
+                        </div>
+
+                        {passwordError && (
+                            <p className="text-red-600 text-sm font-bold mb-4">{passwordError}</p>
+                        )}
+
+                        <button
+                            onClick={handleChangePassword}
+                            disabled={!newPassword || !confirmPassword || passwordLoading}
+                            className="bg-black text-white px-6 py-3 rounded-xl font-black uppercase hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                        >
+                            {passwordLoading ? <Loader2 className="animate-spin" size={18} /> : null}
+                            Alterar Senha
+                        </button>
+                    </div>
+
+                    {/* Sessão — logout avulso, acessível no mobile via item "Perfil" do BottomNav (R3) */}
+                    <div className="mt-8 bg-white border-2 border-black rounded-2xl p-6 sm:p-8 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
+                        <h3 className="text-xl font-black uppercase mb-4 flex items-center gap-2">
+                            <LogOut size={20} /> Sessão
+                        </h3>
+                        <p className="text-sm text-gray-600 mb-4">Sair da sua conta neste dispositivo.</p>
+                        <button
+                            onClick={handleLogout}
+                            disabled={loggingOut}
+                            className="flex items-center justify-center gap-2 bg-black text-white px-6 py-3 rounded-xl font-black uppercase hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            {loggingOut ? <Loader2 size={18} className="animate-spin" /> : <LogOut size={18} />}
+                            {loggingOut ? 'Saindo...' : 'Sair da conta'}
+                        </button>
+                    </div>
+
+                    {/* Zona de Perigo */}
+                    <div className="mt-8 bg-white border-2 border-red-500 rounded-2xl p-6 sm:p-8 shadow-[6px_6px_0px_0px_rgba(239,68,68,1)]">
+                        <h3 className="text-red-600 font-black uppercase text-lg mb-4">Zona de Perigo</h3>
+                        <p className="text-sm text-gray-600 mb-4">A exclusão da sua empresa é irreversível. Todos os dados da empresa serão anonimizados.</p>
+                        <button
+                            onClick={() => setDeleteModalOpen(true)}
+                            className="border-2 border-red-500 text-red-500 bg-white hover:bg-red-50 font-bold uppercase px-4 py-2 rounded-xl transition-colors"
+                        >
+                            Excluir minha empresa
+                        </button>
+                    </div>
+                </>
+            )}
 
         </div>
 

--- a/supabase/migrations/20260714000000_notify_company_on_worker_cancel.sql
+++ b/supabase/migrations/20260714000000_notify_company_on_worker_cancel.sql
@@ -1,0 +1,97 @@
+-- Migration: Notificar a EMPRESA quando o freela CANCELA um turno que aceitou
+-- File: supabase/migrations/20260714000000_notify_company_on_worker_cancel.sql
+-- ADR: .harness/spec/freela-cancela-turno/adr-freela-cancela-turno.md
+-- Gate: harness-architect (toca applications; NÃO toca saldo/escrow).
+--
+-- ============================================================================
+-- ESCOPO (o que ESTA migration faz e o que NÃO faz)
+-- ----------------------------------------------------------------------------
+--   FAZ: cria a função + trigger AFTER UPDATE em public.applications que INSERE
+--        UMA notificação para o dono da empresa quando o freela transiciona
+--        NEW.status='cancelled' a partir de OLD.status IN ('hired','in_progress').
+--
+--   NÃO FAZ (decisão do ADR):
+--     - NÃO altera a transição: o freela JÁ consegue setar status='cancelled'
+--       (validate_application_update não bloqueia 'cancelled'; RLS "Workers can
+--       update own applications" permite). Nenhuma policy/constraint muda.
+--     - NÃO mexe em job: o slot reabre sozinho (job segue 'open'; a unique
+--       (job_id, worker_id) só barra re-convidar o MESMO worker — desejado).
+--     - NÃO move saldo (Article 8). Push/modo A não tem escrow. Se pull-prepago
+--       tiver escrow 'reserved', o refund fica a cargo do fluxo existente da
+--       empresa (refund_escrow), fora deste trigger. Ver ADR §Escrow.
+--
+-- SEGURANÇA / INVARIANTES
+-- ----------------------------------------------------------------------------
+--   - jobs.company_id = auth.uid() do dono da empresa (invariante do projeto;
+--     ver 20260622000300 e notify_new_message). É o notifications.user_id alvo.
+--   - SECURITY DEFINER + SET search_path = '' → roda como owner, bypassa a RLS
+--     de INSERT de notifications (o freela não precisa de permissão de INSERT
+--     para a caixa da empresa). Todos os objetos são totalmente qualificados.
+--   - type='status_change' é valor válido no CHECK de notifications.type.
+--   - Bloco EXCEPTION: falha ao notificar NUNCA bloqueia o cancelamento do freela.
+--
+-- DOWN (rollback): ver rodapé.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.notify_company_on_worker_cancel()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_company_id  uuid;
+    v_job_title   text;
+    v_worker_name text;
+BEGIN
+    -- Dono da empresa (destinatário) + título da vaga.
+    SELECT j.company_id, j.title
+      INTO v_company_id, v_job_title
+      FROM public.jobs j
+     WHERE j.id = NEW.job_id;
+
+    IF v_company_id IS NULL THEN
+        RETURN NEW;  -- sem empresa resolvível → nada a notificar
+    END IF;
+
+    -- Nome do freela para a mensagem (fallback genérico).
+    SELECT COALESCE(w.full_name, 'O freela')
+      INTO v_worker_name
+      FROM public.workers w
+     WHERE w.id = NEW.worker_id;
+
+    INSERT INTO public.notifications (user_id, type, title, message, link, read_at, created_at)
+    VALUES (
+        v_company_id,
+        'status_change',
+        'Turno cancelado pelo freela',
+        COALESCE(v_worker_name, 'O freela') || ' cancelou o turno "' ||
+            COALESCE(v_job_title, 'sem título') || '".',
+        '/company/jobs/' || NEW.job_id::text || '/candidates',
+        NULL,
+        now()
+    );
+
+    RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+    -- Best-effort: um erro na notificação nunca deve bloquear o cancelamento.
+    RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.notify_company_on_worker_cancel() IS
+    'AFTER UPDATE em applications: quando o freela cancela (hired/in_progress -> cancelled), notifica o dono da empresa (jobs.company_id). SECURITY DEFINER + search_path vazio; nao move saldo (Article 8). ADR-20260714.';
+
+-- Recria idempotente. WHEN limita o disparo à transição de cancelamento (1 evento por cancel).
+DROP TRIGGER IF EXISTS trg_notify_company_on_worker_cancel ON public.applications;
+CREATE TRIGGER trg_notify_company_on_worker_cancel
+    AFTER UPDATE ON public.applications
+    FOR EACH ROW
+    WHEN (NEW.status = 'cancelled' AND OLD.status IN ('hired', 'in_progress'))
+    EXECUTE FUNCTION public.notify_company_on_worker_cancel();
+
+-- ============================================================================
+-- DOWN (rollback) — sem impacto em saldo/escrow (nenhuma RPC tocada):
+--   DROP TRIGGER IF EXISTS trg_notify_company_on_worker_cancel ON public.applications;
+--   DROP FUNCTION IF EXISTS public.notify_company_on_worker_cancel();
+-- ============================================================================


### PR DESCRIPTION
Lote de 4 fixes/features pós-teste, via harness (architect gate → builders → evaluator APROVADO). Migration aplicada em prod via MCP.

1. **Perfil** (freela + empresa): Segurança/Sair/Zona de Perigo ocultas atrás do botão "Configurações da Conta".
2. **Home "Próximo Turno"**: corrige "Invalid Date" (`job.date` → `start_date`), destaca "Você está no turno agora" e mostra "Sem próximos turnos marcados".
3. **Sino de mensagens**: limpa as notificações `type='message'` ao abrir a conversa.
4. **Freela cancela turno agendado**: botão na aba Agendados; trigger `SECURITY DEFINER` (`20260714000000`) notifica a empresa automaticamente. Não move saldo (Article 8).

**Verificação:** build ✓ · lint 0 erros · **229/229 testes** · evaluator **APROVADO** · migration verificada no banco.