### PR TITLE
feat: relatório de turnos da empresa (filtros + CSV)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,6 +38,7 @@ const CompanyMessages = lazy(() => import('./pages/company/CompanyMessages'));
 const CompanyWallet = lazy(() => import('./pages/company/CompanyWallet'));
 const CompanyTeam = lazy(() => import('./pages/company/CompanyTeam'));
 const CompanyFinancial = lazy(() => import('./pages/company/CompanyFinancial'));
+const CompanyOrdersReport = lazy(() => import('./pages/company/CompanyOrdersReport'));
 const WorkerPublicProfile = lazy(() => import('./pages/company/WorkerPublicProfile'));
 const NotFound = lazy(() => import('./pages/NotFound'));
 const Terms = lazy(() => import('./pages/Terms'));
@@ -181,6 +182,7 @@ function App() {
                       <Route path="wallet" element={<CompanyWallet />} />
                       <Route path="team" element={<CompanyTeam />} />
                       <Route path="financeiro" element={<CompanyFinancial />} />
+                      <Route path="relatorio" element={<CompanyOrdersReport />} />
                       <Route path="notifications" element={<Notifications />} />
                     </Route>
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Home, Briefcase, User, Wallet, Zap, PlusCircle, Building2, MessageSquare, LogOut, Users, TrendingDown, Contact, Inbox, Loader2 } from 'lucide-react';
+import { Home, Briefcase, User, Wallet, Zap, PlusCircle, Building2, MessageSquare, LogOut, Users, TrendingDown, Contact, Inbox, Loader2, FileText } from 'lucide-react';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 import { useAuth } from '../contexts/AuthContext';
@@ -90,6 +90,7 @@ export default function Sidebar({ type = 'worker' }: SidebarProps) {
         { icon: MessageSquare, label: 'Mensagens', path: '/company/messages' },
         { icon: Wallet, label: 'Carteira', path: '/company/wallet' },
         { icon: TrendingDown, label: 'Financeiro', path: '/company/financeiro' },
+        { icon: FileText, label: 'Relatório', path: '/company/relatorio' },
         { icon: User, label: 'Perfil Empresa', path: '/company/profile' },
     ];
 

--- a/frontend/src/pages/company/CompanyOrdersReport.tsx
+++ b/frontend/src/pages/company/CompanyOrdersReport.tsx
@@ -1,0 +1,386 @@
+/**
+ * CompanyOrdersReport — Relatório de Ordens (turnos) da empresa.
+ *
+ * "Ordem" = turno; "nota"/comprovante = pagamento (shift_payments). Ao registrar o
+ * pagamento o turno já vira 'completed' e some das listas de turnos ativos — esta
+ * página dá a visão consolidada (aberta/paga/conciliada) + export pro financeiro/estoquista.
+ *
+ * Padrões: useState + useEffect, imports relativos, TS strict, design neo-brutalista empresa.
+ */
+
+import { useEffect, useState, useCallback } from 'react';
+import {
+  FileText,
+  Printer,
+  Download,
+  Calendar,
+  Loader2,
+  AlertTriangle,
+} from 'lucide-react';
+import { OrderReportService, toCSV } from '../../services/orderReportService';
+import type { OrderReport, OrderRow, OrderStatus } from '../../services/orderReportService';
+import { ORDER_STATUS_LABELS, PAYMENT_SOURCE_LABELS } from '../../services/orderReportService';
+import { logError } from '../../lib/logger';
+import { useToast } from '../../contexts/ToastContext';
+import PageMeta from '../../components/PageMeta';
+
+// ---------------------------------------------------------------------------
+// Helpers de data/format
+// ---------------------------------------------------------------------------
+
+function toDateInput(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function startOfWeek(d: Date): Date {
+  const day = d.getDay(); // 0 = domingo
+  const diff = d.getDate() - day;
+  return new Date(d.getFullYear(), d.getMonth(), diff);
+}
+
+function startOfMonth(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), 1);
+}
+
+function formatDDMMYYYY(value: string): string {
+  const datePart = value.slice(0, 10);
+  if (/^\d{4}-\d{2}-\d{2}$/.test(datePart)) {
+    const [y, m, dd] = datePart.split('-').map(Number);
+    const dt = new Date(y, m - 1, dd);
+    return `${String(dt.getDate()).padStart(2, '0')}/${String(dt.getMonth() + 1).padStart(2, '0')}/${dt.getFullYear()}`;
+  }
+  const dt = new Date(value);
+  return dt.toLocaleDateString('pt-BR');
+}
+
+function formatBRL(value: number): string {
+  return value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+
+type PresetKey = 'hoje' | 'semana' | 'mes' | 'custom';
+
+const STATUS_OPTIONS: Array<{ key: OrderStatus | 'todas'; label: string }> = [
+  { key: 'todas', label: 'Todas' },
+  { key: 'aberta', label: 'Abertas' },
+  { key: 'paga', label: 'Pagas' },
+  { key: 'conciliada', label: 'Conciliadas' },
+];
+
+const STATUS_BADGE_CLASS: Record<OrderStatus, string> = {
+  aberta: 'bg-yellow-100 text-yellow-700 border-yellow-300',
+  paga: 'bg-blue-100 text-blue-700 border-blue-300',
+  conciliada: 'bg-primary-light text-primary border-black',
+};
+
+// ---------------------------------------------------------------------------
+// Página
+// ---------------------------------------------------------------------------
+
+export default function CompanyOrdersReport() {
+  const { addToast } = useToast();
+
+  const [preset, setPreset] = useState<PresetKey>('mes');
+  const [from, setFrom] = useState<string>(toDateInput(startOfMonth(new Date())));
+  const [to, setTo] = useState<string>(toDateInput(new Date()));
+  const [statusFilter, setStatusFilter] = useState<OrderStatus | 'todas'>('todas');
+
+  const [report, setReport] = useState<OrderReport | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchReport = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await OrderReportService.getReport({ from, to, status: statusFilter });
+      setReport(result);
+    } catch (err) {
+      logError('CompanyOrdersReport.fetchReport', err);
+      setError('Não foi possível carregar o relatório.');
+    } finally {
+      setLoading(false);
+    }
+  }, [from, to, statusFilter]);
+
+  useEffect(() => {
+    fetchReport();
+  }, [fetchReport]);
+
+  function applyPreset(key: PresetKey) {
+    const now = new Date();
+    if (key === 'hoje') {
+      const today = toDateInput(now);
+      setFrom(today);
+      setTo(today);
+    } else if (key === 'semana') {
+      setFrom(toDateInput(startOfWeek(now)));
+      setTo(toDateInput(now));
+    } else if (key === 'mes') {
+      setFrom(toDateInput(startOfMonth(now)));
+      setTo(toDateInput(now));
+    }
+    setPreset(key);
+  }
+
+  function handleCustomDateChange(which: 'from' | 'to', value: string) {
+    setPreset('custom');
+    if (which === 'from') setFrom(value);
+    else setTo(value);
+  }
+
+  function handleExportCSV() {
+    if (!report || report.rows.length === 0) {
+      addToast('Nenhuma ordem para exportar.', 'info');
+      return;
+    }
+    const csv = toCSV(report);
+    // BOM UTF-8 para o Excel pt-BR reconhecer acentos corretamente.
+    const blob = new Blob(['﻿' + csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `relatorio-ordens-${from}_a_${to}.csv`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  const rows: OrderRow[] = report?.rows ?? [];
+  const summary = report?.summary;
+  const periodLabel = `${formatDDMMYYYY(from)} a ${formatDDMMYYYY(to)}`;
+
+  return (
+    <div className="flex flex-col gap-8 pb-20 md:pb-12 font-sans text-accent max-w-5xl mx-auto print:pb-0">
+      <PageMeta title="Relatório de Ordens" />
+
+      {/* Header — some na impressão (cabeçalho de impressão próprio abaixo) */}
+      <header className="print:hidden">
+        <h1 className="text-4xl font-black uppercase tracking-tighter mb-2 flex items-center gap-3">
+          <FileText size={32} strokeWidth={3} /> Relatório de Ordens
+        </h1>
+        <p className="text-gray-500 text-sm">
+          Visão consolidada dos turnos (ordens) e seus pagamentos — export pro financeiro/estoquista.
+        </p>
+      </header>
+
+      {/* Cabeçalho de impressão — só aparece no print */}
+      <div className="hidden print:block">
+        <h1 className="text-2xl font-black uppercase">Relatório de Ordens</h1>
+        <p className="text-sm font-bold">Período: {periodLabel}</p>
+      </div>
+
+      {/* Filtros + ações — não imprime */}
+      <div className="bg-white border-2 border-black rounded-2xl p-6 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] print:hidden flex flex-col gap-5">
+        {/* Presets */}
+        <div className="flex flex-wrap gap-3">
+          {(['hoje', 'semana', 'mes'] as PresetKey[]).map((key) => (
+            <button
+              key={key}
+              onClick={() => applyPreset(key)}
+              className={`px-5 py-2.5 rounded-xl border-2 font-black uppercase text-sm transition-all
+                ${preset === key
+                  ? 'bg-black text-white border-black shadow-[4px_4px_0px_0px_rgba(0,166,81,1)]'
+                  : 'bg-white text-gray-500 border-black hover:bg-gray-100'
+                }`}
+            >
+              {key === 'hoje' ? 'Hoje' : key === 'semana' ? 'Semana' : 'Mês'}
+            </button>
+          ))}
+        </div>
+
+        {/* Intervalo custom + status */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div>
+            <label htmlFor="fromInput" className="block text-xs font-black uppercase text-gray-500 mb-1">
+              De
+            </label>
+            <div className="relative">
+              <Calendar size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+              <input
+                id="fromInput"
+                type="date"
+                value={from}
+                max={to}
+                onChange={(e) => handleCustomDateChange('from', e.target.value)}
+                className="w-full pl-9 pr-3 py-2.5 border-2 border-black rounded-xl font-bold text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+            </div>
+          </div>
+          <div>
+            <label htmlFor="toInput" className="block text-xs font-black uppercase text-gray-500 mb-1">
+              Até
+            </label>
+            <div className="relative">
+              <Calendar size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+              <input
+                id="toInput"
+                type="date"
+                value={to}
+                min={from}
+                onChange={(e) => handleCustomDateChange('to', e.target.value)}
+                className="w-full pl-9 pr-3 py-2.5 border-2 border-black rounded-xl font-bold text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+            </div>
+          </div>
+          <div>
+            <label htmlFor="statusSelect" className="block text-xs font-black uppercase text-gray-500 mb-1">
+              Status
+            </label>
+            <select
+              id="statusSelect"
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value as OrderStatus | 'todas')}
+              className="w-full px-3 py-2.5 border-2 border-black rounded-xl font-bold text-sm focus:outline-none focus:ring-2 focus:ring-primary bg-white"
+            >
+              {STATUS_OPTIONS.map((opt) => (
+                <option key={opt.key} value={opt.key}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Ações */}
+        <div className="flex flex-wrap gap-3 border-t-2 border-black pt-5">
+          <button
+            onClick={handleExportCSV}
+            disabled={loading || rows.length === 0}
+            className="flex items-center gap-2 px-5 py-2.5 bg-black hover:bg-primary text-white rounded-xl font-black uppercase text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <Download size={16} /> Exportar CSV
+          </button>
+          <button
+            onClick={() => window.print()}
+            disabled={loading || rows.length === 0}
+            className="flex items-center gap-2 px-5 py-2.5 border-2 border-black rounded-xl font-black uppercase text-sm hover:bg-black hover:text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <Printer size={16} /> Imprimir / PDF
+          </button>
+        </div>
+      </div>
+
+      {/* Resumo */}
+      {summary && (
+        <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 print:grid-cols-5">
+          <SummaryCard label="Total" value={String(summary.total)} />
+          <SummaryCard label="Abertas" value={String(summary.abertas)} className="text-yellow-700" />
+          <SummaryCard label="Pagas" value={String(summary.pagas)} className="text-blue-700" />
+          <SummaryCard label="Conciliadas" value={String(summary.conciliadas)} className="text-primary" />
+          <SummaryCard label="Valor Total" value={formatBRL(summary.valorTotal)} className="col-span-2 sm:col-span-1" />
+        </div>
+      )}
+
+      {/* Conteúdo */}
+      {loading ? (
+        <div className="flex items-center justify-center py-16 print:hidden">
+          <Loader2 size={28} className="animate-spin text-gray-400" />
+        </div>
+      ) : error ? (
+        <div className="bg-red-50 border-2 border-red-200 rounded-2xl p-6 text-center print:hidden">
+          <AlertTriangle size={28} className="mx-auto mb-2 text-red-500" />
+          <p className="font-black text-red-600 uppercase text-sm">{error}</p>
+          <button
+            onClick={fetchReport}
+            className="mt-3 px-6 py-2 rounded-xl border-2 border-black font-black uppercase text-sm hover:bg-black hover:text-white transition-colors"
+          >
+            Tentar novamente
+          </button>
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="bg-white border-2 border-black rounded-2xl p-10 text-center shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] print:shadow-none">
+          <FileText size={40} className="mx-auto mb-4 text-gray-300" />
+          <p className="font-black text-gray-500 uppercase text-sm">Nenhuma ordem no período.</p>
+        </div>
+      ) : (
+        <>
+          {/* Mobile: cards */}
+          <div className="flex flex-col gap-3 md:hidden print:hidden">
+            {rows.map((row) => (
+              <OrderCard key={row.jobId} row={row} />
+            ))}
+          </div>
+
+          {/* Desktop / impressão: tabela */}
+          <div className="hidden md:block print:block bg-white border-2 border-black rounded-2xl overflow-x-auto shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] print:shadow-none">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b-2 border-black bg-gray-50 text-left">
+                  <th className="px-4 py-3 font-black uppercase text-xs">Data</th>
+                  <th className="px-4 py-3 font-black uppercase text-xs">Função</th>
+                  <th className="px-4 py-3 font-black uppercase text-xs">Freela</th>
+                  <th className="px-4 py-3 font-black uppercase text-xs text-right">Valor</th>
+                  <th className="px-4 py-3 font-black uppercase text-xs">Forma</th>
+                  <th className="px-4 py-3 font-black uppercase text-xs">Status</th>
+                  <th className="px-4 py-3 font-black uppercase text-xs">Data Pgto</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.jobId} className="border-b border-gray-200 last:border-0">
+                    <td className="px-4 py-3 font-bold whitespace-nowrap">{row.date ? formatDDMMYYYY(row.date) : '—'}</td>
+                    <td className="px-4 py-3 font-medium">{row.category ?? row.title}</td>
+                    <td className="px-4 py-3 font-medium">{row.workerName ?? '—'}</td>
+                    <td className="px-4 py-3 font-black tabular-nums text-right whitespace-nowrap">{formatBRL(row.amount)}</td>
+                    <td className="px-4 py-3">{row.source ? PAYMENT_SOURCE_LABELS[row.source] ?? row.source : '—'}</td>
+                    <td className="px-4 py-3">
+                      <StatusBadge status={row.status} />
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap">{row.paidAt ? formatDDMMYYYY(row.paidAt) : '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Subcomponentes
+// ---------------------------------------------------------------------------
+
+function SummaryCard({ label, value, className = '' }: { label: string; value: string; className?: string }) {
+  return (
+    <div className="bg-white border-2 border-black rounded-xl p-4 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] print:shadow-none">
+      <p className="text-[10px] font-black uppercase text-gray-500 mb-1">{label}</p>
+      <p className={`text-xl font-black tabular-nums truncate ${className}`}>{value}</p>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: OrderStatus }) {
+  return (
+    <span className={`text-[10px] font-black uppercase px-2 py-1 rounded-full border-2 ${STATUS_BADGE_CLASS[status]}`}>
+      {ORDER_STATUS_LABELS[status]}
+    </span>
+  );
+}
+
+function OrderCard({ row }: { row: OrderRow }) {
+  return (
+    <div className="bg-white border-2 border-black rounded-xl p-4 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] flex flex-col gap-2">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="font-black text-sm truncate">{row.category ?? row.title}</p>
+          <p className="text-xs text-gray-500">{row.date ? formatDDMMYYYY(row.date) : '—'}</p>
+        </div>
+        <StatusBadge status={row.status} />
+      </div>
+      <div className="flex items-center justify-between text-sm">
+        <span className="font-medium text-gray-600 truncate">{row.workerName ?? '—'}</span>
+        <span className="font-black tabular-nums">{formatBRL(row.amount)}</span>
+      </div>
+      <div className="flex items-center justify-between text-xs text-gray-400">
+        <span>{row.source ? PAYMENT_SOURCE_LABELS[row.source] ?? row.source : '—'}</span>
+        <span>{row.paidAt ? `Pago em ${formatDDMMYYYY(row.paidAt)}` : ''}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/orderReportService.test.ts
+++ b/frontend/src/services/orderReportService.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mock supabase — chain genérica encadeável (select/eq/neq/in) que resolve
+// para `result` no await direto (thenable), no padrão de financialBIService.test.ts.
+// fromMock roteia por nome de tabela.
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeChain(result: { data: any; error: any }) {
+  const promise = Promise.resolve(result)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = {
+    select: vi.fn(() => chain),
+    eq: vi.fn(() => chain),
+    neq: vi.fn(() => chain),
+    in: vi.fn(() => chain),
+    then: promise.then.bind(promise),
+    catch: promise.catch.bind(promise),
+  }
+  return chain
+}
+
+const mockGetUser = vi.fn()
+const mockFrom = vi.fn()
+
+vi.mock('../lib/supabase', () => ({
+  supabase: {
+    auth: { getUser: (...args: unknown[]) => mockGetUser(...args) },
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function routeFrom(handlers: Record<string, any>) {
+  mockFrom.mockImplementation((table: string) => {
+    const handler = handlers[table]
+    if (!handler) throw new Error(`Tabela não mockada: ${table}`)
+    return handler
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'company-1' } } })
+})
+
+// ---------------------------------------------------------------------------
+// Fixtures — 3 turnos no período: aberta (sem marcador), paga (recorded sem
+// confirmação do freela) e conciliada (recorded + worker_confirmed_at).
+// ---------------------------------------------------------------------------
+
+const JOBS_ROWS = [
+  {
+    id: 'job-aberta',
+    title: 'Garçom Evento X',
+    category: 'Garçom',
+    budget: 200,
+    start_date: '2026-07-10',
+    created_at: '2026-07-01T10:00:00Z',
+    status: 'open',
+  },
+  {
+    id: 'job-paga',
+    title: 'Cozinheiro Evento Y',
+    category: null,
+    budget: 300,
+    start_date: '2026-07-11',
+    created_at: '2026-07-02T10:00:00Z',
+    status: 'completed',
+  },
+  {
+    id: 'job-conciliada',
+    title: 'Segurança Evento Z',
+    category: 'Segurança',
+    budget: 250,
+    start_date: '2026-07-12',
+    created_at: '2026-07-03T10:00:00Z',
+    status: 'completed',
+  },
+  {
+    id: 'job-fora-do-periodo',
+    title: 'Fora do período',
+    category: null,
+    budget: 100,
+    start_date: '2026-05-01',
+    created_at: '2026-05-01T10:00:00Z',
+    status: 'completed',
+  },
+]
+
+const SHIFT_PAYMENTS_ROWS = [
+  {
+    job_id: 'job-paga',
+    worker_id: 'worker-paga',
+    amount: 300,
+    source: 'external_pix',
+    status: 'recorded',
+    paid_at: '2026-07-11T18:00:00Z',
+    scheduled_for: null,
+    worker_confirmed_at: null,
+  },
+  {
+    job_id: 'job-conciliada',
+    worker_id: 'worker-conciliada',
+    amount: 250,
+    source: 'cash',
+    status: 'recorded',
+    paid_at: '2026-07-12T18:00:00Z',
+    scheduled_for: null,
+    worker_confirmed_at: '2026-07-13T09:00:00Z',
+  },
+]
+
+const APPLICATIONS_ROWS = [
+  {
+    job_id: 'job-aberta',
+    worker_id: 'worker-aberta',
+    status: 'hired',
+    invitation_response: 'accepted',
+  },
+  {
+    job_id: 'job-paga',
+    worker_id: 'worker-paga',
+    status: 'completed',
+    invitation_response: 'accepted',
+  },
+  {
+    job_id: 'job-conciliada',
+    worker_id: 'worker-conciliada',
+    status: 'completed',
+    invitation_response: 'accepted',
+  },
+]
+
+const WORKERS_ROWS = [
+  { id: 'worker-aberta', full_name: 'Freela Aberta' },
+  { id: 'worker-paga', full_name: 'Freela Paga' },
+  { id: 'worker-conciliada', full_name: 'Freela Conciliada' },
+]
+
+function mockAllTables() {
+  routeFrom({
+    jobs: makeChain({ data: JOBS_ROWS, error: null }),
+    shift_payments: makeChain({ data: SHIFT_PAYMENTS_ROWS, error: null }),
+    applications: makeChain({ data: APPLICATIONS_ROWS, error: null }),
+    workers: makeChain({ data: WORKERS_ROWS, error: null }),
+  })
+}
+
+const PERIOD = { from: '2026-07-01', to: '2026-07-31' }
+
+describe('OrderReportService.getReport — derivação de status e período', () => {
+  it('deriva aberta/paga/conciliada corretamente e ignora turnos fora do período', async () => {
+    mockAllTables()
+    const { OrderReportService } = await import('./orderReportService')
+
+    const report = await OrderReportService.getReport(PERIOD)
+
+    expect(report.rows).toHaveLength(3)
+    expect(report.rows.find((r) => r.jobId === 'job-fora-do-periodo')).toBeUndefined()
+
+    const aberta = report.rows.find((r) => r.jobId === 'job-aberta')
+    expect(aberta?.status).toBe('aberta')
+    expect(aberta?.amount).toBe(200) // fallback pro budget do job
+    expect(aberta?.workerName).toBe('Freela Aberta')
+    expect(aberta?.source).toBeNull()
+
+    const paga = report.rows.find((r) => r.jobId === 'job-paga')
+    expect(paga?.status).toBe('paga')
+    expect(paga?.amount).toBe(300)
+    expect(paga?.source).toBe('external_pix')
+    expect(paga?.paidAt).toBe('2026-07-11T18:00:00Z')
+
+    const conciliada = report.rows.find((r) => r.jobId === 'job-conciliada')
+    expect(conciliada?.status).toBe('conciliada')
+    expect(conciliada?.workerName).toBe('Freela Conciliada')
+
+    expect(report.summary).toEqual({
+      total: 3,
+      abertas: 1,
+      pagas: 1,
+      conciliadas: 1,
+      valorTotal: 200 + 300 + 250,
+    })
+  })
+
+  it('filtra `rows` por status mas mantém `summary` com o período completo', async () => {
+    mockAllTables()
+    const { OrderReportService } = await import('./orderReportService')
+
+    const report = await OrderReportService.getReport({ ...PERIOD, status: 'conciliada' })
+
+    expect(report.rows).toHaveLength(1)
+    expect(report.rows[0].jobId).toBe('job-conciliada')
+    // summary continua refletindo os 3 turnos do período, não só o filtro aplicado
+    expect(report.summary.total).toBe(3)
+  })
+
+  it('retorna vazio quando não há usuário autenticado', async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } })
+    mockAllTables()
+    const { OrderReportService } = await import('./orderReportService')
+
+    const report = await OrderReportService.getReport(PERIOD)
+    expect(report.rows).toEqual([])
+    expect(report.summary.total).toBe(0)
+  })
+
+  it('retorna vazio (sem lançar) quando a query de jobs falha', async () => {
+    routeFrom({
+      jobs: makeChain({ data: null, error: { message: 'boom' } }),
+    })
+    const { OrderReportService } = await import('./orderReportService')
+
+    const report = await OrderReportService.getReport(PERIOD)
+    expect(report.rows).toEqual([])
+  })
+})
+
+describe('toCSV', () => {
+  it('gera CSV pt-BR com ";" e cabeçalho esperado, usando category como Função (fallback title)', async () => {
+    mockAllTables()
+    const { OrderReportService, toCSV } = await import('./orderReportService')
+
+    const report = await OrderReportService.getReport(PERIOD)
+    const csv = toCSV(report)
+    const lines = csv.split('\r\n')
+
+    expect(lines[0]).toBe('Data;Função;Freela;Valor;Forma;Status;Data Pgto')
+
+    const pagaLine = lines.find((l) => l.includes('Freela Paga'))
+    expect(pagaLine).toBeDefined()
+    // job-paga tem category=null -> cai pro title
+    expect(pagaLine).toContain('Cozinheiro Evento Y')
+    expect(pagaLine).toContain('300,00')
+    expect(pagaLine).toContain('PIX')
+    expect(pagaLine).toContain('Paga')
+
+    const abertaLine = lines.find((l) => l.includes('Freela Aberta'))
+    expect(abertaLine).toContain('Garçom') // category presente
+    expect(abertaLine).toContain('—') // sem forma de pagamento
+  })
+
+  it('escapa campos com ";" ou aspas', () => {
+    const csvSource = {
+      rows: [
+        {
+          jobId: 'job-x',
+          date: '2026-07-10',
+          title: 'Turno; especial "raro"',
+          category: null,
+          workerName: 'Fulano',
+          amount: 100,
+          source: null,
+          paidAt: null,
+          status: 'aberta' as const,
+        },
+      ],
+      summary: { total: 1, abertas: 1, pagas: 0, conciliadas: 0, valorTotal: 100 },
+    }
+
+    return import('./orderReportService').then(({ toCSV }) => {
+      const csv = toCSV(csvSource)
+      expect(csv).toContain('"Turno; especial ""raro"""')
+    })
+  })
+})

--- a/frontend/src/services/orderReportService.ts
+++ b/frontend/src/services/orderReportService.ts
@@ -1,0 +1,396 @@
+/**
+ * OrderReportService — Relatório de Ordens (turnos) da empresa.
+ *
+ * "Ordem" = turno (jobs). "Nota"/comprovante = pagamento (shift_payments, modo A —
+ * pagamento externo registrado). Ao registrar o pagamento o turno já vira 'completed'
+ * e some das listas de turnos ativos — este relatório dá a visão consolidada
+ * (aberta/paga/conciliada) + export para o financeiro/estoquista.
+ *
+ * SOMENTE LEITURA — não cria/altera nenhuma linha, não move saldo, sem RPC (fora do
+ * escopo do Article 8; este service nem toca `wallets`/`escrow_transactions`).
+ *
+ * Status derivado por ordem (turno):
+ *  - 'conciliada': shift_payment ATIVO com status='recorded' E worker_confirmed_at preenchido
+ *    (o freela confirmou o recebimento).
+ *  - 'paga': shift_payment ATIVO com status='recorded', mas o freela ainda não confirmou.
+ *  - 'aberta': sem shift_payment 'recorded' (pode ter 'scheduled' pendente, ou nenhum).
+ *
+ * Valor da linha: amount do shift_payment ATIVO (recorded, senão scheduled); na ausência
+ * de qualquer marcador, cai para jobs.budget (estimativa do turno).
+ *
+ * Data da ordem: jobs.start_date; se nulo, jobs.created_at (fallback — turnos antigos
+ * podem não ter start_date preenchido).
+ *
+ * "Função" (CSV/coluna) = jobs.category (o papel/função do turno, ex.: "Garçom",
+ * "Cozinheiro"); se category vier nulo, cai para jobs.title.
+ *
+ * Padrões do projeto:
+ *  - supabase.from direto (Art. 5 — sem React Query).
+ *  - Tipos locais (partial select) — não força atualização de types/index.ts (sem
+ *    mudança de schema; `category` já existe em `jobs` mas ainda não está no Job
+ *    global — mesma convenção já usada em financialBIService.ts).
+ *  - Imports relativos (sem alias @/).
+ *  - logError (nunca console.log).
+ */
+
+import { supabase } from '../lib/supabase';
+import { logError } from '../lib/logger';
+
+// ---------------------------------------------------------------------------
+// Tipos exportados
+// ---------------------------------------------------------------------------
+
+export type OrderStatus = 'aberta' | 'paga' | 'conciliada';
+
+export interface OrderRow {
+  jobId: string;
+  /** ISO date ou date-only (YYYY-MM-DD) — start_date do turno, ou created_at como fallback. */
+  date: string | null;
+  title: string;
+  category: string | null;
+  workerName: string | null;
+  amount: number;
+  /** 'external_pix' | 'cash' | 'other' (ou null se não há marcador de pagamento). */
+  source: string | null;
+  /** Data do pagamento efetivado (só quando status='paga'/'conciliada'). */
+  paidAt: string | null;
+  status: OrderStatus;
+}
+
+export interface OrderReportSummary {
+  total: number;
+  abertas: number;
+  pagas: number;
+  conciliadas: number;
+  valorTotal: number;
+}
+
+export interface OrderReport {
+  rows: OrderRow[];
+  summary: OrderReportSummary;
+}
+
+export interface GetReportParams {
+  /** Início do período (inclusive), YYYY-MM-DD. */
+  from: string;
+  /** Fim do período (inclusive), YYYY-MM-DD. */
+  to: string;
+  /** Filtra as linhas retornadas por status derivado. 'todas' (default) não filtra. */
+  status?: OrderStatus | 'todas';
+}
+
+// ---------------------------------------------------------------------------
+// Tipos internos de linha bruta
+// ---------------------------------------------------------------------------
+
+interface JobRow {
+  id: string;
+  title: string;
+  category: string | null;
+  budget: number;
+  start_date: string | null;
+  created_at: string | null;
+  status: string;
+}
+
+interface ShiftPaymentRow {
+  job_id: string;
+  worker_id: string;
+  amount: number;
+  source: string;
+  status: 'scheduled' | 'recorded';
+  paid_at: string | null;
+  scheduled_for: string | null;
+  worker_confirmed_at: string | null;
+}
+
+interface ApplicationRow {
+  job_id: string;
+  worker_id: string;
+  status: string;
+  invitation_response: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Labels (pt-BR) — reaproveitados pela página e pelo CSV
+// ---------------------------------------------------------------------------
+
+export const ORDER_STATUS_LABELS: Record<OrderStatus, string> = {
+  aberta: 'Aberta',
+  paga: 'Paga',
+  conciliada: 'Conciliada',
+};
+
+export const PAYMENT_SOURCE_LABELS: Record<string, string> = {
+  external_pix: 'PIX',
+  cash: 'Dinheiro',
+  other: 'Outro',
+};
+
+// ---------------------------------------------------------------------------
+// Helpers de data
+// ---------------------------------------------------------------------------
+
+/**
+ * Parseia uma string de data como LOCAL, sem shift de fuso, quando for "date-only"
+ * (YYYY-MM-DD — ex.: `jobs.start_date` quando a coluna é `date`, ou input `<input
+ * type="date">`). Datas com timestamp completo (ISO com hora/timezone) usam o parser
+ * padrão. Mesmo raciocínio de `ReceiptView.formatDateOnly` (evita off-by-one em BRT).
+ */
+function parseDateFlexible(value: string): Date {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    const [y, m, d] = value.split('-').map(Number);
+    return new Date(y, m - 1, d);
+  }
+  return new Date(value);
+}
+
+/** Início do dia (00:00:00 local) a partir de um YYYY-MM-DD. */
+function startOfDayLocal(dateOnly: string): Date {
+  const [y, m, d] = dateOnly.split('-').map(Number);
+  return new Date(y, m - 1, d, 0, 0, 0, 0);
+}
+
+/** Fim do dia (23:59:59.999 local) a partir de um YYYY-MM-DD. */
+function endOfDayLocal(dateOnly: string): Date {
+  const [y, m, d] = dateOnly.split('-').map(Number);
+  return new Date(y, m - 1, d, 23, 59, 59, 999);
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+/** Formata uma data (ISO ou date-only) como dd/MM/yyyy, sem shift de fuso. */
+function formatDDMMYYYY(value: string): string {
+  const d = parseDateFlexible(value);
+  return `${pad2(d.getDate())}/${pad2(d.getMonth() + 1)}/${d.getFullYear()}`;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: seleciona a application "primária" de um turno sem marcador de pagamento
+// (usada só para exibir o nome do freela quando ainda não há shift_payment).
+// ---------------------------------------------------------------------------
+
+const PRIMARY_STATUS_PRIORITY = ['completed', 'hired', 'in_progress'];
+
+function pickPrimaryApplication(apps: ApplicationRow[] | undefined): ApplicationRow | undefined {
+  if (!apps || apps.length === 0) return undefined;
+  for (const st of PRIMARY_STATUS_PRIORITY) {
+    const found = apps.find((a) => a.status === st);
+    if (found) return found;
+  }
+  const accepted = apps.find((a) => a.invitation_response === 'accepted');
+  if (accepted) return accepted;
+  return apps[0];
+}
+
+// ---------------------------------------------------------------------------
+// OrderReportService (exportado)
+// ---------------------------------------------------------------------------
+
+export const OrderReportService = {
+  /**
+   * Busca o relatório de ordens (turnos) da empresa autenticada no período informado.
+   * `summary` sempre reflete o PERÍODO COMPLETO (todos os status); `rows` reflete o
+   * filtro de status quando informado (a tabela e o CSV usam `rows`).
+   */
+  async getReport({ from, to, status }: GetReportParams): Promise<OrderReport> {
+    const empty: OrderReport = {
+      rows: [],
+      summary: { total: 0, abertas: 0, pagas: 0, conciliadas: 0, valorTotal: 0 },
+    };
+
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) return empty;
+
+      // 1. Turnos da empresa (todos, exceto deletados) — filtragem por período é feita
+      //    em JS pois precisamos do fallback start_date -> created_at.
+      const { data: jobsData, error: jobsErr } = await supabase
+        .from('jobs')
+        .select('id, title, category, budget, start_date, created_at, status')
+        .eq('company_id', user.id)
+        .neq('status', 'deleted');
+
+      if (jobsErr) {
+        logError('orderReport.getReport.jobs', jobsErr);
+        return empty;
+      }
+
+      const fromDate = startOfDayLocal(from);
+      const toDate = endOfDayLocal(to);
+
+      const periodJobs = ((jobsData ?? []) as JobRow[]).filter((job) => {
+        const effective = job.start_date ?? job.created_at;
+        if (!effective) return false;
+        const d = parseDateFlexible(effective);
+        return d >= fromDate && d <= toDate;
+      });
+
+      if (periodJobs.length === 0) return empty;
+
+      const jobIds = periodJobs.map((j) => j.id);
+
+      // 2. Marcadores de pagamento ATIVOS (scheduled ou recorded — voided é ignorado)
+      //    e candidaturas/convites dos turnos do período, em paralelo.
+      const [paymentsResult, appsResult] = await Promise.all([
+        supabase
+          .from('shift_payments')
+          .select('job_id, worker_id, amount, source, status, paid_at, scheduled_for, worker_confirmed_at')
+          .in('job_id', jobIds)
+          .in('status', ['scheduled', 'recorded']),
+        supabase
+          .from('applications')
+          .select('job_id, worker_id, status, invitation_response')
+          .in('job_id', jobIds),
+      ]);
+
+      if (paymentsResult.error) {
+        logError('orderReport.getReport.shiftPayments', paymentsResult.error);
+      }
+      if (appsResult.error) {
+        logError('orderReport.getReport.applications', appsResult.error);
+      }
+
+      const payments = (paymentsResult.data ?? []) as ShiftPaymentRow[];
+      const applications = (appsResult.data ?? []) as ApplicationRow[];
+
+      // O UNIQUE parcial (job_id) WHERE status IN ('scheduled','recorded') garante no
+      // máximo 1 linha ativa por turno — mas se por algum motivo vier mais de uma,
+      // 'recorded' tem precedência sobre 'scheduled'.
+      const paymentByJob = new Map<string, ShiftPaymentRow>();
+      for (const p of payments) {
+        const existing = paymentByJob.get(p.job_id);
+        if (!existing || (existing.status === 'scheduled' && p.status === 'recorded')) {
+          paymentByJob.set(p.job_id, p);
+        }
+      }
+
+      const appsByJob = new Map<string, ApplicationRow[]>();
+      for (const a of applications) {
+        const list = appsByJob.get(a.job_id) ?? [];
+        list.push(a);
+        appsByJob.set(a.job_id, list);
+      }
+
+      // 3. Nomes dos freelas — union de worker_ids vindos de pagamentos + applications.
+      const workerIds = [
+        ...new Set([
+          ...payments.map((p) => p.worker_id),
+          ...applications.map((a) => a.worker_id),
+        ]),
+      ];
+
+      const workerNameById = new Map<string, string>();
+      if (workerIds.length > 0) {
+        const { data: workers, error: workersErr } = await supabase
+          .from('workers')
+          .select('id, full_name')
+          .in('id', workerIds);
+        if (workersErr) {
+          logError('orderReport.getReport.workers', workersErr);
+        }
+        for (const w of (workers ?? []) as Array<{ id: string; full_name: string }>) {
+          workerNameById.set(w.id, w.full_name);
+        }
+      }
+
+      // 4. Montar as linhas do relatório.
+      const allRows: OrderRow[] = periodJobs.map((job) => {
+        const payment = paymentByJob.get(job.id);
+        const primaryApp = payment ? undefined : pickPrimaryApplication(appsByJob.get(job.id));
+        const workerId = payment?.worker_id ?? primaryApp?.worker_id ?? null;
+
+        let derivedStatus: OrderStatus = 'aberta';
+        if (payment?.status === 'recorded') {
+          derivedStatus = payment.worker_confirmed_at ? 'conciliada' : 'paga';
+        }
+
+        const amount = payment ? Number(payment.amount) : Number(job.budget ?? 0);
+        const source = payment?.source ?? null;
+        const paidAt = payment?.status === 'recorded' ? payment.paid_at : null;
+
+        return {
+          jobId: job.id,
+          date: job.start_date ?? job.created_at ?? null,
+          title: job.title,
+          category: job.category ?? null,
+          workerName: workerId ? workerNameById.get(workerId) ?? null : null,
+          amount,
+          source,
+          paidAt,
+          status: derivedStatus,
+        };
+      });
+
+      // Mais recente primeiro.
+      allRows.sort((a, b) => {
+        if (!a.date && !b.date) return 0;
+        if (!a.date) return 1;
+        if (!b.date) return -1;
+        return parseDateFlexible(b.date).getTime() - parseDateFlexible(a.date).getTime();
+      });
+
+      const summary: OrderReportSummary = {
+        total: allRows.length,
+        abertas: allRows.filter((r) => r.status === 'aberta').length,
+        pagas: allRows.filter((r) => r.status === 'paga').length,
+        conciliadas: allRows.filter((r) => r.status === 'conciliada').length,
+        valorTotal: allRows.reduce((acc, r) => acc + r.amount, 0),
+      };
+
+      const rows =
+        status && status !== 'todas' ? allRows.filter((r) => r.status === status) : allRows;
+
+      return { rows, summary };
+    } catch (err) {
+      logError('orderReport.getReport', err);
+      return empty;
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// CSV (pt-BR, delimitador ';' — Excel pt-BR abre corretamente sem passo extra)
+// ---------------------------------------------------------------------------
+
+function csvEscape(field: string): string {
+  if (/[;"\n\r]/.test(field)) {
+    return `"${field.replace(/"/g, '""')}"`;
+  }
+  return field;
+}
+
+/** Gera o CSV do relatório (usa `report.rows` — já respeita o filtro de status aplicado). */
+export function toCSV(report: OrderReport): string {
+  const header = ['Data', 'Função', 'Freela', 'Valor', 'Forma', 'Status', 'Data Pgto'];
+  const lines = [header.map(csvEscape).join(';')];
+
+  for (const row of report.rows) {
+    const dateStr = row.date ? formatDDMMYYYY(row.date) : '';
+    const paidAtStr = row.paidAt ? formatDDMMYYYY(row.paidAt) : '';
+    const valorStr = row.amount.toFixed(2).replace('.', ',');
+    const formaStr = row.source ? PAYMENT_SOURCE_LABELS[row.source] ?? row.source : '—';
+    const funcaoStr = row.category ?? row.title;
+    const statusStr = ORDER_STATUS_LABELS[row.status];
+
+    lines.push(
+      [
+        dateStr,
+        funcaoStr,
+        row.workerName ?? '—',
+        valorStr,
+        formaStr,
+        statusStr,
+        paidAtStr,
+      ]
+        .map(csvEscape)
+        .join(';'),
+    );
+  }
+
+  return lines.join('\r\n');
+}


### PR DESCRIPTION
Página /company/relatorio (read-only) + item no menu: lista turnos/ordens por período e status, cards de resumo e export CSV. Sem migration, não toca saldo. Isolamento por empresa (query + RLS). build/lint/**235 testes** verdes; evaluator **APROVADO**.